### PR TITLE
Improve error handling

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -153,8 +153,13 @@ export default class FitPlugin extends Plugin {
 				}
 				return true
 			}
-			console.error("Caught unknown error: ", error)
-			notice.setMessage("Unable to sync, if you are not connected to the internet, turn off auto sync.", true)
+      console.error("Caught unknown error: ", error)
+      
+      try {
+          notice.setMessage(`Unable to sync, if you are not connected to the internet, turn off auto sync. Error: ${error.message}`, true)
+      } catch (e) {
+          notice.setMessage("Unable to sync, if you are not connected to the internet, turn off auto sync.", true)
+      }
 			return true
 		}
 	}

--- a/src/vaultOps.ts
+++ b/src/vaultOps.ts
@@ -52,18 +52,22 @@ export class VaultOperations implements IVaultOperations {
     }
 
     async writeToLocal(path: string, content: string): Promise<FileOpRecord> {
-        // adopted getAbstractFileByPath for mobile compatiability
-        // TODO: add capability for creating folder from remote
-        const file = this.vault.getAbstractFileByPath(path)
-        if (file && file instanceof TFile) {
-            await this.vault.modifyBinary(file, base64ToArrayBuffer(content))
-            return {path, status: "changed"}
-        } else if (!file) {
-            this.ensureFolderExists(path)
-            await this.vault.createBinary(path, base64ToArrayBuffer(content))
-            return {path, status: "created"}
-        } 
-            throw new Error(`${path} writeToLocal operation unsuccessful, vault abstractFile on ${path} is of type ${typeof file}`);
+        try {
+            // adopted getAbstractFileByPath for mobile compatiability
+            // TODO: add capability for creating folder from remote
+            const file = this.vault.getAbstractFileByPath(path)
+            if (file && file instanceof TFile) {
+                await this.vault.modifyBinary(file, base64ToArrayBuffer(content))
+                return {path, status: "changed"}
+            } else if (!file) {
+                this.ensureFolderExists(path)
+                await this.vault.createBinary(path, base64ToArrayBuffer(content))
+                return {path, status: "created"}
+            } 
+                throw new Error(`${path} writeToLocal operation unsuccessful, vault abstractFile on ${path} is of type ${typeof file}`);
+        } catch (e) {
+            throw new Error(`Failed to write file: ${path}. Error: ${e}`);
+        }
     }
 
     async updateLocalFiles(


### PR DESCRIPTION
Currently, useful error messages are swallowed and I have't figured out how to read console.error on Android.

In my case, it was an issue with file names, which I incorrectly interpreted as #23 (many people probably too).

Changes:
- Show underlying error message
- Add specific error with the filepath