### PR TITLE
feat(#69): more meaningful error messages for different sync error types

### DIFF
--- a/src/__mocks__/@octokit/core.ts
+++ b/src/__mocks__/@octokit/core.ts
@@ -1,0 +1,6 @@
+export class Octokit {
+  constructor(options?: Record<string, unknown>) {}
+  request(): Promise<{ data: Record<string, unknown> }> {
+    return Promise.resolve({ data: {} });
+  }
+}

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -7,6 +7,8 @@ import { FitPush } from "./fitPush"
 import { VaultOperations } from "./vaultOps"
 import { LocalStores } from "main"
 import FitNotice from "./fitNotice"
+import { SyncResult, SyncErrors } from "./syncResult"
+import { OctokitHttpError } from "./fit"
 
 export interface IFitSync {
     fit: Fit
@@ -279,28 +281,36 @@ export class FitSync implements IFitSync {
             return {unresolvedFiles, localOps: ops, remoteOps: pushedChanges}
     }
 
-    async sync(syncNotice: FitNotice): Promise<{ops: Array<{heading: string, ops: FileOpRecord[]}>, clash: ClashStatus[]} | void> {
-        syncNotice.setMessage("Performing pre sync checks.")
-		const preSyncCheckResult = await this.performPreSyncChecks();
+	async sync(syncNotice: FitNotice): Promise<SyncResult> {
+		try {
+			syncNotice.setMessage("Performing pre sync checks.")
+			const preSyncCheckResult = await this.performPreSyncChecks();
 
-        // convert to switch statement later on for better maintainability
-		if (preSyncCheckResult.status === "inSync") {
-			syncNotice.setMessage("Sync successful")
-			return
-		}
+			// convert to switch statement later on for better maintainability
+			if (preSyncCheckResult.status === "inSync") {
+				syncNotice.setMessage("Sync successful")
+				return { success: true, operations: [], conflicts: [] }
+			}
 
-		if (preSyncCheckResult.status === "onlyRemoteCommitShaChanged") {
-			const { latestRemoteCommitSha } = preSyncCheckResult.remoteUpdate
-			await this.saveLocalStoreCallback({lastFetchedCommitSha: latestRemoteCommitSha})
-			syncNotice.setMessage("Sync successful")
-			return
-		}
+			if (preSyncCheckResult.status === "onlyRemoteCommitShaChanged") {
+				const { latestRemoteCommitSha } = preSyncCheckResult.remoteUpdate
+				await this.saveLocalStoreCallback({ lastFetchedCommitSha: latestRemoteCommitSha })
+				syncNotice.setMessage("Sync successful")
+				return { success: true, operations: [], conflicts: [] }
+			}
 
-		const remoteUpdate = preSyncCheckResult.remoteUpdate
-		if (preSyncCheckResult.status === "onlyRemoteChanged") {
-			const fileOpsRecord = await this.fitPull.pullRemoteToLocal(remoteUpdate, this.saveLocalStoreCallback)
-            syncNotice.setMessage("Sync successful")
-            return {ops: [{heading: "Local file updates:", ops: fileOpsRecord}], clash: []}
+			const remoteUpdate = preSyncCheckResult.remoteUpdate
+			if (preSyncCheckResult.status === "onlyRemoteChanged") {
+				let fileOpsRecord: FileOpRecord[]
+				try {
+					fileOpsRecord = await this.fitPull.pullRemoteToLocal(remoteUpdate, this.saveLocalStoreCallback)
+				} catch (error) {
+					const errorMessage = error instanceof Error ? error.message : 'Filesystem operation failed'
+					console.error(`Sync operation failed - File system error: ${errorMessage}`)
+					return { success: false, error: SyncErrors.filesystem(errorMessage) }
+			}
+				syncNotice.setMessage("Sync successful")
+				return { success: true, operations: [{ heading: "Local file updates:", ops: fileOpsRecord }], conflicts: [] }
 		}
 
 		const {localChanges, localTreeSha} = preSyncCheckResult
@@ -311,32 +321,34 @@ export class FitSync implements IFitSync {
 		if (preSyncCheckResult.status === "onlyLocalChanged") {
 			syncNotice.setMessage("Uploading local changes")
 			const pushResult = await this.fitPush.pushChangedFilesToRemote(localUpdate)
-            syncNotice.setMessage("Sync successful")
-            if (pushResult) {
-                await this.saveLocalStoreCallback({
-                    localSha: localTreeSha,
-                    lastFetchedRemoteSha: pushResult.lastFetchedRemoteSha,
-                    lastFetchedCommitSha: pushResult.lastFetchedCommitSha
-                })
-                return {ops: [{heading: "Local file updates:", ops: pushResult.pushedChanges}], clash: []}
-            }
-            return
+			syncNotice.setMessage("Sync successful")
+			if (pushResult) {
+				await this.saveLocalStoreCallback({
+					localSha: localTreeSha,
+					lastFetchedRemoteSha: pushResult.lastFetchedRemoteSha,
+					lastFetchedCommitSha: pushResult.lastFetchedCommitSha
+				})
+				return { success: true, operations: [{ heading: "Local file updates:", ops: pushResult.pushedChanges }], conflicts: [] }
+			}
+			console.error("Sync operation failed - Failed to push local changes")
+			return { success: false, error: SyncErrors.unknown("Failed to push local changes") }
 		}
-		
-		// do both pull and push (orders of execution different from pullRemoteToLocal and 
-		// pushChangedFilesToRemote to make this more transaction like, i.e. maintain original 
+
+		// do both pull and push (orders of execution different from pullRemoteToLocal and
+		// pushChangedFilesToRemote to make this more transaction like, i.e. maintain original
 		// state if the transaction failed) If you have ideas on how to make this more transaction-like,
-		//  please open an issue on the fit repo
+		// please open an issue on the fit repo
 		if (preSyncCheckResult.status === "localAndRemoteChangesCompatible") {
 			const {localOps, remoteOps} = await this.syncCompatibleChanges(
 				localUpdate, remoteUpdate, syncNotice)
-                return ({
-                    ops: [
-                        {heading: "Local file updates:", ops: localOps},
-                        {heading: "Remote file updates:", ops: remoteOps},
-                    ], 
-                    clash: []
-                })
+			return {
+				success: true,
+				operations: [
+					{ heading: "Local file updates:", ops: localOps },
+					{ heading: "Remote file updates:", ops: remoteOps },
+				],
+				conflicts: []
+			}
 		}
 
 		if (preSyncCheckResult.status === "localAndRemoteChangesClashed") {
@@ -344,14 +356,50 @@ export class FitSync implements IFitSync {
 				localUpdate.localChanges, remoteUpdate, syncNotice)
 			if (conflictResolutionResult) {
 				const {unresolvedFiles, localOps, remoteOps} = conflictResolutionResult
-                    return ({
-                        ops:[
-                            {heading: "Local file updates:", ops: localOps},
-                            {heading: "Remote file updates:", ops: remoteOps},
-                        ],
-                        clash: unresolvedFiles
-                    })
+                        return {
+                            success: true,
+                            operations: [
+                                {heading: "Local file updates:", ops: localOps},
+                                {heading: "Remote file updates:", ops: remoteOps},
+                            ],
+                            conflicts: unresolvedFiles
+                        }
 			}
 		}
+
+            console.error("Sync operation failed - Unknown sync status")
+            return { success: false, error: SyncErrors.unknown("Unknown sync status") }
+        } catch (error) {
+            // Map specific error types to appropriate SyncError
+            if (error instanceof OctokitHttpError) {
+                if (error.status === 401) {
+                    console.error(`Sync operation failed - Authentication failed: ${error.message}`)
+                    return { success: false, error: SyncErrors.auth(error.message) }
+                }
+                if (error.status === 404) {
+                    if (error.source === 'getRef') {
+                        console.error(`Sync operation failed - Branch not found: ${error.message}`)
+                        return { success: false, error: SyncErrors.remoteNotFound(`Branch not found`) }
+                    } else {
+                        console.error(`Sync operation failed - Remote not found: ${error.message}`)
+                        return { success: false, error: SyncErrors.remoteNotFound(error.message) }
+                    }
+                }
+                // Other HTTP errors from GitHub API
+                console.error(`Sync operation failed - GitHub API error (${error.status}): ${error.message}`)
+                return { success: false, error: SyncErrors.network(`GitHub API error (${error.status}): ${error.message}`) }
+            }
+
+            if (error instanceof Error) {
+                if (error.message.includes('network') || error.message.includes('fetch')) {
+                    console.error(`Sync operation failed - Network error: ${error.message}`)
+                    return { success: false, error: SyncErrors.network(error.message) }
+                }
+            }
+
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred'
+            console.error(`Sync operation failed - Unknown error: ${errorMessage}`)
+            return { success: false, error: SyncErrors.unknown(errorMessage) }
+        }
     }
 }

--- a/src/syncResult.ts
+++ b/src/syncResult.ts
@@ -1,0 +1,75 @@
+/**
+ * Structured result types for sync operations
+ * Replaces error throwing with explicit error state communication
+ */
+
+import { FileOpRecord, ClashStatus } from './fitTypes'
+
+export type SyncErrorType =
+  | 'network'           // Network connectivity issues
+  | 'auth'              // Authentication failures from remote
+  | 'remote_not_found'  // Remote repository, branch, or access issues
+  | 'conflict'          // Unresolvable merge conflicts
+  | 'filesystem'        // Local file system errors
+  | 'api_rate_limit'    // API rate limiting
+  | 'unknown'           // Unexpected errors
+
+export type SyncError = {
+  type: SyncErrorType
+  message: string
+  details?: {
+    statusCode?: number
+    source?: string  // Which operation failed (e.g., 'getRef', 'createCommit')
+    retryable?: boolean
+  }
+}
+
+export type SyncResult = {
+  success: true
+  operations: Array<{heading: string, ops: FileOpRecord[]}>
+  conflicts: ClashStatus[]
+} | {
+  success: false
+  error: SyncError
+}
+
+/**
+ * Utility functions for creating common error types
+ */
+export const SyncErrors = {
+  network: (message: string, details?: SyncError['details']): SyncError => ({
+    type: 'network',
+    message,
+    details: { retryable: true, ...details }
+  }),
+
+  auth: (message: string, details?: SyncError['details']): SyncError => ({
+    type: 'auth',
+    message,
+    details: { retryable: false, ...details }
+  }),
+
+  remoteNotFound: (message: string, details?: SyncError['details']): SyncError => ({
+    type: 'remote_not_found',
+    message,
+    details: { retryable: false, ...details }
+  }),
+
+  rateLimit: (message: string, details?: SyncError['details']): SyncError => ({
+    type: 'api_rate_limit',
+    message,
+    details: { retryable: true, ...details }
+  }),
+
+  filesystem: (message: string, details?: SyncError['details']): SyncError => ({
+    type: 'filesystem',
+    message,
+    details: { retryable: false, ...details }
+  }),
+
+  unknown: (message: string, details?: SyncError['details']): SyncError => ({
+    type: 'unknown',
+    message,
+    details: { retryable: false, ...details }
+  })
+}


### PR DESCRIPTION
Replaces the old generic "unable to sync" error notice:

<img width="322" height="97" alt="Screenshot of old error notice" src="https://github.com/user-attachments/assets/ba317c51-59e1-47fe-be37-95be9c8d48d7" />

with more specific meaningful errors for different cases like filesystem errors:

<img width="320" height="112" alt="Screenshot of new error notice for delete failed" src="https://github.com/user-attachments/assets/2c72e03a-46f7-43eb-9fda-f0a947b34457" />

or remote not found errors:

<img width="319" height="78" alt="Screenshot of new error notice for remote branch not found" src="https://github.com/user-attachments/assets/f699f7f9-a3a9-44ab-9e93-2840b583258f" />