### PR TITLE
chore: Fix lint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,13 +3,14 @@
     "parser": "@typescript-eslint/parser",
     "env": { "node": true },
     "plugins": [
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "@stylistic"
     ],
     "extends": [
       "eslint:recommended",
       "plugin:@typescript-eslint/eslint-recommended",
       "plugin:@typescript-eslint/recommended"
-    ], 
+    ],
     "parserOptions": {
         "sourceType": "module"
     },
@@ -20,6 +21,9 @@
       "no-prototype-builtins": "off",
       "@typescript-eslint/no-empty-function": "off",
       "no-trailing-spaces": "warn",
-      "eol-last": "warn"
-    } 
+      "eol-last": "warn",
+      "@stylistic/no-mixed-spaces-and-tabs": ["warn"],
+      "@stylistic/semi": ["warn", "always"],
+      "@stylistic/indent": ["warn", "tab"]
+    }
   }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,16 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/*.test.ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest',
-  },
-  collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/**/*.test.ts',
-    '!src/__mocks__/**',
-  ],
-  coverageDirectory: 'coverage',
-  coverageReporters: ['text', 'lcov', 'html'],
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>/src'],
+	testMatch: ['**/*.test.ts'],
+	transform: {
+		'^.+\\.ts$': 'ts-jest',
+	},
+	collectCoverageFrom: [
+		'src/**/*.ts',
+		'!src/**/*.test.ts',
+		'!src/__mocks__/**',
+	],
+	coverageDirectory: 'coverage',
+	coverageReporters: ['text', 'lcov', 'html'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@octokit/core": "^6.0.1"
 			},
 			"devDependencies": {
+				"@stylistic/eslint-plugin": "^3.1.0",
 				"@types/jest": "^30.0.0",
 				"@types/node": "^16.11.6",
 				"@types/sha1": "^1.1.5",
@@ -1058,16 +1059,19 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			},
 			"peerDependencies": {
 				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -2048,6 +2052,276 @@
 				"@sinonjs/commons": "^3.0.1"
 			}
 		},
+		"node_modules/@stylistic/eslint-plugin": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
+			"integrity": "sha512-pA6VOrOqk0+S8toJYhQGv2MWpQQR0QpeUo9AhNkC49Y26nxBQ/nH1rta9bUU1rPw2fJ1zZEMV5oCX5AazT7J2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/utils": "^8.13.0",
+				"eslint-visitor-keys": "^4.2.0",
+				"espree": "^10.3.0",
+				"estraverse": "^5.3.0",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/project-service": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+			"integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.44.1",
+				"@typescript-eslint/types": "^8.44.1",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+			"integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.44.1",
+				"@typescript-eslint/visitor-keys": "8.44.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+			"integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+			"integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+			"integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.44.1",
+				"@typescript-eslint/tsconfig-utils": "8.44.1",
+				"@typescript-eslint/types": "8.44.1",
+				"@typescript-eslint/visitor-keys": "8.44.1",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^2.1.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+			"integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.7.0",
+				"@typescript-eslint/scope-manager": "8.44.1",
+				"@typescript-eslint/types": "8.44.1",
+				"@typescript-eslint/typescript-estree": "8.44.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.44.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+			"integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.44.1",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/espree": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/ts-api-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
+			}
+		},
+		"node_modules/@stylistic/eslint-plugin/node_modules/typescript": {
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2672,11 +2946,11 @@
 			]
 		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2689,7 +2963,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
-			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -7091,13 +7364,12 @@
 			"optional": true
 		},
 		"@eslint-community/eslint-utils": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.3"
 			}
 		},
 		"@eslint-community/regexpp": {
@@ -7827,6 +8099,156 @@
 				"@sinonjs/commons": "^3.0.1"
 			}
 		},
+		"@stylistic/eslint-plugin": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
+			"integrity": "sha512-pA6VOrOqk0+S8toJYhQGv2MWpQQR0QpeUo9AhNkC49Y26nxBQ/nH1rta9bUU1rPw2fJ1zZEMV5oCX5AazT7J2g==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/utils": "^8.13.0",
+				"eslint-visitor-keys": "^4.2.0",
+				"espree": "^10.3.0",
+				"estraverse": "^5.3.0",
+				"picomatch": "^4.0.2"
+			},
+			"dependencies": {
+				"@typescript-eslint/project-service": {
+					"version": "8.44.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+					"integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/tsconfig-utils": "^8.44.1",
+						"@typescript-eslint/types": "^8.44.1",
+						"debug": "^4.3.4"
+					}
+				},
+				"@typescript-eslint/scope-manager": {
+					"version": "8.44.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+					"integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "8.44.1",
+						"@typescript-eslint/visitor-keys": "8.44.1"
+					}
+				},
+				"@typescript-eslint/tsconfig-utils": {
+					"version": "8.44.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+					"integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
+					"dev": true,
+					"requires": {}
+				},
+				"@typescript-eslint/types": {
+					"version": "8.44.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+					"integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "8.44.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+					"integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/project-service": "8.44.1",
+						"@typescript-eslint/tsconfig-utils": "8.44.1",
+						"@typescript-eslint/types": "8.44.1",
+						"@typescript-eslint/visitor-keys": "8.44.1",
+						"debug": "^4.3.4",
+						"fast-glob": "^3.3.2",
+						"is-glob": "^4.0.3",
+						"minimatch": "^9.0.4",
+						"semver": "^7.6.0",
+						"ts-api-utils": "^2.1.0"
+					}
+				},
+				"@typescript-eslint/utils": {
+					"version": "8.44.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+					"integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
+					"dev": true,
+					"requires": {
+						"@eslint-community/eslint-utils": "^4.7.0",
+						"@typescript-eslint/scope-manager": "8.44.1",
+						"@typescript-eslint/types": "8.44.1",
+						"@typescript-eslint/typescript-estree": "8.44.1"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "8.44.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+					"integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "8.44.1",
+						"eslint-visitor-keys": "^4.2.1"
+					}
+				},
+				"brace-expansion": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+					"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+					"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+					"dev": true
+				},
+				"espree": {
+					"version": "10.4.0",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+					"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+					"dev": true,
+					"requires": {
+						"acorn": "^8.15.0",
+						"acorn-jsx": "^5.3.2",
+						"eslint-visitor-keys": "^4.2.1"
+					}
+				},
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "9.0.5",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+					"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
+				"picomatch": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"dev": true
+				},
+				"ts-api-utils": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+					"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+					"dev": true,
+					"requires": {}
+				},
+				"typescript": {
+					"version": "5.9.2",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+					"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
 		"@tybys/wasm-util": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -8216,18 +8638,16 @@
 			"optional": true
 		},
 		"acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-			"dev": true,
-			"peer": true
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {}
 		},
 		"ajv": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@stylistic/eslint-plugin": "^3.1.0",
 		"@types/jest": "^30.0.0",
 		"@types/node": "^16.11.6",
 		"@types/sha1": "^1.1.5",

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -1,32 +1,32 @@
 export const arrayBufferToBase64 = jest.fn((buffer: ArrayBuffer) => {
-  return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+	return btoa(String.fromCharCode(...new Uint8Array(buffer)));
 });
 
 export class TFile {
-  path: string;
-  name: string;
-  constructor(path: string) {
-    this.path = path;
-    this.name = path.split('/').pop() || '';
-  }
+	path: string;
+	name: string;
+	constructor(path: string) {
+		this.path = path;
+		this.name = path.split('/').pop() || '';
+	}
 }
 
 export class Vault {
-  readBinary = jest.fn();
+	readBinary = jest.fn();
 }
 
 export class Component {
-  load = jest.fn();
-  unload = jest.fn();
+	load = jest.fn();
+	unload = jest.fn();
 }
 
 export class Notice {
-  constructor(message: string) {}
-  setMessage = jest.fn();
-  hide = jest.fn();
+	constructor(message: string) {}
+	setMessage = jest.fn();
+	hide = jest.fn();
 }
 
 export const Platform = {
-  isDesktop: true,
-  isMobile: false,
+	isDesktop: true,
+	isMobile: false,
 };

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -15,36 +15,36 @@
  * - Binary files are base64 encoded for GitHub API
  */
 
-import { LocalStores, FitSettings } from "main"
-import { Octokit } from "@octokit/core"
-import { RECOGNIZED_BINARY_EXT, compareSha } from "./utils"
-import { VaultOperations } from "./vaultOps"
-import { LocalChange, LocalFileStatus, RemoteChange, RemoteChangeType } from "./fitTypes"
-import { arrayBufferToBase64 } from "obsidian"
+import { LocalStores, FitSettings } from "main";
+import { Octokit } from "@octokit/core";
+import { RECOGNIZED_BINARY_EXT, compareSha } from "./utils";
+import { VaultOperations } from "./vaultOps";
+import { LocalChange, LocalFileStatus, RemoteChange, RemoteChangeType } from "./fitTypes";
+import { arrayBufferToBase64 } from "obsidian";
 
 /**
  * Represents a node in GitHub's git tree structure
  * Maps to GitHub API tree object format
  */
 export type TreeNode = {
-    path: string, 
-    mode: "100644" | "100755" | "040000" | "160000" | "120000" | undefined, 
-    type: "commit" | "blob" | "tree" | undefined, 
-    sha: string | null}
+	path: string,
+	mode: "100644" | "100755" | "040000" | "160000" | "120000" | undefined,
+	type: "commit" | "blob" | "tree" | undefined,
+	sha: string | null};
 
 type OctokitCallMethods = {
-    getUser: () => Promise<{owner: string, avatarUrl: string}>
-    getRepos: () => Promise<string[]>
-    getRef: (ref: string) => Promise<string>
-    getTree: (tree_sha: string) => Promise<TreeNode[]>
-    getCommitTreeSha: (ref: string) => Promise<string>
-    getRemoteTreeSha: (tree_sha: string) => Promise<{[k:string]: string}>
-    createBlob: (content: string, encoding: string) =>Promise<string>
-    createTreeNodeFromFile: ({path, status, extension}: LocalChange, remoteTree: TreeNode[]) => Promise<TreeNode|null>
-    createCommit: (treeSha: string, parentSha: string) =>Promise<string>
-    updateRef: (sha: string, ref: string) => Promise<string>
-    getBlob: (file_sha:string) =>Promise<string>
-}
+	getUser: () => Promise<{owner: string, avatarUrl: string}>
+	getRepos: () => Promise<string[]>
+	getRef: (ref: string) => Promise<string>
+	getTree: (tree_sha: string) => Promise<TreeNode[]>
+	getCommitTreeSha: (ref: string) => Promise<string>
+	getRemoteTreeSha: (tree_sha: string) => Promise<{[k:string]: string}>
+	createBlob: (content: string, encoding: string) =>Promise<string>
+	createTreeNodeFromFile: ({path, status, extension}: LocalChange, remoteTree: TreeNode[]) => Promise<TreeNode|null>
+	createCommit: (treeSha: string, parentSha: string) =>Promise<string>
+	updateRef: (sha: string, ref: string) => Promise<string>
+	getBlob: (file_sha:string) =>Promise<string>
+};
 
 /**
  * Main interface for FIT sync engine
@@ -56,303 +56,303 @@ type OctokitCallMethods = {
  * - Conflict-free sync operations
  */
 export interface IFit extends OctokitCallMethods{
-    owner: string
-    repo: string
-    branch: string
-    headers: {[k: string]: string}
-    deviceName: string
-    localSha: Record<string, string>              // Cache of local file SHAs
+	owner: string
+	repo: string
+	branch: string
+	headers: {[k: string]: string}
+	deviceName: string
+	localSha: Record<string, string>              // Cache of local file SHAs
 	lastFetchedCommitSha: string | null           // Last synced commit SHA
 	lastFetchedRemoteSha: Record<string, string>  // Cache of remote file SHAs
-    octokit: Octokit
-    vaultOps: VaultOperations
-    fileSha1: (path: string) => Promise<string>
+	octokit: Octokit
+	vaultOps: VaultOperations
+	fileSha1: (path: string) => Promise<string>
 }
 
 // Define a custom HttpError class that extends Error
 export class OctokitHttpError extends Error {
-    status: number;
-    source: keyof OctokitCallMethods
+	status: number;
+	source: keyof OctokitCallMethods;
 
-    constructor(message: string, status: number, source: keyof OctokitCallMethods) {
-        super(message);
-        this.name = 'HttpError';
-        this.status = status;
-        this.source = source
-    }
+	constructor(message: string, status: number, source: keyof OctokitCallMethods) {
+		super(message);
+		this.name = 'HttpError';
+		this.status = status;
+		this.source = source;
+	}
 }
 
 export class Fit implements IFit {
-    owner: string
-    repo: string
-    auth: string | undefined
-    branch: string
-    headers: {[k: string]: string}
-    deviceName: string
-    localSha: Record<string, string>
-	lastFetchedCommitSha: string | null
-	lastFetchedRemoteSha: Record<string, string>
-    octokit: Octokit
-    vaultOps: VaultOperations
+	owner: string;
+	repo: string;
+	auth: string | undefined;
+	branch: string;
+	headers: {[k: string]: string};
+	deviceName: string;
+	localSha: Record<string, string>;
+	lastFetchedCommitSha: string | null;
+	lastFetchedRemoteSha: Record<string, string>;
+	octokit: Octokit;
+	vaultOps: VaultOperations;
 
 
-    constructor(setting: FitSettings, localStores: LocalStores, vaultOps: VaultOperations) {
-        this.loadSettings(setting)
-        this.loadLocalStore(localStores)
-        this.vaultOps = vaultOps
-        this.headers = {
-            // Hack to disable caching which leads to inconsistency for
-            // read after write https://github.com/octokit/octokit.js/issues/890
-            "If-None-Match": '', 
-            'X-GitHub-Api-Version': '2022-11-28'
-        }
-    }
-    
-    loadSettings(setting: FitSettings) {
-        this.owner = setting.owner
-        this.repo = setting.repo
-        this.branch = setting.branch
-        this.deviceName = setting.deviceName
-        this.octokit = new Octokit({auth: setting.pat})
-    }
-    
-    loadLocalStore(localStore: LocalStores) {
-        this.localSha = localStore.localSha
-        this.lastFetchedCommitSha = localStore.lastFetchedCommitSha
-        this.lastFetchedRemoteSha = localStore.lastFetchedRemoteSha
-    }
-    
-    async fileSha1(fileContent: string): Promise<string> {
-        const enc = new TextEncoder();
-        const hashBuf = await crypto.subtle.digest('SHA-1', enc.encode(fileContent))
-        const hashArray = Array.from(new Uint8Array(hashBuf));
-        const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
-        return hashHex;
-    }
+	constructor(setting: FitSettings, localStores: LocalStores, vaultOps: VaultOperations) {
+		this.loadSettings(setting);
+		this.loadLocalStore(localStores);
+		this.vaultOps = vaultOps;
+		this.headers = {
+			// Hack to disable caching which leads to inconsistency for
+			// read after write https://github.com/octokit/octokit.js/issues/890
+			"If-None-Match": '',
+			'X-GitHub-Api-Version': '2022-11-28'
+		};
+	}
 
-    async computeFileLocalSha(path: string): Promise<string> {
-        // Note: only support TFile now, investigate need for supporting TFolder later on
-        const file = await this.vaultOps.getTFile(path) 
+	loadSettings(setting: FitSettings) {
+		this.owner = setting.owner;
+		this.repo = setting.repo;
+		this.branch = setting.branch;
+		this.deviceName = setting.deviceName;
+		this.octokit = new Octokit({auth: setting.pat});
+	}
+
+	loadLocalStore(localStore: LocalStores) {
+		this.localSha = localStore.localSha;
+		this.lastFetchedCommitSha = localStore.lastFetchedCommitSha;
+		this.lastFetchedRemoteSha = localStore.lastFetchedRemoteSha;
+	}
+
+	async fileSha1(fileContent: string): Promise<string> {
+		const enc = new TextEncoder();
+		const hashBuf = await crypto.subtle.digest('SHA-1', enc.encode(fileContent));
+		const hashArray = Array.from(new Uint8Array(hashBuf));
+		const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+		return hashHex;
+	}
+
+	async computeFileLocalSha(path: string): Promise<string> {
+		// Note: only support TFile now, investigate need for supporting TFolder later on
+		const file = await this.vaultOps.getTFile(path);
 		// compute sha1 based on path and file content
-        let content: string;
-        if (RECOGNIZED_BINARY_EXT.includes(file.extension)) {
-            content = arrayBufferToBase64(await this.vaultOps.vault.readBinary(file))
-        } else {
-            content = await this.vaultOps.vault.read(file)
-        }
-		return await this.fileSha1(path + content)
+		let content: string;
+		if (RECOGNIZED_BINARY_EXT.includes(file.extension)) {
+			content = arrayBufferToBase64(await this.vaultOps.vault.readBinary(file));
+		} else {
+			content = await this.vaultOps.vault.read(file);
+		}
+		return await this.fileSha1(path + content);
 	}
 
 	async computeLocalSha(): Promise<{[k:string]:string}> {
 		const paths = this.vaultOps.vault.getFiles().map(f=>{
-            // ignore local files in the _fit/ directory
-            return f.path.startsWith("_fit/") ? null : f.path
-        }).filter(Boolean)
+			// ignore local files in the _fit/ directory
+			return f.path.startsWith("_fit/") ? null : f.path;
+		}).filter(Boolean);
 		return Object.fromEntries(
 			await Promise.all(
 				paths.map(async (p: string): Promise<[string, string]> =>{
-					return [p, await this.computeFileLocalSha(p)]
+					return [p, await this.computeFileLocalSha(p)];
 				})
 			)
-		)
+		);
 	}
 
-    async remoteUpdated(): Promise<{remoteCommitSha: string, updated: boolean}> {
-        const remoteCommitSha = await this.getLatestRemoteCommitSha()
-        return {remoteCommitSha, updated: remoteCommitSha !== this.lastFetchedCommitSha}
-    }
+	async remoteUpdated(): Promise<{remoteCommitSha: string, updated: boolean}> {
+		const remoteCommitSha = await this.getLatestRemoteCommitSha();
+		return {remoteCommitSha, updated: remoteCommitSha !== this.lastFetchedCommitSha};
+	}
 
-    async getLocalChanges(currentLocalSha?: Record<string, string>): Promise<LocalChange[]> {
-        if (!currentLocalSha) {
-            currentLocalSha = await this.computeLocalSha()
-        }
-        const localChanges = compareSha(currentLocalSha, this.localSha, "local")
-        return localChanges
-    }
+	async getLocalChanges(currentLocalSha?: Record<string, string>): Promise<LocalChange[]> {
+		if (!currentLocalSha) {
+			currentLocalSha = await this.computeLocalSha();
+		}
+		const localChanges = compareSha(currentLocalSha, this.localSha, "local");
+		return localChanges;
+	}
 
-    async getRemoteChanges(remoteTreeSha: {[k: string]: string}): Promise<RemoteChange[]> {
-        const remoteChanges = compareSha(remoteTreeSha, this.lastFetchedRemoteSha, "remote")
-        return remoteChanges
-    }
+	async getRemoteChanges(remoteTreeSha: {[k: string]: string}): Promise<RemoteChange[]> {
+		const remoteChanges = compareSha(remoteTreeSha, this.lastFetchedRemoteSha, "remote");
+		return remoteChanges;
+	}
 
-    getClashedChanges(localChanges: LocalChange[], remoteChanges:RemoteChange[]): Array<{path: string, localStatus: LocalFileStatus, remoteStatus: RemoteChangeType}> {
-        const localChangePaths = localChanges.map(c=>c.path)
-        const remoteChangePaths = remoteChanges.map(c=>c.path)
-        const clashedFiles = localChangePaths.map(
-            (path, localIndex) => {
-                const remoteIndex = remoteChangePaths.indexOf(path)
-                if (remoteIndex !== -1) {
-                    return {path, localIndex, remoteIndex}
-                }
-                return null
-            }).filter(Boolean) as Array<{path: string, localIndex: number, remoteIndex:number}>
-        return clashedFiles.map(
-            ({path, localIndex, remoteIndex}) => {
-                return {
-                    path,
-                    localStatus: localChanges[localIndex].status,
-                    remoteStatus: remoteChanges[remoteIndex].status
-                }
-            })
-    }
+	getClashedChanges(localChanges: LocalChange[], remoteChanges:RemoteChange[]): Array<{path: string, localStatus: LocalFileStatus, remoteStatus: RemoteChangeType}> {
+		const localChangePaths = localChanges.map(c=>c.path);
+		const remoteChangePaths = remoteChanges.map(c=>c.path);
+		const clashedFiles = localChangePaths.map(
+			(path, localIndex) => {
+				const remoteIndex = remoteChangePaths.indexOf(path);
+				if (remoteIndex !== -1) {
+					return {path, localIndex, remoteIndex};
+				}
+				return null;
+			}).filter(Boolean) as Array<{path: string, localIndex: number, remoteIndex:number}>;
+		return clashedFiles.map(
+			({path, localIndex, remoteIndex}) => {
+				return {
+					path,
+					localStatus: localChanges[localIndex].status,
+					remoteStatus: remoteChanges[remoteIndex].status
+				};
+			});
+	}
 
-    async getUser(): Promise<{owner: string, avatarUrl: string}> {
-        try {
-            const {data: response} = await this.octokit.request(
-                `GET /user`, {
-                    headers: this.headers
-            })
-            return {owner: response.login, avatarUrl:response.avatar_url}
-        } catch (error) {
-            throw new OctokitHttpError(error.message, error.status, "getUser");
-        }
-    }
+	async getUser(): Promise<{owner: string, avatarUrl: string}> {
+		try {
+			const {data: response} = await this.octokit.request(
+				`GET /user`, {
+					headers: this.headers
+				});
+			return {owner: response.login, avatarUrl:response.avatar_url};
+		} catch (error) {
+			throw new OctokitHttpError(error.message, error.status, "getUser");
+		}
+	}
 
-    async getRepos(): Promise<string[]> {
-        const allRepos: string[] = [];
-        let page = 1;
-        const perPage = 100; // Set to the maximum value of 100
+	async getRepos(): Promise<string[]> {
+		const allRepos: string[] = [];
+		let page = 1;
+		const perPage = 100; // Set to the maximum value of 100
 
-        try {
-            let hasMorePages = true;
-            while (hasMorePages) {
-                const { data: response } = await this.octokit.request(
-                    `GET /user/repos`, {
-                    affiliation: "owner",
-                    headers: this.headers,
-                    per_page: perPage, // Number of repositories to import per page (up to 100)
-                    page: page
-                }
-                );
-                allRepos.push(...response.map(r => r.name));
+		try {
+			let hasMorePages = true;
+			while (hasMorePages) {
+				const { data: response } = await this.octokit.request(
+					`GET /user/repos`, {
+						affiliation: "owner",
+						headers: this.headers,
+						per_page: perPage, // Number of repositories to import per page (up to 100)
+						page: page
+					}
+				);
+				allRepos.push(...response.map(r => r.name));
 
-                // Make sure you have the following pages
-                if (response.length < perPage) {
-                    hasMorePages = false; // Exit when there are no more repositories
-                }
+				// Make sure you have the following pages
+				if (response.length < perPage) {
+					hasMorePages = false; // Exit when there are no more repositories
+				}
 
-                page++; // Go to the next page
-            }
+				page++; // Go to the next page
+			}
 
-            return allRepos;
-        } catch (error) {
-            throw new OctokitHttpError(error.message, error.status, "getRepos");
-        }
-    }
+			return allRepos;
+		} catch (error) {
+			throw new OctokitHttpError(error.message, error.status, "getRepos");
+		}
+	}
 
-    async getBranches(): Promise<string[]> {
-        try {
-            const {data: response} = await this.octokit.request(
-                `GET /repos/{owner}/{repo}/branches`, 
-                {
-                    owner: this.owner,
-                    repo: this.repo,
-                    headers: this.headers
-            })
-            return response.map(r => r.name)
-        } catch (error) {
-            throw new OctokitHttpError(error.message, error.status, "getRepos");
-        }
-    }
+	async getBranches(): Promise<string[]> {
+		try {
+			const {data: response} = await this.octokit.request(
+				`GET /repos/{owner}/{repo}/branches`,
+				{
+					owner: this.owner,
+					repo: this.repo,
+					headers: this.headers
+				});
+			return response.map(r => r.name);
+		} catch (error) {
+			throw new OctokitHttpError(error.message, error.status, "getRepos");
+		}
+	}
 
-    async getRef(ref: string): Promise<string> {
-        try {
-            const {data: response} = await this.octokit.request(
-                `GET /repos/{owner}/{repo}/git/ref/{ref}`, {
-                    owner: this.owner,
-                    repo: this.repo,
-                    ref: ref,
-                    headers: this.headers
-            })
-            return response.object.sha
-        } catch (error) {
-            throw new OctokitHttpError(error.message, error.status, "getRef");
-        }
-    }
+	async getRef(ref: string): Promise<string> {
+		try {
+			const {data: response} = await this.octokit.request(
+				`GET /repos/{owner}/{repo}/git/ref/{ref}`, {
+					owner: this.owner,
+					repo: this.repo,
+					ref: ref,
+					headers: this.headers
+				});
+			return response.object.sha;
+		} catch (error) {
+			throw new OctokitHttpError(error.message, error.status, "getRef");
+		}
+	}
 
-    // Get the sha of the latest commit in the default branch (set by user in setting)
-    async getLatestRemoteCommitSha(ref = `heads/${this.branch}`): Promise<string> {
-        return await this.getRef(ref)
-    }
+	// Get the sha of the latest commit in the default branch (set by user in setting)
+	async getLatestRemoteCommitSha(ref = `heads/${this.branch}`): Promise<string> {
+		return await this.getRef(ref);
+	}
 
-    // ref Can be a commit SHA, branch name (heads/BRANCH_NAME), or tag name (tags/TAG_NAME), 
-    // refers to https://git-scm.com/book/en/v2/Git-Internals-Git-References
-    async getCommitTreeSha(ref: string): Promise<string> {
-        const {data: commit} =  await this.octokit.request( 
-            `GET /repos/{owner}/{repo}/commits/{ref}`, {
-            owner: this.owner,
-            repo: this.repo,
-            ref,
-            headers: this.headers
-        })
-        return commit.commit.tree.sha
-    }
+	// ref Can be a commit SHA, branch name (heads/BRANCH_NAME), or tag name (tags/TAG_NAME),
+	// refers to https://git-scm.com/book/en/v2/Git-Internals-Git-References
+	async getCommitTreeSha(ref: string): Promise<string> {
+		const {data: commit} =  await this.octokit.request(
+			`GET /repos/{owner}/{repo}/commits/{ref}`, {
+				owner: this.owner,
+				repo: this.repo,
+				ref,
+				headers: this.headers
+			});
+		return commit.commit.tree.sha;
+	}
 
-    async getTree(tree_sha: string): Promise<TreeNode[]> {
-        const { data: tree } =  await this.octokit.request(
-            `GET /repos/{owner}/{repo}/git/trees/{tree_sha}`, {
-            owner: this.owner,
-            repo: this.repo,
-            tree_sha,
-            recursive: 'true',
-            headers: this.headers
-        })
-        return tree.tree as TreeNode[]
-    }
+	async getTree(tree_sha: string): Promise<TreeNode[]> {
+		const { data: tree } =  await this.octokit.request(
+			`GET /repos/{owner}/{repo}/git/trees/{tree_sha}`, {
+				owner: this.owner,
+				repo: this.repo,
+				tree_sha,
+				recursive: 'true',
+				headers: this.headers
+			});
+		return tree.tree as TreeNode[];
+	}
 
-    // get the remote tree sha in the format compatible with local store
-    async getRemoteTreeSha(tree_sha: string): Promise<{[k:string]: string}> {
-        const remoteTree = await this.getTree(tree_sha)
-        const remoteSha = Object.fromEntries(remoteTree.map((node: TreeNode) : [string, string] | null=>{
-            // currently ignoring directory changes, if you'd like to upload a new directory, 
-            // a quick hack would be creating an empty file inside
-            if (node.type=="blob") {
-                if (!node.path || !node.sha) {
-                    throw new Error("Path or sha not found for blob node in remote");
-                }
-                // ignore changes in the _fit/ directory
-                if (node.path.startsWith("_fit/")) {return null}
-                return [node.path, node.sha]
-            }
-            return null
-        }).filter(Boolean) as [string, string][])
-        return remoteSha
-    }
+	// get the remote tree sha in the format compatible with local store
+	async getRemoteTreeSha(tree_sha: string): Promise<{[k:string]: string}> {
+		const remoteTree = await this.getTree(tree_sha);
+		const remoteSha = Object.fromEntries(remoteTree.map((node: TreeNode) : [string, string] | null=>{
+			// currently ignoring directory changes, if you'd like to upload a new directory,
+			// a quick hack would be creating an empty file inside
+			if (node.type=="blob") {
+				if (!node.path || !node.sha) {
+					throw new Error("Path or sha not found for blob node in remote");
+				}
+				// ignore changes in the _fit/ directory
+				if (node.path.startsWith("_fit/")) {return null;}
+				return [node.path, node.sha];
+			}
+			return null;
+		}).filter(Boolean) as [string, string][]);
+		return remoteSha;
+	}
 
-    async createBlob(content: string, encoding: string): Promise<string> {
-        const {data: blob} = await this.octokit.request(
-            `POST /repos/{owner}/{repo}/git/blobs`, {
-            owner: this.owner,
-            repo: this.repo,
-            content, 
-            encoding,
-            headers: this.headers     
-        })
-        return blob.sha
-    }
+	async createBlob(content: string, encoding: string): Promise<string> {
+		const {data: blob} = await this.octokit.request(
+			`POST /repos/{owner}/{repo}/git/blobs`, {
+				owner: this.owner,
+				repo: this.repo,
+				content,
+				encoding,
+				headers: this.headers
+			});
+		return blob.sha;
+	}
 
 
-    async createTreeNodeFromFile({path, status, extension}: LocalChange, remoteTree: Array<TreeNode>): Promise<TreeNode|null> {
+	async createTreeNodeFromFile({path, status, extension}: LocalChange, remoteTree: Array<TreeNode>): Promise<TreeNode|null> {
 		if (status === "deleted") {
-            // skip creating deletion node if file not found on remote
-            if (remoteTree.every(node => node.path !== path)) {
-                return null
-            }
+			// skip creating deletion node if file not found on remote
+			if (remoteTree.every(node => node.path !== path)) {
+				return null;
+			}
 			return {
 				path,
 				mode: '100644',
 				type: 'blob',
 				sha: null
-			}
+			};
 		}
-        const file = await this.vaultOps.getTFile(path)
+		const file = await this.vaultOps.getTFile(path);
 		let encoding: string;
-		let content: string 
-        // TODO check whether every files including md can be read using readBinary to reduce code complexity
+		let content: string;
+		// TODO check whether every files including md can be read using readBinary to reduce code complexity
 		if (extension && RECOGNIZED_BINARY_EXT.includes(extension)) {
-			encoding = "base64"
+			encoding = "base64";
 
-			const fileArrayBuf = await this.vaultOps.vault.readBinary(file)
+			const fileArrayBuf = await this.vaultOps.vault.readBinary(file);
 			const uint8Array = new Uint8Array(fileArrayBuf);
 			let binaryString = '';
 			for (let i = 0; i < uint8Array.length; i++) {
@@ -360,73 +360,73 @@ export class Fit implements IFit {
 			}
 			content = btoa(binaryString);
 		} else {
-			encoding = 'utf-8'
-			content = await this.vaultOps.vault.read(file)
+			encoding = 'utf-8';
+			content = await this.vaultOps.vault.read(file);
 		}
-		const blobSha = await this.createBlob(content, encoding)
-        // skip creating node if file found on remote is the same as the created blob
-        if (remoteTree.some(node => node.path === path && node.sha === blobSha)) {
-            return null
-        }
+		const blobSha = await this.createBlob(content, encoding);
+		// skip creating node if file found on remote is the same as the created blob
+		if (remoteTree.some(node => node.path === path && node.sha === blobSha)) {
+			return null;
+		}
 		return {
 			path: path,
 			mode: '100644',
 			type: 'blob',
 			sha: blobSha,
-		}
+		};
 	}
 
-    async createTree(
-        treeNodes: Array<TreeNode>,
-        base_tree_sha: string): 
-        Promise<string> {
-            const {data: newTree} = await this.octokit.request(
-                `POST /repos/{owner}/{repo}/git/trees`, 
-                {
-                    owner: this.owner,
-                    repo: this.repo,
-                    tree: treeNodes,
-                    base_tree: base_tree_sha,
-                    headers: this.headers
-                }
-            )
-            return newTree.sha
-    }
+	async createTree(
+		treeNodes: Array<TreeNode>,
+		base_tree_sha: string):
+		Promise<string> {
+		const {data: newTree} = await this.octokit.request(
+			`POST /repos/{owner}/{repo}/git/trees`,
+			{
+				owner: this.owner,
+				repo: this.repo,
+				tree: treeNodes,
+				base_tree: base_tree_sha,
+				headers: this.headers
+			}
+		);
+		return newTree.sha;
+	}
 
-    async createCommit(treeSha: string, parentSha: string): Promise<string> {
-        const message = `Commit from ${this.deviceName} on ${new Date().toLocaleString()}`
-        const { data: createdCommit } = await this.octokit.request(
-            `POST /repos/{owner}/{repo}/git/commits` , {
-            owner: this.owner,
-            repo: this.repo,
-            message,
-            tree: treeSha,
-            parents: [parentSha],
-            headers: this.headers
-        })
-        return createdCommit.sha
-    }
+	async createCommit(treeSha: string, parentSha: string): Promise<string> {
+		const message = `Commit from ${this.deviceName} on ${new Date().toLocaleString()}`;
+		const { data: createdCommit } = await this.octokit.request(
+			`POST /repos/{owner}/{repo}/git/commits` , {
+				owner: this.owner,
+				repo: this.repo,
+				message,
+				tree: treeSha,
+				parents: [parentSha],
+				headers: this.headers
+			});
+		return createdCommit.sha;
+	}
 
-    async updateRef(sha: string, ref = `heads/${this.branch}`): Promise<string> {
-        const { data:updatedRef } = await this.octokit.request(
-            `PATCH /repos/{owner}/{repo}/git/refs/{ref}`, {
-            owner: this.owner,
-            repo: this.repo,
-            ref,
-            sha,
-            headers: this.headers
-        })
-        return updatedRef.object.sha
-    }
+	async updateRef(sha: string, ref = `heads/${this.branch}`): Promise<string> {
+		const { data:updatedRef } = await this.octokit.request(
+			`PATCH /repos/{owner}/{repo}/git/refs/{ref}`, {
+				owner: this.owner,
+				repo: this.repo,
+				ref,
+				sha,
+				headers: this.headers
+			});
+		return updatedRef.object.sha;
+	}
 
-    async getBlob(file_sha:string): Promise<string> {
-        const { data: blob } = await this.octokit.request(
-            `GET /repos/{owner}/{repo}/git/blobs/{file_sha}`, {
-            owner: this.owner,
-            repo: this.repo,
-            file_sha,
-            headers: this.headers
-        })
-        return blob.content
-    }
+	async getBlob(file_sha:string): Promise<string> {
+		const { data: blob } = await this.octokit.request(
+			`GET /repos/{owner}/{repo}/git/blobs/{file_sha}`, {
+				owner: this.owner,
+				repo: this.repo,
+				file_sha,
+				headers: this.headers
+			});
+		return blob.content;
+	}
 }

--- a/src/fitNotice.ts
+++ b/src/fitNotice.ts
@@ -2,76 +2,76 @@ import { Notice } from "obsidian";
 import { Fit } from "./fit";
 
 export default class FitNotice {
-    fit: Fit
-    muted: boolean
-    notice: null | Notice
-    classes: Array<string>
+	fit: Fit;
+	muted: boolean;
+	notice: null | Notice;
+	classes: Array<string>;
 
 	constructor(fit: Fit, addClasses: Array<string> = [], initialMessage?: string, duration = 0, muted = false) {
-        this.fit = fit
-        this.muted = muted
-        this.classes = ['fit-notice']
-        if (initialMessage && !this.muted) {
-            this.show(initialMessage, addClasses, duration)
-        } else {
-            this.classes = [...this.classes, ...addClasses]
-        }
-    }
+		this.fit = fit;
+		this.muted = muted;
+		this.classes = ['fit-notice'];
+		if (initialMessage && !this.muted) {
+			this.show(initialMessage, addClasses, duration);
+		} else {
+			this.classes = [...this.classes, ...addClasses];
+		}
+	}
 
-    mute(): void {
-        this.muted = true
-        if (this.notice) {
-            this.notice.hide()
-        }
-    }
+	mute(): void {
+		this.muted = true;
+		if (this.notice) {
+			this.notice.hide();
+		}
+	}
 
-    unmute(): void {
-        this.muted = false
-    }
+	unmute(): void {
+		this.muted = false;
+	}
 
-    show(initialMessage?: string, addClasses: Array<string> = [], duration = 0): void {
-        if (!this.notice && !this.muted) {
-            const message = (initialMessage && initialMessage.length > 0)? initialMessage : " "
-            this.notice = new Notice(message, duration)
-            this.notice.noticeEl.addClasses([...this.classes, ...addClasses])
-        }
-    }
+	show(initialMessage?: string, addClasses: Array<string> = [], duration = 0): void {
+		if (!this.notice && !this.muted) {
+			const message = (initialMessage && initialMessage.length > 0)? initialMessage : " ";
+			this.notice = new Notice(message, duration);
+			this.notice.noticeEl.addClasses([...this.classes, ...addClasses]);
+		}
+	}
 
-    updateClasses(addClasses: Array<string> = [], removeClasses: Array<string> = []): void {
-        if (this.muted) {return}
-        this.classes = this.classes.filter(c => !removeClasses.includes(c))
-        if (this.notice) {
-            this.notice.noticeEl.removeClasses(removeClasses)
-            this.notice.noticeEl.addClasses(addClasses)
-        }
-        this.classes = [...this.classes, ...addClasses]
-    }
+	updateClasses(addClasses: Array<string> = [], removeClasses: Array<string> = []): void {
+		if (this.muted) {return;}
+		this.classes = this.classes.filter(c => !removeClasses.includes(c));
+		if (this.notice) {
+			this.notice.noticeEl.removeClasses(removeClasses);
+			this.notice.noticeEl.addClasses(addClasses);
+		}
+		this.classes = [...this.classes, ...addClasses];
+	}
 
-    // allows error display to override muted
-    setMessage(message: string, isError?: boolean): void {
-        if (isError) {
-            if (!this.notice) {
-                this.notice = new Notice(message, 0)
-                this.notice.noticeEl.addClasses(['fit-notice', 'error'])
-            } else {
-                this.notice.setMessage(message)
-            }
-        } else {
-            if (this.notice && !this.muted) {
-                this.notice.setMessage(message)
-            }
-        }
-    }
+	// allows error display to override muted
+	setMessage(message: string, isError?: boolean): void {
+		if (isError) {
+			if (!this.notice) {
+				this.notice = new Notice(message, 0);
+				this.notice.noticeEl.addClasses(['fit-notice', 'error']);
+			} else {
+				this.notice.setMessage(message);
+			}
+		} else {
+			if (this.notice && !this.muted) {
+				this.notice.setMessage(message);
+			}
+		}
+	}
 
-    remove(finalClass?: string, duration = 5000): void {
-        if (this.muted) {return}
-		this.notice?.noticeEl.removeClasses(this.classes.filter(c => c !== "fit-notice"))
-        if (finalClass) {
-            this.notice?.noticeEl.addClass(finalClass)
-        } else {
-            this.notice?.noticeEl.addClass("done")
-        }
-        setTimeout(() => this.notice?.hide(), duration)
-    }
+	remove(finalClass?: string, duration = 5000): void {
+		if (this.muted) {return;}
+		this.notice?.noticeEl.removeClasses(this.classes.filter(c => c !== "fit-notice"));
+		if (finalClass) {
+			this.notice?.noticeEl.addClass(finalClass);
+		} else {
+			this.notice?.noticeEl.addClass("done");
+		}
+		setTimeout(() => this.notice?.hide(), duration);
+	}
 
 }

--- a/src/fitPull.ts
+++ b/src/fitPull.ts
@@ -3,87 +3,87 @@ import { LocalStores } from "main";
 import { FileOpRecord, LocalChange, RemoteChange, RemoteUpdate } from "./fitTypes";
 
 type PrePullCheckResultType = (
-    "localCopyUpToDate" | 
-    "localChangesClashWithRemoteChanges" | 
-    "remoteChangesCanBeMerged" | 
+    "localCopyUpToDate" |
+    "localChangesClashWithRemoteChanges" |
+    "remoteChangesCanBeMerged" |
     "noRemoteChangesDetected"
-)
+);
 
 type PrePullCheckResult = (
-    { status: "localCopyUpToDate", remoteUpdate: null } | 
+    { status: "localCopyUpToDate", remoteUpdate: null } |
     { status: Exclude<PrePullCheckResultType, "localCopyUpToDate">, remoteUpdate: RemoteUpdate }
 );
 
 export interface IFitPull {
-    fit: Fit
+	fit: Fit
 }
 
 export class FitPull implements IFitPull {
-    fit: Fit
-    
+	fit: Fit;
 
-    constructor(fit: Fit) {
-        this.fit = fit
-    }
 
-    async performPrePullChecks(localChanges?: LocalChange[]): Promise<PrePullCheckResult> {
-        const {remoteCommitSha, updated} = await this.fit.remoteUpdated()
-        if (!updated) {
-            return {status: "localCopyUpToDate", remoteUpdate: null}
-        }
-        if (!localChanges) {
-            localChanges = await this.fit.getLocalChanges()
-        }
-        const remoteTreeSha = await this.fit.getRemoteTreeSha(remoteCommitSha)
-        const remoteChanges = await this.fit.getRemoteChanges(remoteTreeSha)
-        const clashedFiles = this.fit.getClashedChanges(localChanges, remoteChanges)
-        // TODO handle clashes without completely blocking pull
-        const prePullCheckStatus = (
-            (remoteChanges.length > 0) ? (
-                (clashedFiles.length > 0) ? "localChangesClashWithRemoteChanges" : "remoteChangesCanBeMerged"):
-                "noRemoteChangesDetected")
-        
-        return {
-            status: prePullCheckStatus, 
-            remoteUpdate: {
-                remoteChanges, remoteTreeSha, latestRemoteCommitSha: remoteCommitSha, clashedFiles
-            }
-        }
-    }
+	constructor(fit: Fit) {
+		this.fit = fit;
+	}
 
-    // Get changes from remote, pathShaMap is coupled to the Fit plugin design
-    async getRemoteNonDeletionChangesContent(pathShaMap: Record<string, string>) {
-        const remoteChanges = Object.entries(pathShaMap).map(async ([path, file_sha]) => {
-            const content = await this.fit.getBlob(file_sha);
-            return {path, content};
-        })
-        return await Promise.all(remoteChanges)
-    }
+	async performPrePullChecks(localChanges?: LocalChange[]): Promise<PrePullCheckResult> {
+		const {remoteCommitSha, updated} = await this.fit.remoteUpdated();
+		if (!updated) {
+			return {status: "localCopyUpToDate", remoteUpdate: null};
+		}
+		if (!localChanges) {
+			localChanges = await this.fit.getLocalChanges();
+		}
+		const remoteTreeSha = await this.fit.getRemoteTreeSha(remoteCommitSha);
+		const remoteChanges = await this.fit.getRemoteChanges(remoteTreeSha);
+		const clashedFiles = this.fit.getClashedChanges(localChanges, remoteChanges);
+		// TODO handle clashes without completely blocking pull
+		const prePullCheckStatus = (
+			(remoteChanges.length > 0) ? (
+				(clashedFiles.length > 0) ? "localChangesClashWithRemoteChanges" : "remoteChangesCanBeMerged"):
+				"noRemoteChangesDetected");
 
-    async prepareChangesToExecute(remoteChanges: RemoteChange[]) {
-        const deleteFromLocal = remoteChanges.filter(c=>c.status=="REMOVED").map(c=>c.path)
-			const changesToProcess = remoteChanges.filter(c=>c.status!="REMOVED").reduce(
-				(acc, change) => {
-                    acc[change.path] = change.currentSha as string;
-					return acc;
-                }, {} as Record<string, string>);
+		return {
+			status: prePullCheckStatus,
+			remoteUpdate: {
+				remoteChanges, remoteTreeSha, latestRemoteCommitSha: remoteCommitSha, clashedFiles
+			}
+		};
+	}
 
-		const addToLocal = await this.getRemoteNonDeletionChangesContent(changesToProcess)
-        return {addToLocal, deleteFromLocal}
-    }
+	// Get changes from remote, pathShaMap is coupled to the Fit plugin design
+	async getRemoteNonDeletionChangesContent(pathShaMap: Record<string, string>) {
+		const remoteChanges = Object.entries(pathShaMap).map(async ([path, file_sha]) => {
+			const content = await this.fit.getBlob(file_sha);
+			return {path, content};
+		});
+		return await Promise.all(remoteChanges);
+	}
 
-    async pullRemoteToLocal(
-        remoteUpdate: RemoteUpdate,
-        saveLocalStoreCallback: (localStore: Partial<LocalStores>) => Promise<void>): Promise<FileOpRecord[]> {
-            const {remoteChanges, remoteTreeSha, latestRemoteCommitSha} = remoteUpdate
-            const {addToLocal, deleteFromLocal} = await this.prepareChangesToExecute(remoteChanges)
-			
-			const fileOpsRecord = await this.fit.vaultOps.updateLocalFiles(addToLocal, deleteFromLocal);
-			await saveLocalStoreCallback({
-                lastFetchedRemoteSha: remoteTreeSha, 
-                lastFetchedCommitSha: latestRemoteCommitSha,
-                localSha: await this.fit.computeLocalSha()
-            })
-            return fileOpsRecord
-    }
+	async prepareChangesToExecute(remoteChanges: RemoteChange[]) {
+		const deleteFromLocal = remoteChanges.filter(c=>c.status=="REMOVED").map(c=>c.path);
+		const changesToProcess = remoteChanges.filter(c=>c.status!="REMOVED").reduce(
+			(acc, change) => {
+				acc[change.path] = change.currentSha as string;
+				return acc;
+			}, {} as Record<string, string>);
+
+		const addToLocal = await this.getRemoteNonDeletionChangesContent(changesToProcess);
+		return {addToLocal, deleteFromLocal};
+	}
+
+	async pullRemoteToLocal(
+		remoteUpdate: RemoteUpdate,
+		saveLocalStoreCallback: (localStore: Partial<LocalStores>) => Promise<void>): Promise<FileOpRecord[]> {
+		const {remoteChanges, remoteTreeSha, latestRemoteCommitSha} = remoteUpdate;
+		const {addToLocal, deleteFromLocal} = await this.prepareChangesToExecute(remoteChanges);
+
+		const fileOpsRecord = await this.fit.vaultOps.updateLocalFiles(addToLocal, deleteFromLocal);
+		await saveLocalStoreCallback({
+			lastFetchedRemoteSha: remoteTreeSha,
+			lastFetchedCommitSha: latestRemoteCommitSha,
+			localSha: await this.fit.computeLocalSha()
+		});
+		return fileOpsRecord;
+	}
 }

--- a/src/fitPush.ts
+++ b/src/fitPush.ts
@@ -3,62 +3,62 @@ import { LocalChange, LocalUpdate } from "./fitTypes";
 
 
 export interface IFitPush {
-    localSha: Record<string, string>
-    fit: Fit
+	localSha: Record<string, string>
+	fit: Fit
 }
 
 export class FitPush implements IFitPush {
-    localSha: Record<string, string>;
-    fit: Fit
-    
-
-    constructor(fit: Fit) {
-        this.fit = fit
-    }
-
-    async createCommitFromLocalUpdate(localUpdate: LocalUpdate, remoteTree: Array<TreeNode>): Promise<{createdCommitSha: string, pushedChanges: LocalChange[]} | null> {
-        const {localChanges, parentCommitSha} = localUpdate
-        const pushedChanges: LocalChange[] = [];
-        const treeNodes = (await Promise.all(localChanges.map(async (f, i) => {
-            const node =  await this.fit.createTreeNodeFromFile(f, remoteTree)
-            if (node) {
-                pushedChanges.push(localChanges[i])
-                return node
-            }
-        }))).filter(Boolean) as Array<TreeNode>
-        console.log(treeNodes)
-        if (treeNodes.length === 0) {
-            return null
-        }
-        const latestRemoteCommitTreeSha = await this.fit.getCommitTreeSha(parentCommitSha)
-        const createdTreeSha = await this.fit.createTree(treeNodes, latestRemoteCommitTreeSha)
-        const createdCommitSha = await this.fit.createCommit(createdTreeSha, parentCommitSha)
-        return {createdCommitSha, pushedChanges}
-    }
+	localSha: Record<string, string>;
+	fit: Fit;
 
 
+	constructor(fit: Fit) {
+		this.fit = fit;
+	}
 
-    async pushChangedFilesToRemote(
-        localUpdate: LocalUpdate,
-        ): Promise<{pushedChanges: LocalChange[], lastFetchedRemoteSha: Record<string, string>, lastFetchedCommitSha: string}|null> {
-            if (localUpdate.localChanges.length == 0) {
-                // did not update ref
-                return null
-            }
-            // const {localTreeSha} = localUpdate;
-            const remoteTree = await this.fit.getTree(localUpdate.parentCommitSha)
-            const createCommitResult = await this.createCommitFromLocalUpdate(localUpdate, remoteTree)
-            if (!createCommitResult) {
-                // did not update ref
-                return null
-            }
-            const {createdCommitSha, pushedChanges} = createCommitResult
-            const updatedRefSha = await this.fit.updateRef(createdCommitSha)
-            const updatedRemoteTreeSha = await this.fit.getRemoteTreeSha(updatedRefSha)
-            return {
-                pushedChanges, 
-                lastFetchedRemoteSha: updatedRemoteTreeSha, 
-                lastFetchedCommitSha: createdCommitSha,
-            }
-    }
+	async createCommitFromLocalUpdate(localUpdate: LocalUpdate, remoteTree: Array<TreeNode>): Promise<{createdCommitSha: string, pushedChanges: LocalChange[]} | null> {
+		const {localChanges, parentCommitSha} = localUpdate;
+		const pushedChanges: LocalChange[] = [];
+		const treeNodes = (await Promise.all(localChanges.map(async (f, i) => {
+			const node =  await this.fit.createTreeNodeFromFile(f, remoteTree);
+			if (node) {
+				pushedChanges.push(localChanges[i]);
+				return node;
+			}
+		}))).filter(Boolean) as Array<TreeNode>;
+		console.log(treeNodes);
+		if (treeNodes.length === 0) {
+			return null;
+		}
+		const latestRemoteCommitTreeSha = await this.fit.getCommitTreeSha(parentCommitSha);
+		const createdTreeSha = await this.fit.createTree(treeNodes, latestRemoteCommitTreeSha);
+		const createdCommitSha = await this.fit.createCommit(createdTreeSha, parentCommitSha);
+		return {createdCommitSha, pushedChanges};
+	}
+
+
+
+	async pushChangedFilesToRemote(
+		localUpdate: LocalUpdate,
+	): Promise<{pushedChanges: LocalChange[], lastFetchedRemoteSha: Record<string, string>, lastFetchedCommitSha: string}|null> {
+		if (localUpdate.localChanges.length == 0) {
+			// did not update ref
+			return null;
+		}
+		// const {localTreeSha} = localUpdate;
+		const remoteTree = await this.fit.getTree(localUpdate.parentCommitSha);
+		const createCommitResult = await this.createCommitFromLocalUpdate(localUpdate, remoteTree);
+		if (!createCommitResult) {
+			// did not update ref
+			return null;
+		}
+		const {createdCommitSha, pushedChanges} = createCommitResult;
+		const updatedRefSha = await this.fit.updateRef(createdCommitSha);
+		const updatedRemoteTreeSha = await this.fit.getRemoteTreeSha(updatedRefSha);
+		return {
+			pushedChanges,
+			lastFetchedRemoteSha: updatedRemoteTreeSha,
+			lastFetchedCommitSha: createdCommitSha,
+		};
+	}
 }

--- a/src/fitSetting.ts
+++ b/src/fitSetting.ts
@@ -3,17 +3,17 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 import { setEqual } from "./utils";
 import { warn } from "console";
 
-type RefreshCheckPoint = "repo(0)" | "branch(1)" | "link(2)" | "initialize" | "withCache"
+type RefreshCheckPoint = "repo(0)" | "branch(1)" | "link(2)" | "initialize" | "withCache";
 
 export default class FitSettingTab extends PluginSettingTab {
 	plugin: FitPlugin;
 	authenticating: boolean;
 	authUserAvatar: HTMLDivElement;
 	authUserHandle: HTMLSpanElement;
-	patSetting: Setting
-	ownerSetting: Setting
-	repoSetting: Setting
-	branchSetting: Setting
+	patSetting: Setting;
+	ownerSetting: Setting;
+	repoSetting: Setting;
+	branchSetting: Setting;
 	existingRepos: Array<string>;
 	existingBranches: Array<string>;
 	repoLink: string;
@@ -22,89 +22,89 @@ export default class FitSettingTab extends PluginSettingTab {
 		super(app, plugin);
 		this.plugin = plugin;
 		this.repoLink = this.getLatestLink();
-		this.authenticating = false
-		this.existingRepos = []
-		this.existingBranches = []
+		this.authenticating = false;
+		this.existingRepos = [];
+		this.existingBranches = [];
 	}
 
 	getLatestLink = (): string => {
 		const {owner, repo, branch} = this.plugin.settings;
 		if (owner.length > 0 && repo.length > 0 && branch.length > 0) {
-			return `https://github.com/${owner}/${repo}/tree/${branch}`
+			return `https://github.com/${owner}/${repo}/tree/${branch}`;
 		}
-		return ""
-	}
+		return "";
+	};
 
 	handleUserFetch = async () => {
-		this.authenticating = true
-		this.authUserAvatar.removeClass('error')
-		this.authUserAvatar.empty()
-		this.authUserAvatar.removeClass('empty')
-		this.authUserAvatar.addClass('cat')
+		this.authenticating = true;
+		this.authUserAvatar.removeClass('error');
+		this.authUserAvatar.empty();
+		this.authUserAvatar.removeClass('empty');
+		this.authUserAvatar.addClass('cat');
 		try {
 			const {owner, avatarUrl} = await this.plugin.fit.getUser();
-			this.authUserAvatar.removeClass('cat')
+			this.authUserAvatar.removeClass('cat');
 			this.authUserAvatar.createEl('img', { attr: { src: avatarUrl } });
-			this.authUserHandle.setText(owner)
+			this.authUserHandle.setText(owner);
 			if (owner !== this.plugin.settings.owner) {
-				this.plugin.settings.owner = owner
-				this.plugin.settings.avatarUrl = avatarUrl
-				this.plugin.settings.repo = ""
-				this.plugin.settings.branch = ""
-				this.existingBranches = []
-				this.existingRepos = []
+				this.plugin.settings.owner = owner;
+				this.plugin.settings.avatarUrl = avatarUrl;
+				this.plugin.settings.repo = "";
+				this.plugin.settings.branch = "";
+				this.existingBranches = [];
+				this.existingRepos = [];
 				await this.plugin.saveSettings();
 				await this.refreshFields('repo(0)');
 			}
-			this.authenticating = false
+			this.authenticating = false;
 		} catch (error) {
-			this.authUserAvatar.removeClass('cat')
-			this.authUserAvatar.addClass('error')
-			this.authUserHandle.setText("Authentication failed, make sure your token has not expired.")
-			this.plugin.settings.owner = ""
-			this.plugin.settings.avatarUrl = ""
-			this.plugin.settings.repo = ""
-			this.plugin.settings.branch = ""
-			this.existingBranches = []
-			this.existingRepos = []
+			this.authUserAvatar.removeClass('cat');
+			this.authUserAvatar.addClass('error');
+			this.authUserHandle.setText("Authentication failed, make sure your token has not expired.");
+			this.plugin.settings.owner = "";
+			this.plugin.settings.avatarUrl = "";
+			this.plugin.settings.repo = "";
+			this.plugin.settings.branch = "";
+			this.existingBranches = [];
+			this.existingRepos = [];
 			await this.plugin.saveSettings();
 			this.refreshFields('initialize');
-			this.authenticating = false
+			this.authenticating = false;
 		}
-	}
+	};
 
 	githubUserInfoBlock = () => {
-		const {containerEl} = this
+		const {containerEl} = this;
 		new Setting(containerEl).setHeading()
-		.setName("GitHub user info")
-		.addButton(button => button
-			.setCta()
-			.setButtonText("Authenticate user")
-			.setDisabled(this.authenticating)
-			.onClick(async ()=>{
-				if (this.authenticating) return
-				await this.handleUserFetch()
-			}))
+			.setName("GitHub user info")
+			.addButton(button => button
+				.setCta()
+				.setButtonText("Authenticate user")
+				.setDisabled(this.authenticating)
+				.onClick(async ()=>{
+					if (this.authenticating) return;
+					await this.handleUserFetch();
+				}));
 		this.ownerSetting = new Setting(containerEl)
 			.setDesc("Input your personal access token below to get authenticated. Create a GitHub account here if you don't have one yet.")
 			.addExtraButton(button=>button
 				.setIcon('github')
 				.setTooltip("Sign up on github.com")
 				.onClick(async ()=>{
-					window.open("https://github.com/signup", "_blank")
-				}))
+					window.open("https://github.com/signup", "_blank");
+				}));
 		this.ownerSetting.nameEl.addClass('fit-avatar-container');
 		if (this.plugin.settings.owner === "") {
 			this.authUserAvatar = this.ownerSetting.nameEl.createDiv(
-				{cls: 'fit-avatar-container empty'})
-			this.authUserHandle = this.ownerSetting.nameEl.createEl('span', {cls: 'fit-github-handle'})
-			this.authUserHandle.setText("Unauthenticated")
+				{cls: 'fit-avatar-container empty'});
+			this.authUserHandle = this.ownerSetting.nameEl.createEl('span', {cls: 'fit-github-handle'});
+			this.authUserHandle.setText("Unauthenticated");
 		} else {
 			this.authUserAvatar = this.ownerSetting.nameEl.createDiv(
-				{cls: 'fit-avatar-container'})
+				{cls: 'fit-avatar-container'});
 			this.authUserAvatar.createEl('img', { attr: { src: this.plugin.settings.avatarUrl } });
-			this.authUserHandle = this.ownerSetting.nameEl.createEl('span', {cls: 'fit-github-handle'})
-			this.authUserHandle.setText(this.plugin.settings.owner)
+			this.authUserHandle = this.ownerSetting.nameEl.createEl('span', {cls: 'fit-github-handle'});
+			this.authUserHandle.setText(this.plugin.settings.owner);
 		}
 		// hide the control element to make space for authUser
 		this.ownerSetting.controlEl.addClass('fit-avatar-display-text');
@@ -126,21 +126,21 @@ export default class FitSettingTab extends PluginSettingTab {
 					window.open(
 						"https://github.com/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write",
 						'_blank');
-				}))
-	}
+				}));
+	};
 
 	repoInfoBlock = async () => {
-		const {containerEl} = this
+		const {containerEl} = this;
 		new Setting(containerEl).setHeading().setName("Repository info")
-		.setDesc("Refresh to retrieve the latest list of repos and branches.")
-		.addExtraButton(button => button
-			.setTooltip("Refresh repos and branches list")
-			.setDisabled(this.plugin.settings.owner === "")
-			.setIcon('refresh-cw')
-			.onClick(async () => {
-				await this.refreshFields('repo(0)');
-			}))
-			
+			.setDesc("Refresh to retrieve the latest list of repos and branches.")
+			.addExtraButton(button => button
+				.setTooltip("Refresh repos and branches list")
+				.setDisabled(this.plugin.settings.owner === "")
+				.setIcon('refresh-cw')
+				.onClick(async () => {
+					await this.refreshFields('repo(0)');
+				}));
+
 		new Setting(containerEl)
 			.setDesc("Select 'Add a README file' if creating a new repo. Make sure you are logged in to github on your browser.")
 			.addExtraButton(button => button
@@ -148,45 +148,45 @@ export default class FitSettingTab extends PluginSettingTab {
 				.setTooltip("Create a new repository")
 				.onClick(() => {
 					window.open(`https://github.com/new`, '_blank');
-				}))
-				
+				}));
+
 		this.repoSetting = new Setting(containerEl)
 			.setName('Github repository name')
 			.setDesc("Select a repo to sync your vault, refresh to see your latest repos. If some repos are missing, make sure your token are granted access to them.")
 			.addDropdown(dropdown => {
 				dropdown.selectEl.addClass('repo-dropdown');
-				this.existingRepos.map(repo=>dropdown.addOption(repo, repo))
-				dropdown.setDisabled(this.existingRepos.length === 0)
-				dropdown.setValue(this.plugin.settings.repo)
+				this.existingRepos.map(repo=>dropdown.addOption(repo, repo));
+				dropdown.setDisabled(this.existingRepos.length === 0);
+				dropdown.setValue(this.plugin.settings.repo);
 				dropdown.onChange(async (value) => {
-					const repoChanged = value !== this.plugin.settings.repo
+					const repoChanged = value !== this.plugin.settings.repo;
 					if (repoChanged) {
 						this.plugin.settings.repo = value;
 						await this.plugin.saveSettings();
 						await this.refreshFields('branch(1)');
 					}
-				})
-			})
+				});
+			});
 
 		this.branchSetting = new Setting(containerEl)
 			.setName('Branch name')
 			.setDesc('Select a repo above to view existing branches.')
 			.addDropdown(dropdown => {
 				dropdown.selectEl.addClass('branch-dropdown');
-				dropdown.setDisabled(this.existingBranches.length === 0)
-				this.existingBranches.map(repo=>dropdown.addOption(repo, repo))
-				dropdown.setValue(this.plugin.settings.branch)
+				dropdown.setDisabled(this.existingBranches.length === 0);
+				this.existingBranches.map(repo=>dropdown.addOption(repo, repo));
+				dropdown.setValue(this.plugin.settings.branch);
 				dropdown.onChange(async (value) => {
-					const branchChanged = value !== this.plugin.settings.branch
+					const branchChanged = value !== this.plugin.settings.branch;
 					if (branchChanged) {
 						this.plugin.settings.branch = value;
 						await this.plugin.saveSettings();
 						await this.refreshFields('link(2)');
 					}
-				})
-			})
+				});
+			});
 
-		this.repoLink = this.getLatestLink()
+		this.repoLink = this.getLatestLink();
 		const linkDisplay = new Setting(containerEl)
 			.setName("View your vault on GitHub")
 			.setDesc(this.repoLink)
@@ -195,16 +195,16 @@ export default class FitSettingTab extends PluginSettingTab {
 				.setTooltip("Open on GitHub")
 				.setIcon('external-link')
 				.onClick(() => {
-					console.log(`opening ${this.repoLink}`)
+					console.log(`opening ${this.repoLink}`);
 					window.open(this.repoLink, '_blank');
 				})
-			)
-		linkDisplay.descEl.addClass("link-desc")
-	}
+			);
+		linkDisplay.descEl.addClass("link-desc");
+	};
 
 	localConfigBlock = () => {
-		const {containerEl} = this
-		new Setting(containerEl).setHeading().setName("Local configurations");		
+		const {containerEl} = this;
+		new Setting(containerEl).setHeading().setName("Local configurations");
 		new Setting(containerEl)
 			.setName('Device name')
 			.setDesc('Sign commit message with this device name.')
@@ -216,25 +216,25 @@ export default class FitSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				}));
 
-				
+
 		new Setting(containerEl)
-		.setName("Auto sync")
-		.setDesc(`Automatically sync your vault when remote has updates. (Muted: sync in the background without displaying notices, except for file changes and conflicts notice)`)
-		.addDropdown(dropdown => {
-			dropdown
-			.addOption('off', 'Off')
-			.addOption('muted', 'Muted')
-			.addOption('remind', 'Remind only')
-			.addOption('on', 'On')
-			.setValue(this.plugin.settings.autoSync ? this.plugin.settings.autoSync : 'off')
-			.onChange(async (value) => {
-				this.plugin.settings.autoSync = value as "off" | "muted" | "remind" | "on";
-				checkIntervalSlider.settingEl.addClass(value === "off" ? "clear" : "restore");
-				checkIntervalSlider.settingEl.removeClass(value === "off" ? "restore" : "clear");
-				await this.plugin.saveSettings();
-			})
-		})
-		
+			.setName("Auto sync")
+			.setDesc(`Automatically sync your vault when remote has updates. (Muted: sync in the background without displaying notices, except for file changes and conflicts notice)`)
+			.addDropdown(dropdown => {
+				dropdown
+					.addOption('off', 'Off')
+					.addOption('muted', 'Muted')
+					.addOption('remind', 'Remind only')
+					.addOption('on', 'On')
+					.setValue(this.plugin.settings.autoSync ? this.plugin.settings.autoSync : 'off')
+					.onChange(async (value) => {
+						this.plugin.settings.autoSync = value as "off" | "muted" | "remind" | "on";
+						checkIntervalSlider.settingEl.addClass(value === "off" ? "clear" : "restore");
+						checkIntervalSlider.settingEl.removeClass(value === "off" ? "restore" : "clear");
+						await this.plugin.saveSettings();
+					});
+			});
+
 		const checkIntervalSlider = new Setting(containerEl)
 			.setName('Auto check interval')
 			.setDesc(`Automatically check for remote changes in the background every ${this.plugin.settings.checkEveryXMinutes} minutes.`)
@@ -245,171 +245,171 @@ export default class FitSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.checkEveryXMinutes = value;
 					await this.plugin.saveSettings();
-					checkIntervalSlider.setDesc(`Automatically check for remote changes in the background every ${value} minutes.`)
+					checkIntervalSlider.setDesc(`Automatically check for remote changes in the background every ${value} minutes.`);
 				})
-			)
+			);
 
 		if (this.plugin.settings.autoSync === "off") {
-			checkIntervalSlider.settingEl.addClass("clear")
+			checkIntervalSlider.settingEl.addClass("clear");
 		}
-	}
+	};
 
 	noticeConfigBlock = () => {
-		const {containerEl} = this
-		const selectedCol = "var(--interactive-accent)"
-		const selectedTxtCol = "var(--text-on-accent)"
-		const unselectedColor = "var(--interactive-normal)"
-		const unselectedTxtCol = "var(--text-normal)"
+		const {containerEl} = this;
+		const selectedCol = "var(--interactive-accent)";
+		const selectedTxtCol = "var(--text-on-accent)";
+		const unselectedColor = "var(--interactive-normal)";
+		const unselectedTxtCol = "var(--text-normal)";
 		const stateTextMap = (notifyConflicts: boolean, notifyChanges: boolean) => {
 			if (notifyConflicts && notifyChanges) {
-				return "Displaying file changes and conflicts "
+				return "Displaying file changes and conflicts ";
 			} else if (!notifyConflicts && notifyChanges) {
-				return "Displaying file changes "
+				return "Displaying file changes ";
 			} else if (notifyConflicts && !notifyChanges) {
-				return "Displaying change conflicts "
+				return "Displaying change conflicts ";
 			} else {
-				return "No notice displayed "
+				return "No notice displayed ";
 			}
-		}
+		};
 		const noticeDisplay = new Setting(containerEl)
 			.setName("Notice display")
-			.setDesc(`${stateTextMap(this.plugin.settings.notifyConflicts, this.plugin.settings.notifyChanges)} after sync.`)
+			.setDesc(`${stateTextMap(this.plugin.settings.notifyConflicts, this.plugin.settings.notifyChanges)} after sync.`);
 
 		noticeDisplay.addButton(button => {
-			button.setButtonText("Change conflicts")
+			button.setButtonText("Change conflicts");
 			button.onClick(async () => {
 				const notifyConflicts = !this.plugin.settings.notifyConflicts;
-				this.plugin.settings.notifyConflicts = notifyConflicts
+				this.plugin.settings.notifyConflicts = notifyConflicts;
 				await this.plugin.saveSettings();
 				button.buttonEl.setCssStyles({
 					"background": notifyConflicts ? selectedCol : unselectedColor,
 					"color": notifyConflicts ? selectedTxtCol : unselectedTxtCol,
-				})
-				noticeDisplay.setDesc(`${stateTextMap(notifyConflicts, this.plugin.settings.notifyChanges)} after sync.`)
-			})
+				});
+				noticeDisplay.setDesc(`${stateTextMap(notifyConflicts, this.plugin.settings.notifyChanges)} after sync.`);
+			});
 			button.buttonEl.setCssStyles({
 				"background": this.plugin.settings.notifyConflicts ? selectedCol : unselectedColor,
 				"color": this.plugin.settings.notifyConflicts ? selectedTxtCol : unselectedTxtCol,
-			})
-		})
+			});
+		});
 		noticeDisplay.addButton(button => {
-			button.setButtonText("File changes")
+			button.setButtonText("File changes");
 			button.onClick(async () => {
 				const notifyChanges = !this.plugin.settings.notifyChanges;
-				this.plugin.settings.notifyChanges = notifyChanges
+				this.plugin.settings.notifyChanges = notifyChanges;
 				await this.plugin.saveSettings();
 				button.buttonEl.setCssStyles({
 					"background": notifyChanges ? selectedCol : unselectedColor,
 					"color": notifyChanges ? selectedTxtCol : unselectedTxtCol,
-				})
-				noticeDisplay.setDesc(`${stateTextMap(this.plugin.settings.notifyConflicts, notifyChanges)} after sync.`)
-			})
+				});
+				noticeDisplay.setDesc(`${stateTextMap(this.plugin.settings.notifyConflicts, notifyChanges)} after sync.`);
+			});
 			button.buttonEl.setCssStyles({
 				"background": this.plugin.settings.notifyChanges ? selectedCol : unselectedColor,
 				"color": this.plugin.settings.notifyChanges ? selectedTxtCol : unselectedTxtCol,
-			})
-		})
-	}
+			});
+		});
+	};
 
 	refreshFields = async (refreshFrom: RefreshCheckPoint) => {
-		const {containerEl} = this
-		const repo_dropdown = containerEl.querySelector('.repo-dropdown') as HTMLSelectElement
-		const branch_dropdown = containerEl.querySelector('.branch-dropdown') as HTMLSelectElement
-		const link_el = containerEl.querySelector('.link-desc') as HTMLElement
+		const {containerEl} = this;
+		const repo_dropdown = containerEl.querySelector('.repo-dropdown') as HTMLSelectElement;
+		const branch_dropdown = containerEl.querySelector('.branch-dropdown') as HTMLSelectElement;
+		const link_el = containerEl.querySelector('.link-desc') as HTMLElement;
 		if (refreshFrom === "repo(0)") {
-			repo_dropdown.disabled = true
-			branch_dropdown.disabled = true
+			repo_dropdown.disabled = true;
+			branch_dropdown.disabled = true;
 			this.existingRepos = await this.plugin.fit.getRepos();
 			const repoOptions = Array.from(repo_dropdown.options).map(option => option.value);
 			if (!setEqual<string>(this.existingRepos, repoOptions)) {
-				repo_dropdown.empty()
+				repo_dropdown.empty();
 				this.existingRepos.map(repo => {
-					repo_dropdown.add(new Option(repo, repo))
+					repo_dropdown.add(new Option(repo, repo));
 				});
 				// if original repo not in the updated existing repo, -1 will be returned
 				const selectedRepoIndex = this.existingRepos.indexOf(this.plugin.settings.repo);
 				// setting selectedIndex to -1 to indicate no options selected
-				repo_dropdown.selectedIndex = selectedRepoIndex 
+				repo_dropdown.selectedIndex = selectedRepoIndex;
 				if (selectedRepoIndex===-1){
-					this.plugin.settings.repo = ""
+					this.plugin.settings.repo = "";
 				}
 			}
-			repo_dropdown.disabled = false
+			repo_dropdown.disabled = false;
 		}
 		if (refreshFrom === "branch(1)" || refreshFrom === "repo(0)") {
 			if (this.plugin.settings.repo === "") {
-				branch_dropdown.empty()
+				branch_dropdown.empty();
 			} else {
 				const latestBranches = await this.plugin.fit.getBranches();
 				if (!setEqual<string>(this.existingBranches, latestBranches)) {
-					branch_dropdown.empty()
-					this.existingBranches = latestBranches
+					branch_dropdown.empty();
+					this.existingBranches = latestBranches;
 					this.existingBranches.map(branch => {
-						branch_dropdown.add(new Option(branch, branch))
+						branch_dropdown.add(new Option(branch, branch));
 					});
 					// if original branch not in the updated existing branch, -1 will be returned
 					const selectedBranchIndex = this.existingBranches.indexOf(this.plugin.settings.branch);
 					// setting selectedIndex to -1 to indicate no options selected
-					branch_dropdown.selectedIndex = selectedBranchIndex
+					branch_dropdown.selectedIndex = selectedBranchIndex;
 					if (selectedBranchIndex===-1){
-						this.plugin.settings.branch = ""
+						this.plugin.settings.branch = "";
 					}
 				}
 			}
-			branch_dropdown.disabled = false
-		} 
+			branch_dropdown.disabled = false;
+		}
 		if (refreshFrom === "link(2)" || refreshFrom === "branch(1)" || refreshFrom === "repo(0)") {
 			this.repoLink = this.getLatestLink();
-			link_el.innerText = this.repoLink
-		} 
+			link_el.innerText = this.repoLink;
+		}
 		if (refreshFrom === "initialize") {
-			const {repo, branch} = this.plugin.settings
-			repo_dropdown.empty()
-			branch_dropdown.empty()
-			repo_dropdown.add(new Option(repo, repo))
-			branch_dropdown.add(new Option(branch, branch))
-			link_el.innerText = this.getLatestLink()
+			const {repo, branch} = this.plugin.settings;
+			repo_dropdown.empty();
+			branch_dropdown.empty();
+			repo_dropdown.add(new Option(repo, repo));
+			branch_dropdown.add(new Option(branch, branch));
+			link_el.innerText = this.getLatestLink();
 		}
 		if (refreshFrom === "withCache") {
-			repo_dropdown.empty()
-			branch_dropdown.empty()
+			repo_dropdown.empty();
+			branch_dropdown.empty();
 			if (this.existingRepos.length > 0) {
 				this.existingRepos.map(repo => {
-					repo_dropdown.add(new Option(repo, repo))
+					repo_dropdown.add(new Option(repo, repo));
 				});
-				repo_dropdown.selectedIndex = this.existingRepos.indexOf(this.plugin.settings.repo)
+				repo_dropdown.selectedIndex = this.existingRepos.indexOf(this.plugin.settings.repo);
 			}
 			if (this.existingBranches.length > 0) {
 				this.existingBranches.map(branch => {
-					branch_dropdown.add(new Option(branch, branch))
+					branch_dropdown.add(new Option(branch, branch));
 				});
 				if (this.plugin.settings.branch === "") {
-					branch_dropdown.selectedIndex = -1
+					branch_dropdown.selectedIndex = -1;
 				}
-				branch_dropdown.selectedIndex = this.existingBranches.indexOf(this.plugin.settings.branch)
+				branch_dropdown.selectedIndex = this.existingBranches.indexOf(this.plugin.settings.branch);
 			}
 			if (this.plugin.settings.repo !== "") {
 				if (this.existingRepos.length === 0) {
-					repo_dropdown.add(new Option(this.plugin.settings.repo, this.plugin.settings.repo))
+					repo_dropdown.add(new Option(this.plugin.settings.repo, this.plugin.settings.repo));
 				} else {
-					repo_dropdown.selectedIndex = this.existingRepos.indexOf(this.plugin.settings.repo)
+					repo_dropdown.selectedIndex = this.existingRepos.indexOf(this.plugin.settings.repo);
 					if (branch_dropdown.selectedIndex === -1) {
-						warn(`warning: selected branch ${this.plugin.settings.branch} not found, existing branches: ${this.existingBranches}`)
+						warn(`warning: selected branch ${this.plugin.settings.branch} not found, existing branches: ${this.existingBranches}`);
 					}
 				}
 			}
 			if (this.plugin.settings.branch !== "") {
 				if (this.existingBranches.length === 0) {
-					branch_dropdown.add(new Option(this.plugin.settings.branch, this.plugin.settings.branch))
+					branch_dropdown.add(new Option(this.plugin.settings.branch, this.plugin.settings.branch));
 				} else {
-					branch_dropdown.selectedIndex = this.existingBranches.indexOf(this.plugin.settings.branch)
+					branch_dropdown.selectedIndex = this.existingBranches.indexOf(this.plugin.settings.branch);
 					if (branch_dropdown.selectedIndex === -1) {
-						warn(`warning: selected branch ${this.plugin.settings.branch} not found, existing branches: ${this.existingBranches}`)
+						warn(`warning: selected branch ${this.plugin.settings.branch} not found, existing branches: ${this.existingBranches}`);
 					}
 				}
 			}
 		}
-	}
+	};
 
 
 	async display(): Promise<void> {
@@ -417,10 +417,10 @@ export default class FitSettingTab extends PluginSettingTab {
 
 		containerEl.empty();
 
-		this.githubUserInfoBlock()
-		this.repoInfoBlock()
-		this.localConfigBlock()
-		this.noticeConfigBlock()
-		this.refreshFields("withCache")
+		this.githubUserInfoBlock();
+		this.repoInfoBlock();
+		this.localConfigBlock();
+		this.noticeConfigBlock();
+		this.refreshFields("withCache");
 	}
 }

--- a/src/fitSync.test.ts
+++ b/src/fitSync.test.ts
@@ -7,217 +7,217 @@ import { LocalChange, RemoteChange, FileOpRecord } from './fitTypes';
 
 // Simple test doubles focused on behavior
 describe('FitSync', () => {
-  let fitSync: FitSync;
-  let saveLocalStoreCallback: jest.MockedFunction<(localStore: Partial<LocalStores>) => Promise<void>>;
+	let fitSync: FitSync;
+	let saveLocalStoreCallback: jest.MockedFunction<(localStore: Partial<LocalStores>) => Promise<void>>;
 
-  // Helper to create a FitSync with configured behavior
-  function createFitSync(scenario: {
-    localChanges?: LocalChange[];
-    remoteUpdated?: boolean;
-    remoteCommitSha?: string;
-    remoteChanges?: RemoteChange[];
-    remoteTreeSha?: Record<string, string>;
-  }) {
-    const mockFit = {
-      computeLocalSha: jest.fn().mockResolvedValue({ 'file1.txt': 'sha1' }),
-      getLocalChanges: jest.fn().mockResolvedValue(scenario.localChanges || []),
-      remoteUpdated: jest.fn().mockResolvedValue({
-        remoteCommitSha: scenario.remoteCommitSha || 'commit123',
-        updated: scenario.remoteUpdated || false
-      }),
-      getRemoteTreeSha: jest.fn().mockResolvedValue(scenario.remoteTreeSha || {}),
-      getRemoteChanges: jest.fn().mockResolvedValue(scenario.remoteChanges || []),
-      getClashedChanges: jest.fn().mockReturnValue([]),
-      vaultOps: {} as VaultOperations,
-    } as unknown as Fit;
+	// Helper to create a FitSync with configured behavior
+	function createFitSync(scenario: {
+		localChanges?: LocalChange[];
+		remoteUpdated?: boolean;
+		remoteCommitSha?: string;
+		remoteChanges?: RemoteChange[];
+		remoteTreeSha?: Record<string, string>;
+	}) {
+		const mockFit = {
+			computeLocalSha: jest.fn().mockResolvedValue({ 'file1.txt': 'sha1' }),
+			getLocalChanges: jest.fn().mockResolvedValue(scenario.localChanges || []),
+			remoteUpdated: jest.fn().mockResolvedValue({
+				remoteCommitSha: scenario.remoteCommitSha || 'commit123',
+				updated: scenario.remoteUpdated || false
+			}),
+			getRemoteTreeSha: jest.fn().mockResolvedValue(scenario.remoteTreeSha || {}),
+			getRemoteChanges: jest.fn().mockResolvedValue(scenario.remoteChanges || []),
+			getClashedChanges: jest.fn().mockReturnValue([]),
+			vaultOps: {} as VaultOperations,
+		} as unknown as Fit;
 
-    const mockVaultOps = {
-      updateLocalFiles: jest.fn().mockResolvedValue([{ path: 'file.txt', status: 'created' as const }] as FileOpRecord[]),
-    } as unknown as VaultOperations;
+		const mockVaultOps = {
+			updateLocalFiles: jest.fn().mockResolvedValue([{ path: 'file.txt', status: 'created' as const }] as FileOpRecord[]),
+		} as unknown as VaultOperations;
 
-    return new FitSync(mockFit, mockVaultOps, saveLocalStoreCallback);
-  }
+		return new FitSync(mockFit, mockVaultOps, saveLocalStoreCallback);
+	}
 
-  beforeEach(() => {
-    saveLocalStoreCallback = jest.fn().mockResolvedValue(undefined);
-  });
+	beforeEach(() => {
+		saveLocalStoreCallback = jest.fn().mockResolvedValue(undefined);
+	});
 
-  describe('sync', () => {
-    it('should complete successfully when files are already in sync', async () => {
-      // Arrange
-      fitSync = createFitSync({ localChanges: [], remoteUpdated: false });
-      const notice = { setMessage: jest.fn() } as unknown as FitNotice;
+	describe('sync', () => {
+		it('should complete successfully when files are already in sync', async () => {
+			// Arrange
+			fitSync = createFitSync({ localChanges: [], remoteUpdated: false });
+			const notice = { setMessage: jest.fn() } as unknown as FitNotice;
 
-      // Act
-      const result = await fitSync.sync(notice);
+			// Act
+			const result = await fitSync.sync(notice);
 
-      // Assert
-      expect(result).toBeUndefined();
-    });
+			// Assert
+			expect(result).toBeUndefined();
+		});
 
-    it('should update commit SHA when only remote commit changed', async () => {
-      // Arrange
-      const newCommitSha = 'newCommit456';
-      fitSync = createFitSync({
-        localChanges: [],
-        remoteUpdated: true,
-        remoteCommitSha: newCommitSha,
-        remoteChanges: []
-      });
-      const notice = { setMessage: jest.fn() } as unknown as FitNotice;
+		it('should update commit SHA when only remote commit changed', async () => {
+			// Arrange
+			const newCommitSha = 'newCommit456';
+			fitSync = createFitSync({
+				localChanges: [],
+				remoteUpdated: true,
+				remoteCommitSha: newCommitSha,
+				remoteChanges: []
+			});
+			const notice = { setMessage: jest.fn() } as unknown as FitNotice;
 
-      // Act
-      const result = await fitSync.sync(notice);
+			// Act
+			const result = await fitSync.sync(notice);
 
-      // Assert
-      expect(result).toBeUndefined();
-      expect(saveLocalStoreCallback).toHaveBeenCalledWith({
-        lastFetchedCommitSha: newCommitSha
-      });
-    });
+			// Assert
+			expect(result).toBeUndefined();
+			expect(saveLocalStoreCallback).toHaveBeenCalledWith({
+				lastFetchedCommitSha: newCommitSha
+			});
+		});
 
-    it('should handle local changes scenario', async () => {
-      // Arrange
-      const localChanges = [{ path: 'file1.txt', status: 'changed' as const }];
-      fitSync = createFitSync({ localChanges, remoteUpdated: false });
-      const notice = { setMessage: jest.fn() } as unknown as FitNotice;
+		it('should handle local changes scenario', async () => {
+			// Arrange
+			const localChanges = [{ path: 'file1.txt', status: 'changed' as const }];
+			fitSync = createFitSync({ localChanges, remoteUpdated: false });
+			const notice = { setMessage: jest.fn() } as unknown as FitNotice;
 
-      // Mock the push behavior
-      fitSync.fitPush.pushChangedFilesToRemote = jest.fn().mockResolvedValue({
-        pushedChanges: localChanges,
-        lastFetchedRemoteSha: { 'file1.txt': 'newSha1' },
-        lastFetchedCommitSha: 'newCommit789'
-      });
+			// Mock the push behavior
+			fitSync.fitPush.pushChangedFilesToRemote = jest.fn().mockResolvedValue({
+				pushedChanges: localChanges,
+				lastFetchedRemoteSha: { 'file1.txt': 'newSha1' },
+				lastFetchedCommitSha: 'newCommit789'
+			});
 
-      // Act
-      const result = await fitSync.sync(notice);
+			// Act
+			const result = await fitSync.sync(notice);
 
-      // Assert
-      expect(result).toEqual({
-        ops: [{ heading: 'Local file updates:', ops: localChanges }],
-        clash: []
-      });
-    });
+			// Assert
+			expect(result).toEqual({
+				ops: [{ heading: 'Local file updates:', ops: localChanges }],
+				clash: []
+			});
+		});
 
-    it('should handle remote changes scenario', async () => {
-      // Arrange
-      const remoteChanges = [{ path: 'file2.txt', status: 'ADDED' as const }];
-      fitSync = createFitSync({
-        localChanges: [],
-        remoteUpdated: true,
-        remoteCommitSha: 'commit456',
-        remoteChanges,
-        remoteTreeSha: { 'file1.txt': 'sha1', 'file2.txt': 'sha2' }
-      });
-      const notice = { setMessage: jest.fn() } as unknown as FitNotice;
+		it('should handle remote changes scenario', async () => {
+			// Arrange
+			const remoteChanges = [{ path: 'file2.txt', status: 'ADDED' as const }];
+			fitSync = createFitSync({
+				localChanges: [],
+				remoteUpdated: true,
+				remoteCommitSha: 'commit456',
+				remoteChanges,
+				remoteTreeSha: { 'file1.txt': 'sha1', 'file2.txt': 'sha2' }
+			});
+			const notice = { setMessage: jest.fn() } as unknown as FitNotice;
 
-      // Mock the pull behavior
-      const mockFileOps = [{ path: 'file2.txt', status: 'created' as const }];
-      fitSync.fitPull.pullRemoteToLocal = jest.fn().mockResolvedValue(mockFileOps);
+			// Mock the pull behavior
+			const mockFileOps = [{ path: 'file2.txt', status: 'created' as const }];
+			fitSync.fitPull.pullRemoteToLocal = jest.fn().mockResolvedValue(mockFileOps);
 
-      // Act
-      const result = await fitSync.sync(notice);
+			// Act
+			const result = await fitSync.sync(notice);
 
-      // Assert
-      expect(result).toEqual({
-        ops: [{ heading: 'Local file updates:', ops: mockFileOps }],
-        clash: []
-      });
-    });
+			// Assert
+			expect(result).toEqual({
+				ops: [{ heading: 'Local file updates:', ops: mockFileOps }],
+				clash: []
+			});
+		});
 
-    it('should handle compatible local and remote changes', async () => {
-      // Arrange
-      const localChanges = [{ path: 'file1.txt', status: 'changed' as const }];
-      const remoteChanges = [{ path: 'file2.txt', status: 'ADDED' as const }];
-      fitSync = createFitSync({
-        localChanges,
-        remoteUpdated: true,
-        remoteCommitSha: 'commit456',
-        remoteChanges,
-        remoteTreeSha: { 'file1.txt': 'sha1', 'file2.txt': 'sha2' }
-      });
-      const notice = { setMessage: jest.fn() } as unknown as FitNotice;
+		it('should handle compatible local and remote changes', async () => {
+			// Arrange
+			const localChanges = [{ path: 'file1.txt', status: 'changed' as const }];
+			const remoteChanges = [{ path: 'file2.txt', status: 'ADDED' as const }];
+			fitSync = createFitSync({
+				localChanges,
+				remoteUpdated: true,
+				remoteCommitSha: 'commit456',
+				remoteChanges,
+				remoteTreeSha: { 'file1.txt': 'sha1', 'file2.txt': 'sha2' }
+			});
+			const notice = { setMessage: jest.fn() } as unknown as FitNotice;
 
-      // Mock the compatible changes behavior
-      const mockLocalOps = [{ path: 'file2.txt', status: 'created' as const }];
-      const mockRemoteOps = [{ path: 'file1.txt', status: 'changed' as const }];
+			// Mock the compatible changes behavior
+			const mockLocalOps = [{ path: 'file2.txt', status: 'created' as const }];
+			const mockRemoteOps = [{ path: 'file1.txt', status: 'changed' as const }];
 
-      fitSync.syncCompatibleChanges = jest.fn().mockResolvedValue({
-        localOps: mockLocalOps,
-        remoteOps: mockRemoteOps
-      });
+			fitSync.syncCompatibleChanges = jest.fn().mockResolvedValue({
+				localOps: mockLocalOps,
+				remoteOps: mockRemoteOps
+			});
 
-      // Act
-      const result = await fitSync.sync(notice);
+			// Act
+			const result = await fitSync.sync(notice);
 
-      // Assert
-      expect(result).toEqual({
-        ops: [
-          { heading: 'Local file updates:', ops: mockLocalOps },
-          { heading: 'Remote file updates:', ops: mockRemoteOps }
-        ],
-        clash: []
-      });
-    });
+			// Assert
+			expect(result).toEqual({
+				ops: [
+					{ heading: 'Local file updates:', ops: mockLocalOps },
+					{ heading: 'Remote file updates:', ops: mockRemoteOps }
+				],
+				clash: []
+			});
+		});
 
-    it('should handle conflicts and create _fit directory for unresolved files', async () => {
-      // Arrange
-      const localChanges = [{ path: 'shared.txt', status: 'changed' as const }];
-      const remoteChanges = [{ path: 'shared.txt', status: 'MODIFIED' as const }];
-      const clashedFiles = [{ path: 'shared.txt', localStatus: 'changed' as const, remoteStatus: 'MODIFIED' as const }];
+		it('should handle conflicts and create _fit directory for unresolved files', async () => {
+			// Arrange
+			const localChanges = [{ path: 'shared.txt', status: 'changed' as const }];
+			const remoteChanges = [{ path: 'shared.txt', status: 'MODIFIED' as const }];
+			const clashedFiles = [{ path: 'shared.txt', localStatus: 'changed' as const, remoteStatus: 'MODIFIED' as const }];
 
-      fitSync = createFitSync({
-        localChanges,
-        remoteUpdated: true,
-        remoteCommitSha: 'commit456',
-        remoteChanges,
-        remoteTreeSha: { 'shared.txt': 'remotesha' }
-      });
+			fitSync = createFitSync({
+				localChanges,
+				remoteUpdated: true,
+				remoteCommitSha: 'commit456',
+				remoteChanges,
+				remoteTreeSha: { 'shared.txt': 'remotesha' }
+			});
 
-      // Override getClashedChanges to return conflicts
-      fitSync.fit.getClashedChanges = jest.fn().mockReturnValue(clashedFiles);
+			// Override getClashedChanges to return conflicts
+			fitSync.fit.getClashedChanges = jest.fn().mockReturnValue(clashedFiles);
 
-      const notice = { setMessage: jest.fn() } as unknown as FitNotice;
+			const notice = { setMessage: jest.fn() } as unknown as FitNotice;
 
-      // Mock conflict resolution that creates files in _fit directory
-      const conflictFileOps = [{ path: '_fit/shared.txt', status: 'created' as const }];
-      fitSync.syncWithConflicts = jest.fn().mockResolvedValue({
-        unresolvedFiles: clashedFiles,
-        localOps: conflictFileOps,
-        remoteOps: []
-      });
+			// Mock conflict resolution that creates files in _fit directory
+			const conflictFileOps = [{ path: '_fit/shared.txt', status: 'created' as const }];
+			fitSync.syncWithConflicts = jest.fn().mockResolvedValue({
+				unresolvedFiles: clashedFiles,
+				localOps: conflictFileOps,
+				remoteOps: []
+			});
 
-      // Act
-      const result = await fitSync.sync(notice);
+			// Act
+			const result = await fitSync.sync(notice);
 
-      // Assert
-      expect(result).toEqual({
-        ops: [
-          { heading: 'Local file updates:', ops: conflictFileOps },
-          { heading: 'Remote file updates:', ops: [] }
-        ],
-        clash: clashedFiles
-      });
-    });
+			// Assert
+			expect(result).toEqual({
+				ops: [
+					{ heading: 'Local file updates:', ops: conflictFileOps },
+					{ heading: 'Remote file updates:', ops: [] }
+				],
+				clash: clashedFiles
+			});
+		});
 
-    it('should handle notice lifecycle correctly', async () => {
-      // Arrange
-      fitSync = createFitSync({ localChanges: [], remoteUpdated: false });
-      const mockNotice = {
-        setMessage: jest.fn(),
-        remove: jest.fn(),
-        mute: jest.fn(),
-        hide: jest.fn()
-      };
-      const notice = mockNotice as unknown as FitNotice;
+		it('should handle notice lifecycle correctly', async () => {
+			// Arrange
+			fitSync = createFitSync({ localChanges: [], remoteUpdated: false });
+			const mockNotice = {
+				setMessage: jest.fn(),
+				remove: jest.fn(),
+				mute: jest.fn(),
+				hide: jest.fn()
+			};
+			const notice = mockNotice as unknown as FitNotice;
 
-      // Act
-      await fitSync.sync(notice);
+			// Act
+			await fitSync.sync(notice);
 
-      // Assert - verify notice was used for communication but no hiding called directly
-      expect(mockNotice.setMessage).toHaveBeenCalled();
-      expect(mockNotice.hide).not.toHaveBeenCalled(); // FitSync doesn't directly hide notices
-      expect(mockNotice.mute).not.toHaveBeenCalled(); // FitSync doesn't mute notices
-    });
-  });
+			// Assert - verify notice was used for communication but no hiding called directly
+			expect(mockNotice.setMessage).toHaveBeenCalled();
+			expect(mockNotice.hide).not.toHaveBeenCalled(); // FitSync doesn't directly hide notices
+			expect(mockNotice.mute).not.toHaveBeenCalled(); // FitSync doesn't mute notices
+		});
+	});
 });

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -1,357 +1,357 @@
-import { arrayBufferToBase64 } from "obsidian"
-import { Fit } from "./fit"
-import { ClashStatus, ConflictReport, ConflictResolutionResult, FileOpRecord, LocalChange, LocalUpdate, RemoteChange, RemoteUpdate } from "./fitTypes"
-import { RECOGNIZED_BINARY_EXT, extractExtension, removeLineEndingsFromBase64String } from "./utils"
-import { FitPull } from "./fitPull"
-import { FitPush } from "./fitPush"
-import { VaultOperations } from "./vaultOps"
-import { LocalStores } from "main"
-import FitNotice from "./fitNotice"
+import { arrayBufferToBase64 } from "obsidian";
+import { Fit } from "./fit";
+import { ClashStatus, ConflictReport, ConflictResolutionResult, FileOpRecord, LocalChange, LocalUpdate, RemoteChange, RemoteUpdate } from "./fitTypes";
+import { RECOGNIZED_BINARY_EXT, extractExtension, removeLineEndingsFromBase64String } from "./utils";
+import { FitPull } from "./fitPull";
+import { FitPush } from "./fitPush";
+import { VaultOperations } from "./vaultOps";
+import { LocalStores } from "main";
+import FitNotice from "./fitNotice";
 
 export interface IFitSync {
-    fit: Fit
+	fit: Fit
 }
 
 type PreSyncCheckResult =  {
-    status: "inSync"
+	status: "inSync"
 } | {
-    status: Exclude<PreSyncCheckResultType, "inSync">
-    remoteUpdate: RemoteUpdate
-    localChanges: LocalChange[]
-    localTreeSha: Record<string, string>
-}
+	status: Exclude<PreSyncCheckResultType, "inSync">
+	remoteUpdate: RemoteUpdate
+	localChanges: LocalChange[]
+	localTreeSha: Record<string, string>
+};
 
 type PreSyncCheckResultType = (
-    "inSync" | 
-    "onlyLocalChanged" | 
-    "onlyRemoteChanged" | 
+    "inSync" |
+    "onlyLocalChanged" |
+    "onlyRemoteChanged" |
     "onlyRemoteCommitShaChanged" |
-    "localAndRemoteChangesCompatible" | 
+    "localAndRemoteChangesCompatible" |
     "localAndRemoteChangesClashed"
-)
+);
 
 export class FitSync implements IFitSync {
-    fit: Fit
-    fitPull: FitPull
-    fitPush: FitPush
-    vaultOps: VaultOperations
-    saveLocalStoreCallback: (localStore: Partial<LocalStores>) => Promise<void>
-    
+	fit: Fit;
+	fitPull: FitPull;
+	fitPush: FitPush;
+	vaultOps: VaultOperations;
+	saveLocalStoreCallback: (localStore: Partial<LocalStores>) => Promise<void>;
 
-    constructor(fit: Fit, vaultOps: VaultOperations, saveLocalStoreCallback: (localStore: Partial<LocalStores>) => Promise<void>) {
-        this.fit = fit
-        this.fitPull = new FitPull(fit)
-        this.fitPush = new FitPush(fit)
-        this.vaultOps = vaultOps
-        this.saveLocalStoreCallback = saveLocalStoreCallback
-    }
 
-    async performPreSyncChecks(): Promise<PreSyncCheckResult> {
-        const currentLocalSha = await this.fit.computeLocalSha()
-        const localChanges = await this.fit.getLocalChanges(currentLocalSha)
-        const {remoteCommitSha, updated: remoteUpdated} = await this.fit.remoteUpdated();
-        if (localChanges.length === 0 && !remoteUpdated) {
-            return {status: "inSync"}
-        }
-        const remoteTreeSha = await this.fit.getRemoteTreeSha(remoteCommitSha)
-        const remoteChanges = await this.fit.getRemoteChanges(remoteTreeSha)
-        let clashes: ClashStatus[] = [];
-        let status: PreSyncCheckResultType
-        if (localChanges.length > 0 && !remoteUpdated) {
-            status = "onlyLocalChanged"
-        } else if (remoteUpdated && localChanges.length === 0 && remoteChanges.length === 0) {
-            status = "onlyRemoteCommitShaChanged"
-        } else if (localChanges.length === 0 && remoteUpdated) {
-            status = "onlyRemoteChanged"
-        } else {
-            clashes = this.fit.getClashedChanges(localChanges, remoteChanges)
-            if (clashes.length === 0) {
-                status = "localAndRemoteChangesCompatible"
-            } else {
-                status =  "localAndRemoteChangesClashed"
-            }    
-        }
-        return {
-            status, 
-            remoteUpdate: {
-                remoteChanges, 
-                remoteTreeSha, 
-                latestRemoteCommitSha: remoteCommitSha, 
-                clashedFiles: clashes
-            }, 
-            localChanges, 
-            localTreeSha: currentLocalSha
-        }
-    }
-
-    generateConflictReport(path: string, localContent: string, remoteContent: string): ConflictReport {
-        const detectedExtension = extractExtension(path)
-        if (detectedExtension && RECOGNIZED_BINARY_EXT.includes(detectedExtension)) {
-            return {
-                path,
-                resolutionStrategy: "binary",
-                remoteContent
-            }
-        }
-        // assume file encoding is utf8 if extension is not known
-        return {
-            path,
-            resolutionStrategy: "utf-8",
-            localContent,
-            remoteContent,
-        }
-    }
-
-    async handleBinaryConflict(path: string, remoteContent: string): Promise<FileOpRecord> {
-        const conflictResolutionFolder = "_fit"
-        const conflictResolutionPath = `${conflictResolutionFolder}/${path}`
-        await this.fit.vaultOps.ensureFolderExists(conflictResolutionPath)
-        await this.fit.vaultOps.writeToLocal(conflictResolutionPath, remoteContent)
-        return {
-            path: conflictResolutionPath,
-            status: "created"
-        }
-
-    }
-
-    async handleUTF8Conflict(path: string, localContent: string, remoteConent: string): Promise<FileOpRecord> {
-        const conflictResolutionFolder = "_fit"
-        const conflictResolutionPath = `${conflictResolutionFolder}/${path}`
-        this.fit.vaultOps.ensureFolderExists(conflictResolutionPath)
-        this.fit.vaultOps.writeToLocal(conflictResolutionPath, remoteConent)
-        return {
-            path: conflictResolutionPath,
-            status: "created"
-        }
-    }
-
-    async handleLocalDeletionConflict(path: string, remoteContent: string): Promise<FileOpRecord> {
-        const conflictResolutionFolder = "_fit"
-        this.fit.vaultOps.ensureFolderExists(conflictResolutionFolder)
-        const conflictResolutionPath = `${conflictResolutionFolder}/${path}`
-        this.fit.vaultOps.writeToLocal(conflictResolutionPath, remoteContent)
-        return {
-            path: conflictResolutionPath,
-            status: "created"
-        }
-    }
-
-    async resolveFileConflict(clash: ClashStatus, latestRemoteFileSha: string): Promise<ConflictResolutionResult> {
-        if (clash.localStatus === "deleted" && clash.remoteStatus === "REMOVED") {
-            return {path: clash.path, noDiff: true}
-        } else if (clash.localStatus === "deleted") {
-            const remoteContent = await this.fit.getBlob(latestRemoteFileSha)
-            const fileOp = await this.handleLocalDeletionConflict(clash.path, remoteContent)
-            return {path: clash.path, noDiff: false, fileOp: fileOp}
-        }
-
-        const localFile = await this.fit.vaultOps.getTFile(clash.path)
-        const localFileContent = arrayBufferToBase64(await this.fit.vaultOps.vault.readBinary(localFile))
-        
-        if (latestRemoteFileSha) {
-            const remoteContent = await this.fit.getBlob(latestRemoteFileSha)
-            if (removeLineEndingsFromBase64String(remoteContent) !== removeLineEndingsFromBase64String(localFileContent)) {
-                const report = this.generateConflictReport(clash.path, localFileContent, remoteContent)
-                let fileOp: FileOpRecord
-                if (report.resolutionStrategy === "binary") {
-                    fileOp = await this.handleBinaryConflict(clash.path, report.remoteContent)
-                } else {
-                    fileOp = await this.handleUTF8Conflict(clash.path, report.localContent, report.remoteContent)
-                }
-                return {path: clash.path, noDiff: false, fileOp: fileOp}
-            }
-            return { path: clash.path, noDiff: true }
-        } else {
-            // assumes remote file is deleted if sha not found in latestRemoteTreeSha.
-            return { path: clash.path, noDiff: false }
-        }
+	constructor(fit: Fit, vaultOps: VaultOperations, saveLocalStoreCallback: (localStore: Partial<LocalStores>) => Promise<void>) {
+		this.fit = fit;
+		this.fitPull = new FitPull(fit);
+		this.fitPush = new FitPush(fit);
+		this.vaultOps = vaultOps;
+		this.saveLocalStoreCallback = saveLocalStoreCallback;
 	}
 
-    async resolveConflicts(
-        clashedFiles: Array<ClashStatus>, latestRemoteTreeSha: Record<string, string>)
-        : Promise<{noConflict: boolean, unresolvedFiles: ClashStatus[], fileOpsRecord: FileOpRecord[]}> {    
-            const fileResolutions = await Promise.all(
-                clashedFiles.map(clash=>{return this.resolveFileConflict(clash, latestRemoteTreeSha[clash.path])}))
-            const unresolvedFiles = fileResolutions.map((res, i)=> {
-                if (!res.noDiff) {
-                    return clashedFiles[i]
-                }
-                return null
-            }).filter(Boolean) as Array<ClashStatus>
-            return {
-                noConflict: fileResolutions.every(res=>res.noDiff), 
-                unresolvedFiles,
-                fileOpsRecord: fileResolutions.map(r => r.fileOp).filter(Boolean) as FileOpRecord[]
-            }
-    }
-
-    async syncCompatibleChanges(
-        localUpdate: LocalUpdate, 
-        remoteUpdate: RemoteUpdate, 
-        syncNotice: FitNotice): Promise<{localOps: LocalChange[], remoteOps: FileOpRecord[]}> {
-			const {addToLocal, deleteFromLocal} = await this.fitPull.prepareChangesToExecute(
-				remoteUpdate.remoteChanges)
-			syncNotice.setMessage("Uploading local changes")
-			const remoteTree = await this.fit.getTree(localUpdate.parentCommitSha)
-			const createCommitResult = await this.fitPush.createCommitFromLocalUpdate(localUpdate, remoteTree)
-			let latestRemoteTreeSha: Record<string, string>;
-			let latestCommitSha: string;
-			let pushedChanges: Array<LocalChange>;
-			if (createCommitResult) {
-				const {createdCommitSha} = createCommitResult
-				const latestRefSha = await this.fit.updateRef(createdCommitSha)
-				latestRemoteTreeSha = await this.fit.getRemoteTreeSha(latestRefSha)
-				latestCommitSha = createdCommitSha
-				pushedChanges = createCommitResult.pushedChanges
+	async performPreSyncChecks(): Promise<PreSyncCheckResult> {
+		const currentLocalSha = await this.fit.computeLocalSha();
+		const localChanges = await this.fit.getLocalChanges(currentLocalSha);
+		const {remoteCommitSha, updated: remoteUpdated} = await this.fit.remoteUpdated();
+		if (localChanges.length === 0 && !remoteUpdated) {
+			return {status: "inSync"};
+		}
+		const remoteTreeSha = await this.fit.getRemoteTreeSha(remoteCommitSha);
+		const remoteChanges = await this.fit.getRemoteChanges(remoteTreeSha);
+		let clashes: ClashStatus[] = [];
+		let status: PreSyncCheckResultType;
+		if (localChanges.length > 0 && !remoteUpdated) {
+			status = "onlyLocalChanged";
+		} else if (remoteUpdated && localChanges.length === 0 && remoteChanges.length === 0) {
+			status = "onlyRemoteCommitShaChanged";
+		} else if (localChanges.length === 0 && remoteUpdated) {
+			status = "onlyRemoteChanged";
+		} else {
+			clashes = this.fit.getClashedChanges(localChanges, remoteChanges);
+			if (clashes.length === 0) {
+				status = "localAndRemoteChangesCompatible";
 			} else {
-				latestRemoteTreeSha = remoteUpdate.remoteTreeSha
-				latestCommitSha = remoteUpdate.latestRemoteCommitSha
-				pushedChanges = []
+				status =  "localAndRemoteChangesClashed";
 			}
-			
-			syncNotice.setMessage("Writing remote changes to local")
-			const localFileOpsRecord = await this.vaultOps.updateLocalFiles(addToLocal, deleteFromLocal)
-			await this.saveLocalStoreCallback({
-				lastFetchedRemoteSha: latestRemoteTreeSha, 
-				lastFetchedCommitSha: latestCommitSha,
-				localSha: await this.fit.computeLocalSha()
-			})
-			syncNotice.setMessage("Sync successful")
-            return {localOps: localFileOpsRecord, remoteOps: pushedChanges}
-    }
+		}
+		return {
+			status,
+			remoteUpdate: {
+				remoteChanges,
+				remoteTreeSha,
+				latestRemoteCommitSha: remoteCommitSha,
+				clashedFiles: clashes
+			},
+			localChanges,
+			localTreeSha: currentLocalSha
+		};
+	}
+
+	generateConflictReport(path: string, localContent: string, remoteContent: string): ConflictReport {
+		const detectedExtension = extractExtension(path);
+		if (detectedExtension && RECOGNIZED_BINARY_EXT.includes(detectedExtension)) {
+			return {
+				path,
+				resolutionStrategy: "binary",
+				remoteContent
+			};
+		}
+		// assume file encoding is utf8 if extension is not known
+		return {
+			path,
+			resolutionStrategy: "utf-8",
+			localContent,
+			remoteContent,
+		};
+	}
+
+	async handleBinaryConflict(path: string, remoteContent: string): Promise<FileOpRecord> {
+		const conflictResolutionFolder = "_fit";
+		const conflictResolutionPath = `${conflictResolutionFolder}/${path}`;
+		await this.fit.vaultOps.ensureFolderExists(conflictResolutionPath);
+		await this.fit.vaultOps.writeToLocal(conflictResolutionPath, remoteContent);
+		return {
+			path: conflictResolutionPath,
+			status: "created"
+		};
+
+	}
+
+	async handleUTF8Conflict(path: string, localContent: string, remoteConent: string): Promise<FileOpRecord> {
+		const conflictResolutionFolder = "_fit";
+		const conflictResolutionPath = `${conflictResolutionFolder}/${path}`;
+		this.fit.vaultOps.ensureFolderExists(conflictResolutionPath);
+		this.fit.vaultOps.writeToLocal(conflictResolutionPath, remoteConent);
+		return {
+			path: conflictResolutionPath,
+			status: "created"
+		};
+	}
+
+	async handleLocalDeletionConflict(path: string, remoteContent: string): Promise<FileOpRecord> {
+		const conflictResolutionFolder = "_fit";
+		this.fit.vaultOps.ensureFolderExists(conflictResolutionFolder);
+		const conflictResolutionPath = `${conflictResolutionFolder}/${path}`;
+		this.fit.vaultOps.writeToLocal(conflictResolutionPath, remoteContent);
+		return {
+			path: conflictResolutionPath,
+			status: "created"
+		};
+	}
+
+	async resolveFileConflict(clash: ClashStatus, latestRemoteFileSha: string): Promise<ConflictResolutionResult> {
+		if (clash.localStatus === "deleted" && clash.remoteStatus === "REMOVED") {
+			return {path: clash.path, noDiff: true};
+		} else if (clash.localStatus === "deleted") {
+			const remoteContent = await this.fit.getBlob(latestRemoteFileSha);
+			const fileOp = await this.handleLocalDeletionConflict(clash.path, remoteContent);
+			return {path: clash.path, noDiff: false, fileOp: fileOp};
+		}
+
+		const localFile = await this.fit.vaultOps.getTFile(clash.path);
+		const localFileContent = arrayBufferToBase64(await this.fit.vaultOps.vault.readBinary(localFile));
+
+		if (latestRemoteFileSha) {
+			const remoteContent = await this.fit.getBlob(latestRemoteFileSha);
+			if (removeLineEndingsFromBase64String(remoteContent) !== removeLineEndingsFromBase64String(localFileContent)) {
+				const report = this.generateConflictReport(clash.path, localFileContent, remoteContent);
+				let fileOp: FileOpRecord;
+				if (report.resolutionStrategy === "binary") {
+					fileOp = await this.handleBinaryConflict(clash.path, report.remoteContent);
+				} else {
+					fileOp = await this.handleUTF8Conflict(clash.path, report.localContent, report.remoteContent);
+				}
+				return {path: clash.path, noDiff: false, fileOp: fileOp};
+			}
+			return { path: clash.path, noDiff: true };
+		} else {
+			// assumes remote file is deleted if sha not found in latestRemoteTreeSha.
+			return { path: clash.path, noDiff: false };
+		}
+	}
+
+	async resolveConflicts(
+		clashedFiles: Array<ClashStatus>, latestRemoteTreeSha: Record<string, string>)
+		: Promise<{noConflict: boolean, unresolvedFiles: ClashStatus[], fileOpsRecord: FileOpRecord[]}> {
+		const fileResolutions = await Promise.all(
+			clashedFiles.map(clash=>{return this.resolveFileConflict(clash, latestRemoteTreeSha[clash.path]);}));
+		const unresolvedFiles = fileResolutions.map((res, i)=> {
+			if (!res.noDiff) {
+				return clashedFiles[i];
+			}
+			return null;
+		}).filter(Boolean) as Array<ClashStatus>;
+		return {
+			noConflict: fileResolutions.every(res=>res.noDiff),
+			unresolvedFiles,
+			fileOpsRecord: fileResolutions.map(r => r.fileOp).filter(Boolean) as FileOpRecord[]
+		};
+	}
+
+	async syncCompatibleChanges(
+		localUpdate: LocalUpdate,
+		remoteUpdate: RemoteUpdate,
+		syncNotice: FitNotice): Promise<{localOps: LocalChange[], remoteOps: FileOpRecord[]}> {
+		const {addToLocal, deleteFromLocal} = await this.fitPull.prepareChangesToExecute(
+			remoteUpdate.remoteChanges);
+		syncNotice.setMessage("Uploading local changes");
+		const remoteTree = await this.fit.getTree(localUpdate.parentCommitSha);
+		const createCommitResult = await this.fitPush.createCommitFromLocalUpdate(localUpdate, remoteTree);
+		let latestRemoteTreeSha: Record<string, string>;
+		let latestCommitSha: string;
+		let pushedChanges: Array<LocalChange>;
+		if (createCommitResult) {
+			const {createdCommitSha} = createCommitResult;
+			const latestRefSha = await this.fit.updateRef(createdCommitSha);
+			latestRemoteTreeSha = await this.fit.getRemoteTreeSha(latestRefSha);
+			latestCommitSha = createdCommitSha;
+			pushedChanges = createCommitResult.pushedChanges;
+		} else {
+			latestRemoteTreeSha = remoteUpdate.remoteTreeSha;
+			latestCommitSha = remoteUpdate.latestRemoteCommitSha;
+			pushedChanges = [];
+		}
+
+		syncNotice.setMessage("Writing remote changes to local");
+		const localFileOpsRecord = await this.vaultOps.updateLocalFiles(addToLocal, deleteFromLocal);
+		await this.saveLocalStoreCallback({
+			lastFetchedRemoteSha: latestRemoteTreeSha,
+			lastFetchedCommitSha: latestCommitSha,
+			localSha: await this.fit.computeLocalSha()
+		});
+		syncNotice.setMessage("Sync successful");
+		return {localOps: localFileOpsRecord, remoteOps: pushedChanges};
+	}
 
 
-    async syncWithConflicts(
-        localChanges: LocalChange[],
-        remoteUpdate: RemoteUpdate, 
-        syncNotice: FitNotice) : Promise<{unresolvedFiles: ClashStatus[], localOps: LocalChange[], remoteOps: LocalChange[]} | null> {
-        const {latestRemoteCommitSha, clashedFiles, remoteTreeSha: latestRemoteTreeSha} = remoteUpdate
-			const {noConflict, unresolvedFiles, fileOpsRecord} = await this.resolveConflicts(clashedFiles, latestRemoteTreeSha)
-            let localChangesToPush: Array<LocalChange>;
-            let remoteChangesToWrite: Array<RemoteChange>
-			if (noConflict) {
-				// no conflict detected among clashed files, just pull changes only made on remote and push changes only made on local
-                remoteChangesToWrite = remoteUpdate.remoteChanges.filter(c => !localChanges.some(l => l.path === c.path))
-                localChangesToPush = localChanges.filter(c => !remoteUpdate.remoteChanges.some(r => r.path === c.path))
+	async syncWithConflicts(
+		localChanges: LocalChange[],
+		remoteUpdate: RemoteUpdate,
+		syncNotice: FitNotice) : Promise<{unresolvedFiles: ClashStatus[], localOps: LocalChange[], remoteOps: LocalChange[]} | null> {
+		const {latestRemoteCommitSha, clashedFiles, remoteTreeSha: latestRemoteTreeSha} = remoteUpdate;
+		const {noConflict, unresolvedFiles, fileOpsRecord} = await this.resolveConflicts(clashedFiles, latestRemoteTreeSha);
+		let localChangesToPush: Array<LocalChange>;
+		let remoteChangesToWrite: Array<RemoteChange>;
+		if (noConflict) {
+			// no conflict detected among clashed files, just pull changes only made on remote and push changes only made on local
+			remoteChangesToWrite = remoteUpdate.remoteChanges.filter(c => !localChanges.some(l => l.path === c.path));
+			localChangesToPush = localChanges.filter(c => !remoteUpdate.remoteChanges.some(r => r.path === c.path));
 
-			} else {
-				syncNotice.setMessage(`Change conflicts detected`)
-                // do not modify unresolved files locally
-                remoteChangesToWrite = remoteUpdate.remoteChanges.filter(c => !unresolvedFiles.some(l => l.path === c.path))
-                // push change even if they are in unresolved files, so remote has a record of them, 
-                // so user can resolve later by modifying local and push again
-                localChangesToPush = localChanges
-            }
-            const {addToLocal, deleteFromLocal} = await this.fitPull.prepareChangesToExecute(remoteChangesToWrite)
-            const syncLocalUpdate = {
-                localChanges: localChangesToPush,
-                parentCommitSha: latestRemoteCommitSha
-            }
-            const pushResult = await this.fitPush.pushChangedFilesToRemote(syncLocalUpdate)
-            let pushedChanges: LocalChange[];
-            let lastFetchedCommitSha: string;
-            let lastFetchedRemoteSha: Record<string, string>;
-            if (pushResult) {
-                pushedChanges = pushResult.pushedChanges
-                lastFetchedCommitSha = pushResult.lastFetchedCommitSha
-                lastFetchedRemoteSha = pushResult.lastFetchedRemoteSha
-            } else {
-                // did not push any changes
-                pushedChanges = []
-                lastFetchedCommitSha = remoteUpdate.latestRemoteCommitSha
-                lastFetchedRemoteSha = remoteUpdate.remoteTreeSha
-            }
-            const localFileOpsRecord = await this.vaultOps.updateLocalFiles(addToLocal, deleteFromLocal)
-            await this.saveLocalStoreCallback({
-                lastFetchedRemoteSha, 
-                lastFetchedCommitSha,
-                localSha: await this.fit.computeLocalSha()
-            })
-            const ops = localFileOpsRecord.concat(fileOpsRecord)
-            if (unresolvedFiles.length === 0) {
-                syncNotice.setMessage(`Sync successful`)
-            } else if (unresolvedFiles.some(f => f.remoteStatus !== "REMOVED")) {
-                // let user knows remote file changes have been written to _fit if non-deletion change on remote clashed with local changes
-                syncNotice.setMessage(`Synced with remote, unresolved conflicts written to _fit`)
-            } else {
-                syncNotice.setMessage(`Synced with remote, ignored remote deletion of locally changed files`)
-            }
-            return {unresolvedFiles, localOps: ops, remoteOps: pushedChanges}
-    }
+		} else {
+			syncNotice.setMessage(`Change conflicts detected`);
+			// do not modify unresolved files locally
+			remoteChangesToWrite = remoteUpdate.remoteChanges.filter(c => !unresolvedFiles.some(l => l.path === c.path));
+			// push change even if they are in unresolved files, so remote has a record of them,
+			// so user can resolve later by modifying local and push again
+			localChangesToPush = localChanges;
+		}
+		const {addToLocal, deleteFromLocal} = await this.fitPull.prepareChangesToExecute(remoteChangesToWrite);
+		const syncLocalUpdate = {
+			localChanges: localChangesToPush,
+			parentCommitSha: latestRemoteCommitSha
+		};
+		const pushResult = await this.fitPush.pushChangedFilesToRemote(syncLocalUpdate);
+		let pushedChanges: LocalChange[];
+		let lastFetchedCommitSha: string;
+		let lastFetchedRemoteSha: Record<string, string>;
+		if (pushResult) {
+			pushedChanges = pushResult.pushedChanges;
+			lastFetchedCommitSha = pushResult.lastFetchedCommitSha;
+			lastFetchedRemoteSha = pushResult.lastFetchedRemoteSha;
+		} else {
+			// did not push any changes
+			pushedChanges = [];
+			lastFetchedCommitSha = remoteUpdate.latestRemoteCommitSha;
+			lastFetchedRemoteSha = remoteUpdate.remoteTreeSha;
+		}
+		const localFileOpsRecord = await this.vaultOps.updateLocalFiles(addToLocal, deleteFromLocal);
+		await this.saveLocalStoreCallback({
+			lastFetchedRemoteSha,
+			lastFetchedCommitSha,
+			localSha: await this.fit.computeLocalSha()
+		});
+		const ops = localFileOpsRecord.concat(fileOpsRecord);
+		if (unresolvedFiles.length === 0) {
+			syncNotice.setMessage(`Sync successful`);
+		} else if (unresolvedFiles.some(f => f.remoteStatus !== "REMOVED")) {
+			// let user knows remote file changes have been written to _fit if non-deletion change on remote clashed with local changes
+			syncNotice.setMessage(`Synced with remote, unresolved conflicts written to _fit`);
+		} else {
+			syncNotice.setMessage(`Synced with remote, ignored remote deletion of locally changed files`);
+		}
+		return {unresolvedFiles, localOps: ops, remoteOps: pushedChanges};
+	}
 
-    async sync(syncNotice: FitNotice): Promise<{ops: Array<{heading: string, ops: FileOpRecord[]}>, clash: ClashStatus[]} | void> {
-        syncNotice.setMessage("Performing pre sync checks.")
+	async sync(syncNotice: FitNotice): Promise<{ops: Array<{heading: string, ops: FileOpRecord[]}>, clash: ClashStatus[]} | void> {
+		syncNotice.setMessage("Performing pre sync checks.");
 		const preSyncCheckResult = await this.performPreSyncChecks();
 
-        // convert to switch statement later on for better maintainability
+		// convert to switch statement later on for better maintainability
 		if (preSyncCheckResult.status === "inSync") {
-			syncNotice.setMessage("Sync successful")
-			return
+			syncNotice.setMessage("Sync successful");
+			return;
 		}
 
 		if (preSyncCheckResult.status === "onlyRemoteCommitShaChanged") {
-			const { latestRemoteCommitSha } = preSyncCheckResult.remoteUpdate
-			await this.saveLocalStoreCallback({lastFetchedCommitSha: latestRemoteCommitSha})
-			syncNotice.setMessage("Sync successful")
-			return
+			const { latestRemoteCommitSha } = preSyncCheckResult.remoteUpdate;
+			await this.saveLocalStoreCallback({lastFetchedCommitSha: latestRemoteCommitSha});
+			syncNotice.setMessage("Sync successful");
+			return;
 		}
 
-		const remoteUpdate = preSyncCheckResult.remoteUpdate
+		const remoteUpdate = preSyncCheckResult.remoteUpdate;
 		if (preSyncCheckResult.status === "onlyRemoteChanged") {
-			const fileOpsRecord = await this.fitPull.pullRemoteToLocal(remoteUpdate, this.saveLocalStoreCallback)
-            syncNotice.setMessage("Sync successful")
-            return {ops: [{heading: "Local file updates:", ops: fileOpsRecord}], clash: []}
+			const fileOpsRecord = await this.fitPull.pullRemoteToLocal(remoteUpdate, this.saveLocalStoreCallback);
+			syncNotice.setMessage("Sync successful");
+			return {ops: [{heading: "Local file updates:", ops: fileOpsRecord}], clash: []};
 		}
 
-		const {localChanges, localTreeSha} = preSyncCheckResult
+		const {localChanges, localTreeSha} = preSyncCheckResult;
 		const localUpdate = {
 			localChanges,
 			parentCommitSha: remoteUpdate.latestRemoteCommitSha
-		}
+		};
 		if (preSyncCheckResult.status === "onlyLocalChanged") {
-			syncNotice.setMessage("Uploading local changes")
-			const pushResult = await this.fitPush.pushChangedFilesToRemote(localUpdate)
-            syncNotice.setMessage("Sync successful")
-            if (pushResult) {
-                await this.saveLocalStoreCallback({
-                    localSha: localTreeSha,
-                    lastFetchedRemoteSha: pushResult.lastFetchedRemoteSha,
-                    lastFetchedCommitSha: pushResult.lastFetchedCommitSha
-                })
-                return {ops: [{heading: "Local file updates:", ops: pushResult.pushedChanges}], clash: []}
-            }
-            return
+			syncNotice.setMessage("Uploading local changes");
+			const pushResult = await this.fitPush.pushChangedFilesToRemote(localUpdate);
+			syncNotice.setMessage("Sync successful");
+			if (pushResult) {
+				await this.saveLocalStoreCallback({
+					localSha: localTreeSha,
+					lastFetchedRemoteSha: pushResult.lastFetchedRemoteSha,
+					lastFetchedCommitSha: pushResult.lastFetchedCommitSha
+				});
+				return {ops: [{heading: "Local file updates:", ops: pushResult.pushedChanges}], clash: []};
+			}
+			return;
 		}
-		
-		// do both pull and push (orders of execution different from pullRemoteToLocal and 
-		// pushChangedFilesToRemote to make this more transaction like, i.e. maintain original 
+
+		// do both pull and push (orders of execution different from pullRemoteToLocal and
+		// pushChangedFilesToRemote to make this more transaction like, i.e. maintain original
 		// state if the transaction failed) If you have ideas on how to make this more transaction-like,
 		//  please open an issue on the fit repo
 		if (preSyncCheckResult.status === "localAndRemoteChangesCompatible") {
 			const {localOps, remoteOps} = await this.syncCompatibleChanges(
-				localUpdate, remoteUpdate, syncNotice)
-                return ({
-                    ops: [
-                        {heading: "Local file updates:", ops: localOps},
-                        {heading: "Remote file updates:", ops: remoteOps},
-                    ], 
-                    clash: []
-                })
+				localUpdate, remoteUpdate, syncNotice);
+			return ({
+				ops: [
+					{heading: "Local file updates:", ops: localOps},
+					{heading: "Remote file updates:", ops: remoteOps},
+				],
+				clash: []
+			});
 		}
 
 		if (preSyncCheckResult.status === "localAndRemoteChangesClashed") {
 			const conflictResolutionResult = await this.syncWithConflicts(
-				localUpdate.localChanges, remoteUpdate, syncNotice)
+				localUpdate.localChanges, remoteUpdate, syncNotice);
 			if (conflictResolutionResult) {
-				const {unresolvedFiles, localOps, remoteOps} = conflictResolutionResult
-                    return ({
-                        ops:[
-                            {heading: "Local file updates:", ops: localOps},
-                            {heading: "Remote file updates:", ops: remoteOps},
-                        ],
-                        clash: unresolvedFiles
-                    })
+				const {unresolvedFiles, localOps, remoteOps} = conflictResolutionResult;
+				return ({
+					ops:[
+						{heading: "Local file updates:", ops: localOps},
+						{heading: "Remote file updates:", ops: remoteOps},
+					],
+					clash: unresolvedFiles
+				});
 			}
 		}
-    }
+	}
 }

--- a/src/fitTypes.ts
+++ b/src/fitTypes.ts
@@ -1,55 +1,55 @@
-export type LocalFileStatus = "deleted" | "created" | "changed"
-export type RemoteChangeType = "ADDED" | "MODIFIED" | "REMOVED"
+export type LocalFileStatus = "deleted" | "created" | "changed";
+export type RemoteChangeType = "ADDED" | "MODIFIED" | "REMOVED";
 
 export type LocalChange = {
-    path: string,
-    status: LocalFileStatus,
-    extension? : string
-}
+	path: string,
+	status: LocalFileStatus,
+	extension? : string
+};
 
 export type LocalUpdate = {
-    localChanges: LocalChange[],
-    // localTreeSha: Record<string, string>,
-    parentCommitSha: string
-}
+	localChanges: LocalChange[],
+	// localTreeSha: Record<string, string>,
+	parentCommitSha: string
+};
 
 export type RemoteChange = {
-    path: string,
-    status: RemoteChangeType,
-    currentSha?: string
-}
+	path: string,
+	status: RemoteChangeType,
+	currentSha?: string
+};
 
 export type RemoteUpdate = {
-    remoteChanges: RemoteChange[],
-    remoteTreeSha: Record<string, string>, 
-    latestRemoteCommitSha: string,
-    clashedFiles: Array<ClashStatus>
-}
+	remoteChanges: RemoteChange[],
+	remoteTreeSha: Record<string, string>,
+	latestRemoteCommitSha: string,
+	clashedFiles: Array<ClashStatus>
+};
 
 export type ClashStatus = {
-    path: string
-    localStatus: LocalFileStatus
-    remoteStatus: RemoteChangeType
-}
+	path: string
+	localStatus: LocalFileStatus
+	remoteStatus: RemoteChangeType
+};
 
 export type ConflictReport = {
-    path: string
-    resolutionStrategy: "utf-8"
-    localContent: string
-    remoteContent: string
-} | { 
-    resolutionStrategy: "binary", 
-    path: string, 
-    remoteContent: string 
-}
+	path: string
+	resolutionStrategy: "utf-8"
+	localContent: string
+	remoteContent: string
+} | {
+	resolutionStrategy: "binary",
+	path: string,
+	remoteContent: string
+};
 
 export type ConflictResolutionResult = {
-    path: string
-    noDiff: boolean
-    fileOp?: FileOpRecord
-}
+	path: string
+	noDiff: boolean
+	fileOp?: FileOpRecord
+};
 
 export type FileOpRecord = {
-    path: string
-    status: LocalFileStatus
-}
+	path: string
+	status: LocalFileStatus
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,157 +1,157 @@
 import { Notice } from "obsidian";
 import { ClashStatus, FileOpRecord, LocalFileStatus, RemoteChangeType } from "./fitTypes";
 
-type Status = RemoteChangeType | LocalFileStatus
+type Status = RemoteChangeType | LocalFileStatus;
 
-type FileLocation = "remote" | "local"
+type FileLocation = "remote" | "local";
 
 type ComparisonResult<Env extends FileLocation> = {
-    path: string, 
-    status: Env extends "local" ? LocalFileStatus: RemoteChangeType
-    currentSha?: string
-    extension?: string
-}
+	path: string,
+	status: Env extends "local" ? LocalFileStatus: RemoteChangeType
+	currentSha?: string
+	extension?: string
+};
 
 function getValueOrNull(obj: Record<string, string>, key: string): string | null {
-    return obj.hasOwnProperty(key) ? obj[key] : null;
+	return obj.hasOwnProperty(key) ? obj[key] : null;
 }
 
 
 // compare currentSha with storedSha and check for differences, files only in currentSha
 //  are considerd added, while files only in storedSha are considered removed
 export function compareSha<Env extends "remote" | "local">(
-    currentShaMap: Record<string, string>, 
-    storedShaMap: Record<string, string>,
-    env: Env): ComparisonResult<Env>[] {
-        const determineStatus = (currentSha: string | null, storedSha: string | null): Status | null  => 
-        {
-            if (currentSha && storedSha && currentSha !== storedSha) {
-                return env === "local" ? "changed" : "MODIFIED";
-            } else if (currentSha && !storedSha) {
-                return env === "local" ? "created" : "ADDED";
-            } else if (!currentSha && storedSha) {
-                return env === "local" ? "deleted" : "REMOVED";
-            }
-            return null
-        }
+	currentShaMap: Record<string, string>,
+	storedShaMap: Record<string, string>,
+	env: Env): ComparisonResult<Env>[] {
+	const determineStatus = (currentSha: string | null, storedSha: string | null): Status | null  =>
+	{
+		if (currentSha && storedSha && currentSha !== storedSha) {
+			return env === "local" ? "changed" : "MODIFIED";
+		} else if (currentSha && !storedSha) {
+			return env === "local" ? "created" : "ADDED";
+		} else if (!currentSha && storedSha) {
+			return env === "local" ? "deleted" : "REMOVED";
+		}
+		return null;
+	};
 
-        return Object.keys({ ...currentShaMap, ...storedShaMap }).flatMap((path): ComparisonResult<Env>[] => {
-            const [currentSha, storedSha] = [getValueOrNull(currentShaMap, path), getValueOrNull(storedShaMap, path)];
-            const status = determineStatus(currentSha, storedSha);
-            if (status) {
-                return [{
-                    path,
-                    status: status as Env extends "local" ? LocalFileStatus : RemoteChangeType,
-                    currentSha: currentSha ?? undefined,
-                    extension: extractExtension(path)
-                }];
-            }
-            return [];
-        });
+	return Object.keys({ ...currentShaMap, ...storedShaMap }).flatMap((path): ComparisonResult<Env>[] => {
+		const [currentSha, storedSha] = [getValueOrNull(currentShaMap, path), getValueOrNull(storedShaMap, path)];
+		const status = determineStatus(currentSha, storedSha);
+		if (status) {
+			return [{
+				path,
+				status: status as Env extends "local" ? LocalFileStatus : RemoteChangeType,
+				currentSha: currentSha ?? undefined,
+				extension: extractExtension(path)
+			}];
+		}
+		return [];
+	});
 }
 
-export const RECOGNIZED_BINARY_EXT = ["png", "jpg", "jpeg", "pdf"]
+export const RECOGNIZED_BINARY_EXT = ["png", "jpg", "jpeg", "pdf"];
 
 export function extractExtension(path: string): string | undefined {
-    return path.match(/[^.]+$/)?.[0];
+	return path.match(/[^.]+$/)?.[0];
 }
 
 // Using file extension to determine encoding of files (works in most cases)
 export function getFileEncoding(path: string): string {
-    const extension = path.match(/[^.]+$/)?.[0];
-    const isBinary = extension && RECOGNIZED_BINARY_EXT.includes(extension);
-    if (isBinary) {
-        return "base64"
-    } 
-    return "utf-8"
+	const extension = path.match(/[^.]+$/)?.[0];
+	const isBinary = extension && RECOGNIZED_BINARY_EXT.includes(extension);
+	if (isBinary) {
+		return "base64";
+	}
+	return "utf-8";
 }
 
 export function setEqual<T>(arr1: Array<T>, arr2: Array<T>) {
-    const set1 = new Set(arr1);
-    const set2 = new Set(arr2);
-    const isEqual = set1.size === set2.size && [...set1].every(value => set2.has(value));
-    return isEqual
+	const set1 = new Set(arr1);
+	const set2 = new Set(arr2);
+	const isEqual = set1.size === set2.size && [...set1].every(value => set2.has(value));
+	return isEqual;
 }
 
 export function removeLineEndingsFromBase64String(content: string): string {
-    return content.replace(/\r?\n|\r|\n/g, '');
+	return content.replace(/\r?\n|\r|\n/g, '');
 }
 
 export function showFileOpsRecord(records: Array<{heading: string, ops: FileOpRecord[]}>): void {
-    console.log(records)
-    if (records.length === 0 || records.every(r=>r.ops.length===0)) {return}
-    const fileOpsNotice = new Notice("", 0)
-    records.map(recordSet => {
-        if (recordSet.ops.length === 0) {return}
-        const heading = fileOpsNotice.noticeEl.createEl("span", {
-            cls: "file-changes-heading"
-        })
-        heading.setText(`${recordSet.heading}\n`)
-        const fileChanges = {
-            created: [] as Array<string>, 
-            changed: [] as Array<string>, 
-            deleted: [] as Array<string>
-        }
-        for (const op of recordSet.ops) {
-            fileChanges[op.status].push(op.path)
-        }
-        for (const [changeType, paths] of Object.entries(fileChanges)) {
-            if (paths.length === 0) {continue}
-            const heading = fileOpsNotice.noticeEl.createEl("span")
-            heading.setText(`${changeType.charAt(0).toUpperCase() + changeType.slice(1)}\n`)
-            heading.addClass(`file-changes-subheading`)
-            for (const path of paths) {
-                const listItem = fileOpsNotice.noticeEl.createEl("li", {
-                    cls: "file-update-row"
-                });
-                listItem.setText(`${path}`);
-                listItem.addClass(`file-${changeType}`);
-            }
-        }
-    })
+	console.log(records);
+	if (records.length === 0 || records.every(r=>r.ops.length===0)) {return;}
+	const fileOpsNotice = new Notice("", 0);
+	records.map(recordSet => {
+		if (recordSet.ops.length === 0) {return;}
+		const heading = fileOpsNotice.noticeEl.createEl("span", {
+			cls: "file-changes-heading"
+		});
+		heading.setText(`${recordSet.heading}\n`);
+		const fileChanges = {
+			created: [] as Array<string>,
+			changed: [] as Array<string>,
+			deleted: [] as Array<string>
+		};
+		for (const op of recordSet.ops) {
+			fileChanges[op.status].push(op.path);
+		}
+		for (const [changeType, paths] of Object.entries(fileChanges)) {
+			if (paths.length === 0) {continue;}
+			const heading = fileOpsNotice.noticeEl.createEl("span");
+			heading.setText(`${changeType.charAt(0).toUpperCase() + changeType.slice(1)}\n`);
+			heading.addClass(`file-changes-subheading`);
+			for (const path of paths) {
+				const listItem = fileOpsNotice.noticeEl.createEl("li", {
+					cls: "file-update-row"
+				});
+				listItem.setText(`${path}`);
+				listItem.addClass(`file-${changeType}`);
+			}
+		}
+	});
 }
 
 export function showUnappliedConflicts(clashedFiles: Array<ClashStatus>): void {
-    if (clashedFiles.length === 0) {return}
-    const localStatusMap = {
-        created: "create",
-        changed: "change",
-        deleted: "delete"
-    }
-    const remoteStatusMap = {
-        ADDED:  "create",
-        MODIFIED: "change",
-        REMOVED: "delete"
-    }
-    const conflictNotice = new Notice("", 0)
-    const heading = conflictNotice.noticeEl.createEl("span")
-    heading.setText(`Change conflicts:\n`)
-    heading.addClass(`file-changes-subheading`)
-    const conflictStatus = conflictNotice.noticeEl.createDiv({
-        cls: "file-conflict-row"
-    });
-    conflictStatus.createDiv().setText("Local")
-	conflictStatus.createDiv().setText("Remote")
-    for (const clash of clashedFiles) {
-        const conflictItem = conflictNotice.noticeEl.createDiv({
-            cls: "file-conflict-row"
-        });
-        conflictItem.createDiv({
-            cls: `file-conflict-${localStatusMap[clash.localStatus]}`
-        });
-        conflictItem.createDiv("div")
-            .setText(clash.path);
-        conflictItem.createDiv({
-            cls: `file-conflict-${remoteStatusMap[clash.remoteStatus]}`
-        });
-    }
-    const footer = conflictNotice.noticeEl.createDiv({
-        cls: "file-conflict-row"
-    })
-    footer.setText("Note:")
-    footer.style.fontWeight = "bold";
-    conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
-        .setText("Remote changes in _fit")
-    conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
-        .setText("_fit folder is overwritten on conflict, copy needed changes outside _fit.")
+	if (clashedFiles.length === 0) {return;}
+	const localStatusMap = {
+		created: "create",
+		changed: "change",
+		deleted: "delete"
+	};
+	const remoteStatusMap = {
+		ADDED:  "create",
+		MODIFIED: "change",
+		REMOVED: "delete"
+	};
+	const conflictNotice = new Notice("", 0);
+	const heading = conflictNotice.noticeEl.createEl("span");
+	heading.setText(`Change conflicts:\n`);
+	heading.addClass(`file-changes-subheading`);
+	const conflictStatus = conflictNotice.noticeEl.createDiv({
+		cls: "file-conflict-row"
+	});
+	conflictStatus.createDiv().setText("Local");
+	conflictStatus.createDiv().setText("Remote");
+	for (const clash of clashedFiles) {
+		const conflictItem = conflictNotice.noticeEl.createDiv({
+			cls: "file-conflict-row"
+		});
+		conflictItem.createDiv({
+			cls: `file-conflict-${localStatusMap[clash.localStatus]}`
+		});
+		conflictItem.createDiv("div")
+			.setText(clash.path);
+		conflictItem.createDiv({
+			cls: `file-conflict-${remoteStatusMap[clash.remoteStatus]}`
+		});
+	}
+	const footer = conflictNotice.noticeEl.createDiv({
+		cls: "file-conflict-row"
+	});
+	footer.setText("Note:");
+	footer.style.fontWeight = "bold";
+	conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
+		.setText("Remote changes in _fit");
+	conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
+		.setText("_fit folder is overwritten on conflict, copy needed changes outside _fit.");
 }

--- a/src/vaultOps.ts
+++ b/src/vaultOps.ts
@@ -3,104 +3,104 @@ import { FileOpRecord } from "./fitTypes";
 
 
 export interface IVaultOperations {
-    vault: Vault
-    deleteFromLocal: (path: string) => Promise<FileOpRecord>
-    writeToLocal: (path: string, content: string) => Promise<FileOpRecord>
-    updateLocalFiles: (
-        addToLocal: {path: string, content: string}[], deleteFromLocal: Array<string>) 
-        => Promise<FileOpRecord[]>
-    createCopyInDir: (path: string, copyDir: string) => Promise<void>
+	vault: Vault
+	deleteFromLocal: (path: string) => Promise<FileOpRecord>
+	writeToLocal: (path: string, content: string) => Promise<FileOpRecord>
+	updateLocalFiles: (
+		addToLocal: {path: string, content: string}[], deleteFromLocal: Array<string>)
+	=> Promise<FileOpRecord[]>
+	createCopyInDir: (path: string, copyDir: string) => Promise<void>
 }
 
 export class VaultOperations implements IVaultOperations {
-    vault: Vault
+	vault: Vault;
 
-    constructor(vault: Vault) {
-        this.vault = vault
-    }
+	constructor(vault: Vault) {
+		this.vault = vault;
+	}
 
-    async getTFile(path: string): Promise<TFile> {
-        const file = this.vault.getAbstractFileByPath(path)
-        if (file && file instanceof TFile) {
-            return file
-        } else {
-            throw new Error(`Attempting to read ${path} from local drive as TFile but not successful,
-            file is of type ${typeof file}.`)
-        }
-    }
+	async getTFile(path: string): Promise<TFile> {
+		const file = this.vault.getAbstractFileByPath(path);
+		if (file && file instanceof TFile) {
+			return file;
+		} else {
+			throw new Error(`Attempting to read ${path} from local drive as TFile but not successful,
+            file is of type ${typeof file}.`);
+		}
+	}
 
-    async deleteFromLocal(path: string): Promise<FileOpRecord> {
-        // adopted getAbstractFileByPath for mobile compatiability
-        const file = this.vault.getAbstractFileByPath(path)
-        if (file && file instanceof TFile) {
-            await this.vault.delete(file);
-            return {path, status: "deleted"}
-        } 
-        throw new Error(`Attempting to delete ${path} from local but not successful, file is of type ${typeof file}.`);
-    }
+	async deleteFromLocal(path: string): Promise<FileOpRecord> {
+		// adopted getAbstractFileByPath for mobile compatiability
+		const file = this.vault.getAbstractFileByPath(path);
+		if (file && file instanceof TFile) {
+			await this.vault.delete(file);
+			return {path, status: "deleted"};
+		}
+		throw new Error(`Attempting to delete ${path} from local but not successful, file is of type ${typeof file}.`);
+	}
 
-    // if checking a folder, require including the last / in the path param
-    async ensureFolderExists(path: string): Promise<void> {
-        // extract folder path, return empty string is no folder path is matched (exclude the last /)
-        const folderPath = path.match(/^(.*)\//)?.[1] || '';
-        if (folderPath != "") {
-            const folder = this.vault.getAbstractFileByPath(folderPath)
-            if (!folder) {
-                await this.vault.createFolder(folderPath)
-            }
-        }
-    }
+	// if checking a folder, require including the last / in the path param
+	async ensureFolderExists(path: string): Promise<void> {
+		// extract folder path, return empty string is no folder path is matched (exclude the last /)
+		const folderPath = path.match(/^(.*)\//)?.[1] || '';
+		if (folderPath != "") {
+			const folder = this.vault.getAbstractFileByPath(folderPath);
+			if (!folder) {
+				await this.vault.createFolder(folderPath);
+			}
+		}
+	}
 
-    async writeToLocal(path: string, content: string): Promise<FileOpRecord> {
-        // adopted getAbstractFileByPath for mobile compatiability
-        // TODO: add capability for creating folder from remote
-        const file = this.vault.getAbstractFileByPath(path)
-        if (file && file instanceof TFile) {
-            await this.vault.modifyBinary(file, base64ToArrayBuffer(content))
-            return {path, status: "changed"}
-        } else if (!file) {
-            this.ensureFolderExists(path)
-            await this.vault.createBinary(path, base64ToArrayBuffer(content))
-            return {path, status: "created"}
-        } 
-            throw new Error(`${path} writeToLocal operation unsuccessful, vault abstractFile on ${path} is of type ${typeof file}`);
-    }
+	async writeToLocal(path: string, content: string): Promise<FileOpRecord> {
+		// adopted getAbstractFileByPath for mobile compatiability
+		// TODO: add capability for creating folder from remote
+		const file = this.vault.getAbstractFileByPath(path);
+		if (file && file instanceof TFile) {
+			await this.vault.modifyBinary(file, base64ToArrayBuffer(content));
+			return {path, status: "changed"};
+		} else if (!file) {
+			this.ensureFolderExists(path);
+			await this.vault.createBinary(path, base64ToArrayBuffer(content));
+			return {path, status: "created"};
+		}
+		throw new Error(`${path} writeToLocal operation unsuccessful, vault abstractFile on ${path} is of type ${typeof file}`);
+	}
 
-    async updateLocalFiles(
-        addToLocal: {path: string, content: string}[], 
-        deleteFromLocal: Array<string>): Promise<FileOpRecord[]> {
-            // Process file additions or updates
-            const writeOperations = addToLocal.map(async ({path, content}) => {
-                return await this.writeToLocal(path, content)
-            });
-        
-            // Process file deletions
-            const deletionOperations = deleteFromLocal.map(async (path) => {
-                return await this.deleteFromLocal(path)
-            });
-            const fileOps = await Promise.all([...writeOperations, ...deletionOperations]);
-            return fileOps
-    }
+	async updateLocalFiles(
+		addToLocal: {path: string, content: string}[],
+		deleteFromLocal: Array<string>): Promise<FileOpRecord[]> {
+		// Process file additions or updates
+		const writeOperations = addToLocal.map(async ({path, content}) => {
+			return await this.writeToLocal(path, content);
+		});
 
-    async createCopyInDir(path: string, copyDir = "_fit"): Promise<void> {
-        const file = this.vault.getAbstractFileByPath(path)
-        if (file && file instanceof TFile) {
-            const copy = await this.vault.readBinary(file)
-            const copyPath = `${copyDir}/${path}`
-            this.ensureFolderExists(copyPath)
-            const copyFile = this.vault.getAbstractFileByPath(path)
-            if (copyFile && copyFile instanceof TFile) {
-                await this.vault.modifyBinary(copyFile, copy)
-            } else if (!copyFile) {
-                await this.vault.createBinary(copyPath, copy)
-            } else {
-                this.vault.delete(copyFile, true) // TODO add warning to let user know files in _fit will be overwritten
-                await this.vault.createBinary(copyPath, copy)
-            }
-            await this.vault.createBinary(copyPath, copy)
-        } else {
-            throw new Error(`Attempting to create copy of ${path} from local drive as TFile but not successful,
-            file is of type ${typeof file}.`)
-        }
-    }
+		// Process file deletions
+		const deletionOperations = deleteFromLocal.map(async (path) => {
+			return await this.deleteFromLocal(path);
+		});
+		const fileOps = await Promise.all([...writeOperations, ...deletionOperations]);
+		return fileOps;
+	}
+
+	async createCopyInDir(path: string, copyDir = "_fit"): Promise<void> {
+		const file = this.vault.getAbstractFileByPath(path);
+		if (file && file instanceof TFile) {
+			const copy = await this.vault.readBinary(file);
+			const copyPath = `${copyDir}/${path}`;
+			this.ensureFolderExists(copyPath);
+			const copyFile = this.vault.getAbstractFileByPath(path);
+			if (copyFile && copyFile instanceof TFile) {
+				await this.vault.modifyBinary(copyFile, copy);
+			} else if (!copyFile) {
+				await this.vault.createBinary(copyPath, copy);
+			} else {
+				this.vault.delete(copyFile, true); // TODO add warning to let user know files in _fit will be overwritten
+				await this.vault.createBinary(copyPath, copy);
+			}
+			await this.vault.createBinary(copyPath, copy);
+		} else {
+			throw new Error(`Attempting to create copy of ${path} from local drive as TFile but not successful,
+            file is of type ${typeof file}.`);
+		}
+	}
 }


### PR DESCRIPTION
Enables a few more lints in warning mode (`no-mixed-tabs-and-spaces`, `semi`, `indent`) and auto-fixes problems.

I'm going with tabs in TS/JS/JSON because that's mostly what they already used and what was configured in editorconfig. I actually prefer spaces but using tabs consistently is way better than a jagged mix of both.