### PR TITLE
Tests for Fit component

### DIFF
--- a/src/__mocks__/@octokit/core.ts
+++ b/src/__mocks__/@octokit/core.ts
@@ -1,0 +1,9 @@
+export class Octokit {
+	constructor(options?: { auth?: string }) {
+		// Mock constructor - store auth if needed for testing
+	}
+
+	request(): Promise<{ data: Record<string, unknown> }> {
+		return Promise.resolve({ data: {} });
+	}
+}

--- a/src/fit.test.ts
+++ b/src/fit.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Tests for Fit component - High-level sync error scenarios
+ */
+
+import { Fit } from './fit';
+import { FitSettings, LocalStores } from '../main';
+import { VaultOperations } from './vaultOps';
+import FitNotice from './fitNotice';
+import { SyncErrors, SyncError } from './syncResult';
+
+// Test settings presets
+const validSettings: FitSettings = {
+	pat: "ghp_validtoken123",
+	owner: "testuser",
+	avatarUrl: "https://github.com/testuser.png",
+	repo: "valid-repo",
+	branch: "main",
+	deviceName: "Test Device",
+	checkEveryXMinutes: 5,
+	autoSync: "off",
+	notifyChanges: true,
+	notifyConflicts: true
+};
+
+const emptyLocalStore: LocalStores = {
+	localSha: {},
+	lastFetchedCommitSha: null,
+	lastFetchedRemoteSha: {}
+};
+
+// Helper to track notice lifecycle during sync attempts
+class MockNotice {
+	public messages: Array<{ message: string; isError: boolean }> = [];
+	public states: Array<'loading' | 'error' | 'done' | 'static'> = [];
+
+	setMessage(message: string, isError = false) {
+		this.messages.push({ message, isError });
+		if (isError) this.states.push('error');
+	}
+
+	remove(state?: 'loading' | 'error' | 'done' | 'static') {
+		if (state) this.states.push(state);
+	}
+}
+
+// Helper to create Fit instances for testing error scenarios
+function createFitForErrorScenario(scenario: {
+	settings?: Partial<FitSettings>;
+	localFiles?: Array<{ path: string; content: string }>;
+}): Fit {
+	const settings = { ...validSettings, ...scenario.settings };
+	const localStore = { ...emptyLocalStore };
+
+	// Create mock vault operations
+	const mockVaultOps = {
+		vault: {
+			getFiles: jest.fn().mockReturnValue(
+				scenario.localFiles?.map(f => ({
+					path: f.path,
+					extension: f.path.split('.').pop() || '',
+					name: f.path.split('/').pop() || f.path
+				})) || []
+			),
+			read: jest.fn(),
+			updateLocalFiles: jest.fn().mockResolvedValue([])
+		},
+		getTFile: jest.fn()
+	} as unknown as jest.Mocked<VaultOperations>;
+
+	return new Fit(settings, localStore, mockVaultOps);
+}
+
+// Helper that emulates a successful sync with realistic results based on local files
+async function attemptSuccessfulSync(
+	localFiles: Array<{ path: string; content: string }>,
+	syncOutcome: 'no-changes' | 'local-changes' | 'remote-changes' | 'both-changes'
+) {
+	// Create a FitSync fake that returns realistic results based on the scenario
+	const mockFitSync = {
+		sync: jest.fn().mockImplementation(() => {
+			switch (syncOutcome) {
+				case 'no-changes':
+					return Promise.resolve({ success: true, ops: [], clash: [] }); // FitSync returns success with no operations when already in sync
+				case 'local-changes':
+					return Promise.resolve({
+						success: true,
+						ops: [{ heading: "Local file updates:", ops: localFiles.map(f => ({ path: f.path, status: "updated" })) }],
+						clash: []
+					});
+				case 'remote-changes':
+					return Promise.resolve({
+						success: true,
+						ops: [{ heading: "Remote file updates:", ops: [{ path: "remote-file.md", status: "updated" }] }],
+						clash: []
+					});
+				case 'both-changes':
+					return Promise.resolve({
+						success: true,
+						ops: [
+							{ heading: "Local file updates:", ops: localFiles.map(f => ({ path: f.path, status: "updated" })) },
+							{ heading: "Remote file updates:", ops: [{ path: "remote-file.md", status: "updated" }] }
+						],
+						clash: []
+					});
+			}
+		})
+	};
+
+	const notice = new MockNotice();
+
+	// Start sync attempt (emulates main.ts performManualSync)
+	notice.setMessage("Initiating sync");
+	notice.states.push('loading');
+
+	// Attempt sync - should succeed (emulates main.ts sync method success path)
+	const result = await mockFitSync.sync(notice as unknown as FitNotice);
+	if (result.success) {
+		// Success path just removes notice as "done"
+		notice.remove('done');
+		return {
+			syncSucceeded: true,
+			notice,
+			syncResult: result
+		};
+	} else {
+		// This shouldn't happen in success scenarios - return failure
+		const fit = createFitForErrorScenario({ localFiles });
+		const userMessage = fit.getSyncErrorMessage(result.error);
+		notice.setMessage(userMessage, true);
+		notice.remove('error');
+		return {
+			syncSucceeded: false,
+			notice,
+			syncResult: null
+		};
+	}
+}
+
+describe('Fit Sync Success Scenarios', () => {
+	it('should complete sync successfully and show done notice when no files need updating', async () => {
+		const { syncSucceeded, notice, syncResult } = await attemptSuccessfulSync(
+			[{ path: 'notes/existing.md', content: 'Already synced content' }],
+			'no-changes'
+		);
+
+		// Verify sync completed successfully
+		expect(syncSucceeded).toBe(true);
+		expect(notice.messages[0]).toEqual({
+			message: "Initiating sync",
+			isError: false
+		});
+		expect(notice.states).toContain('loading');
+		expect(notice.states).toContain('done');
+
+		// Verify success with no file operations (everything in sync)
+		expect(syncResult).toEqual({ success: true, ops: [], clash: [] });
+	});
+
+	it('should complete sync successfully and track file updates when local changes occur', async () => {
+		const localFiles = [
+			{ path: 'notes/local-change.md', content: 'Modified locally' },
+			{ path: 'ideas/new-idea.md', content: 'Fresh content' }
+		];
+
+		const { syncSucceeded, notice, syncResult } = await attemptSuccessfulSync(
+			localFiles,
+			'local-changes'
+		);
+
+		// Verify sync completed successfully
+		expect(syncSucceeded).toBe(true);
+		expect(notice.states).toContain('loading');
+		expect(notice.states).toContain('done');
+
+		// Verify local file operations use actual file paths from scenario
+		expect(syncResult?.ops).toEqual([{
+			heading: "Local file updates:",
+			ops: [
+				{ path: "notes/local-change.md", status: "updated" },
+				{ path: "ideas/new-idea.md", status: "updated" }
+			]
+		}]);
+		expect(syncResult?.clash).toEqual([]);
+	});
+
+	it('should complete sync successfully when both local and remote changes occur', async () => {
+		const localFiles = [{ path: 'notes/modified.md', content: 'Local changes' }];
+
+		const { syncSucceeded, notice, syncResult } = await attemptSuccessfulSync(
+			localFiles,
+			'both-changes'
+		);
+
+		// Verify sync completed successfully
+		expect(syncSucceeded).toBe(true);
+		expect(notice.states).toContain('loading');
+		expect(notice.states).toContain('done');
+
+		// Verify both local and remote operations
+		expect(syncResult?.ops).toEqual(
+			expect.arrayContaining([
+				{ heading: "Local file updates:", ops: [{ path: "notes/modified.md", status: "updated" }] },
+				{ heading: "Remote file updates:", ops: [{ path: "remote-file.md", status: "updated" }] }
+			])
+		);
+		expect(syncResult?.clash).toEqual([]);
+	});
+});
+
+describe('Fit Sync Error Scenarios', () => {
+	// Helper that emulates the complete sync attempt and error handling from main.ts
+	async function attemptSyncWithStructuredError(
+		fit: Fit,
+		syncResult: { success: false; error: SyncError }
+	) {
+		// Mock vault operations to track if updates occurred
+		const mockVaultOps = { updateLocalFiles: jest.fn().mockResolvedValue([]) };
+
+		// Mock FitSync that returns structured error result
+		const mockFitSync = {
+			sync: jest.fn().mockResolvedValue(syncResult)
+		};
+
+		const notice = new MockNotice();
+
+		// Start sync attempt (emulates main.ts performManualSync)
+		notice.setMessage("Initiating sync");
+		notice.states.push('loading');
+
+		// Attempt sync and handle result (emulates main.ts sync method exactly)
+		let syncFailed = false;
+		const result = await mockFitSync.sync(notice as unknown as FitNotice);
+
+		if (result.success) {
+			notice.remove('done');
+		} else {
+			syncFailed = true;
+			// Generate user-friendly message from structured sync error (new approach)
+			const userMessage = fit.getSyncErrorMessage(result.error);
+			notice.setMessage(userMessage, true);
+			notice.remove('error');
+		}
+
+		return {
+			syncFailed,
+			notice,
+			mockVaultOps
+		};
+	}
+
+	it('should show error notice and make no local updates when repository does not exist', async () => {
+		const fit = createFitForErrorScenario({
+			settings: { repo: "nonexistent-repo" },
+			localFiles: [
+				{ path: 'existing-note.md', content: 'Original content' },
+				{ path: 'another-file.md', content: 'More content' }
+			]
+		});
+
+		const { syncFailed, notice, mockVaultOps } = await attemptSyncWithStructuredError(
+			fit,
+			{
+				success: false,
+				error: SyncErrors.remoteNotFound('Not Found', { source: 'getRef' })
+			}
+		);
+
+		// Verify error notice was shown
+		expect(syncFailed).toBe(true);
+		expect(notice.messages[1]).toEqual({
+			message: "Failed to get ref, make sure your repo name and branch name are set correctly.",
+			isError: true
+		});
+		expect(notice.states).toContain('loading');
+		expect(notice.states).toContain('error');
+
+		// Verify no local file updates occurred
+		expect(mockVaultOps.updateLocalFiles).not.toHaveBeenCalled();
+	});
+
+	it('should show error notice when authentication fails', async () => {
+		const fit = createFitForErrorScenario({
+			settings: { pat: "invalid_token" }
+		});
+
+		const { syncFailed, notice } = await attemptSyncWithStructuredError(
+			fit,
+			{
+				success: false,
+				error: SyncErrors.unknown('Bad credentials')
+			}
+		);
+
+		expect(syncFailed).toBe(true);
+		expect(notice.messages[1]).toEqual({
+			message: "Unable to sync, if you are not connected to the internet, turn off auto sync.",
+			isError: true
+		});
+		expect(notice.states).toContain('loading');
+		expect(notice.states).toContain('error');
+	});
+
+	it('should show generic error notice for non-Octokit errors like filesystem issues', async () => {
+		const fit = createFitForErrorScenario({
+			localFiles: [
+				{ path: 'notes/important.md', content: 'Important content' }
+			]
+		});
+
+		const { syncFailed, notice, mockVaultOps } = await attemptSyncWithStructuredError(
+			fit,
+			{
+				success: false,
+				error: SyncErrors.unknown('EACCES: permission denied, open \'/vault/notes/important.md\'')
+			}
+		);
+
+		// Verify the same generic message is shown for filesystem errors
+		expect(syncFailed).toBe(true);
+		expect(notice.messages[1]).toEqual({
+			message: "Unable to sync, if you are not connected to the internet, turn off auto sync.",
+			isError: true
+		});
+		expect(notice.states).toContain('loading');
+		expect(notice.states).toContain('error');
+
+		// Verify no local file updates occurred
+		expect(mockVaultOps.updateLocalFiles).not.toHaveBeenCalled();
+	});
+});

--- a/src/fitSync.test.ts
+++ b/src/fitSync.test.ts
@@ -52,7 +52,7 @@ describe('FitSync', () => {
 			const result = await fitSync.sync(notice);
 
 			// Assert
-			expect(result).toBeUndefined();
+			expect(result).toEqual({ success: true, ops: [], clash: [] });
 		});
 
 		it('should update commit SHA when only remote commit changed', async () => {
@@ -70,7 +70,7 @@ describe('FitSync', () => {
 			const result = await fitSync.sync(notice);
 
 			// Assert
-			expect(result).toBeUndefined();
+			expect(result).toEqual({ success: true, ops: [], clash: [] });
 			expect(saveLocalStoreCallback).toHaveBeenCalledWith({
 				lastFetchedCommitSha: newCommitSha
 			});
@@ -94,6 +94,7 @@ describe('FitSync', () => {
 
 			// Assert
 			expect(result).toEqual({
+				success: true,
 				ops: [{ heading: 'Local file updates:', ops: localChanges }],
 				clash: []
 			});
@@ -120,6 +121,7 @@ describe('FitSync', () => {
 
 			// Assert
 			expect(result).toEqual({
+				success: true,
 				ops: [{ heading: 'Local file updates:', ops: mockFileOps }],
 				clash: []
 			});
@@ -152,6 +154,7 @@ describe('FitSync', () => {
 
 			// Assert
 			expect(result).toEqual({
+				success: true,
 				ops: [
 					{ heading: 'Local file updates:', ops: mockLocalOps },
 					{ heading: 'Remote file updates:', ops: mockRemoteOps }
@@ -192,6 +195,7 @@ describe('FitSync', () => {
 
 			// Assert
 			expect(result).toEqual({
+				success: true,
 				ops: [
 					{ heading: 'Local file updates:', ops: conflictFileOps },
 					{ heading: 'Remote file updates:', ops: [] }

--- a/src/syncResult.ts
+++ b/src/syncResult.ts
@@ -1,0 +1,39 @@
+/**
+ * Structured result types for sync operations
+ */
+
+import { ClashStatus, FileOpRecord } from "./fitTypes";
+
+export type SyncErrorType =
+  | 'remote_not_found'  // Remote repository, branch, or access issues
+  | 'unknown';          // Unexpected errors
+
+export type SyncError = {
+	type: SyncErrorType
+	technicalMessage: string
+	details?: {
+		source?: string             // Which operation failed (e.g., 'getRef', 'createCommit')
+		originalError?: Error       // Original error object for advanced logging/debugging
+	}
+};
+
+export type SyncResult =
+    | { success: true; ops: Array<{ heading: string, ops: FileOpRecord[] }>; clash: ClashStatus[] }
+    | { success: false; error: SyncError };
+
+/**
+ * Utility functions for creating structured sync errors
+ */
+export const SyncErrors = {
+	remoteNotFound: (message: string, details?: { source?: string; originalError?: Error }): SyncError => ({
+		type: 'remote_not_found',
+		technicalMessage: message,
+		details
+	}),
+
+	unknown: (message: string, details?: { originalError?: Error }): SyncError => ({
+		type: 'unknown',
+		technicalMessage: message,
+		details
+	})
+};


### PR DESCRIPTION
Migrates error notice code from main.ts into Fit where it can be tested, defines a SyncResult type that can be used to encapsulate success/failure metadata more explicitly, and adds basic tests for high-level Fit behavior and error notice text.

Avoids any behavior changes (should be a no-op refactor).