### PR TITLE
feat(#59): Also distinguish errors for repo vs branch

### DIFF
--- a/src/fit.test.ts
+++ b/src/fit.test.ts
@@ -259,14 +259,14 @@ describe('Fit Sync Error Scenarios', () => {
 			fit,
 			{
 				success: false,
-				error: SyncErrors.remoteNotFound('Repository \'testuser/valid-repo\' or branch \'nonexistent-branch\' not found', { source: 'getRef', originalError: new Error('Branch not found') })
+				error: SyncErrors.remoteNotFound('Branch \'nonexistent-branch\' not found on repository \'testuser/valid-repo\'', { source: 'getRef', originalError: new Error('Branch not found') })
 			}
 		);
 
 		// Verify error notice was shown with user-friendly message
 		expect(syncFailed).toBe(true);
 		expect(notice.messages[1]).toEqual({
-			message: "Sync failed: Repository 'testuser/valid-repo' or branch 'nonexistent-branch' not found. Check your repo and branch settings.",
+			message: "Sync failed: Branch 'nonexistent-branch' not found on repository 'testuser/valid-repo'. Check your repo and branch settings.",
 			isError: true
 		});
 		expect(notice.states).toContain('loading');
@@ -288,14 +288,14 @@ describe('Fit Sync Error Scenarios', () => {
 			fit,
 			{
 				success: false,
-				error: SyncErrors.remoteNotFound('Repository \'testuser/nonexistent-repo\' or branch \'main\' not found', { originalError: new Error('Repository not found'), source: 'getTree' })
+				error: SyncErrors.remoteNotFound('Repository \'testuser/nonexistent-repo\' not found', { originalError: new Error('Repository not found'), source: 'getTree' })
 			}
 		);
 
 		// Verify error notice was shown with user-friendly message
 		expect(syncFailed).toBe(true);
 		expect(notice.messages[1]).toEqual({
-			message: "Sync failed: Repository 'testuser/nonexistent-repo' or branch 'main' not found. Check your repo and branch settings.",
+			message: "Sync failed: Repository 'testuser/nonexistent-repo' not found. Check your repo and branch settings.",
 			isError: true
 		});
 		expect(notice.states).toContain('loading');

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -37,6 +37,7 @@ type OctokitCallMethods = {
 	getUser: () => Promise<{owner: string, avatarUrl: string}>
 	getRepos: () => Promise<string[]>
 	getRef: (ref: string) => Promise<string>
+	getRepo: () => Promise<void>
 	getTree: (tree_sha: string) => Promise<TreeNode[]>
 	getCommitTreeSha: (ref: string) => Promise<string>
 	getRemoteTreeSha: (tree_sha: string) => Promise<{[k:string]: string}>
@@ -253,6 +254,22 @@ export class Fit implements IFit {
 			return response.map(r => r.name);
 		} catch (error) {
 			throw new OctokitHttpError(error.message, error.status ?? null, "getRepos");
+		}
+	}
+
+	/**
+     * Get repository info - throws OctokitHttpError with status codes
+     * Used to check if repository exists and is accessible
+     */
+	async getRepo(): Promise<void> {
+		try {
+			await this.octokit.request(`GET /repos/{owner}/{repo}`, {
+				owner: this.owner,
+				repo: this.repo,
+				headers: this.headers
+			});
+		} catch (error) {
+			throw new OctokitHttpError(error.message, error.status, "getRepo");
 		}
 	}
 

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -422,8 +422,21 @@ export class FitSync implements IFitSync {
 
 				// GitHub API 404 errors for repository/branch access
 				if (error.status === 404 && (error.source === 'getRef' || error.source === 'getTree')) {
-					const detailMessage = `Repository '${this.fit.owner}/${this.fit.repo}' or branch '${this.fit.branch}' not found`;
-					return { success: false, error: SyncErrors.remoteNotFound(detailMessage, { source: error.source, originalError: error }) };
+					// Try to distinguish between repo and branch errors
+					try {
+						await this.fit.getRepo(); // If this succeeds, repo exists but branch doesn't
+						const detailMessage = `Branch '${this.fit.branch}' not found on repository '${this.fit.owner}/${this.fit.repo}'`;
+						return { success: false, error: SyncErrors.remoteNotFound(detailMessage, { source: error.source, originalError: error }) };
+					} catch (repoError) {
+						// Only if getRepo fails with 404, we know it's specifically a repo issue
+						if (repoError instanceof OctokitHttpError && repoError.status === 404) {
+							const detailMessage = `Repository '${this.fit.owner}/${this.fit.repo}' not found`;
+							return { success: false, error: SyncErrors.remoteNotFound(detailMessage, { source: error.source, originalError: error }) };
+						}
+						// For other getRepo errors (403, network, etc.), fall back to generic message
+						const detailMessage = `Repository '${this.fit.owner}/${this.fit.repo}' or branch '${this.fit.branch}' not found`;
+						return { success: false, error: SyncErrors.remoteNotFound(detailMessage, { source: error.source, originalError: error }) };
+					}
 				}
 
 				// All other GitHub API errors (rate limiting, server errors, etc.)


### PR DESCRIPTION
For error notices for remote not found, shows slightly nicer "Repository not found" or "Branch not found" notice depending on whether it detects that the repo exists.