### PR TITLE
chore: Update GH stale workflow to actions/stale@v10

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v10
       with:
         stale-issue-message: 'Stale issue message'
         stale-pr-message: 'Stale pull request message'


### PR DESCRIPTION
actionlint was complaining that v5 is too old to run on GitHub Actions.