### PR TITLE
fix: a bug mishandling unsynced _fit/ paths

### DIFF
--- a/src/fit.ts
+++ b/src/fit.ts
@@ -83,6 +83,23 @@ export class Fit {
 		return true;
 	}
 
+	/**
+	 * Filter a FileState to include only paths that should be synced.
+	 * Used when updating LocalStores to ensure excluded paths (like _fit/) aren't tracked.
+	 *
+	 * @param state - Complete file state from vault
+	 * @returns Filtered state containing only synced paths
+	 */
+	filterSyncedState(state: FileState): FileState {
+		const filtered: FileState = {};
+		for (const [path, sha] of Object.entries(state)) {
+			if (this.shouldSyncPath(path)) {
+				filtered[path] = sha;
+			}
+		}
+		return filtered;
+	}
+
 	async remoteUpdated(): Promise<{remoteCommitSha: string, updated: boolean}> {
 		const remoteCommitSha = await this.remoteVault.getLatestCommitSha();
 		return {remoteCommitSha, updated: remoteCommitSha !== this.lastFetchedCommitSha};

--- a/src/fitPull.ts
+++ b/src/fitPull.ts
@@ -101,10 +101,11 @@ export class FitPull {
 
 		const fileOpsRecord = await this.fit.localVault.applyChanges(addToLocal, deleteFromLocal);
 
+		const newLocalState = await this.fit.localVault.readFromSource();
 		await saveLocalStoreCallback({
-			lastFetchedRemoteSha: remoteTreeSha,
+			lastFetchedRemoteSha: this.fit.filterSyncedState(remoteTreeSha),
 			lastFetchedCommitSha: latestRemoteCommitSha,
-			localSha: await this.fit.localVault.readFromSource()
+			localSha: this.fit.filterSyncedState(newLocalState)
 		});
 		return fileOpsRecord;
 	}

--- a/src/fitSync.test.ts
+++ b/src/fitSync.test.ts
@@ -29,6 +29,9 @@ describe('FitSync', () => {
 
 		const fakeFit = {
 			// Core change detection methods
+			shouldSyncPath(path: string) {
+				return true;
+			},
 			async remoteUpdated() {
 				return {
 					remoteCommitSha: remoteCommitSha || '',
@@ -50,6 +53,10 @@ describe('FitSync', () => {
 			},
 			getClashedChanges(_localChanges: LocalChange[], _remoteChanges: RemoteChange[]) {
 				return [];
+			},
+			filterSyncedState(state: Record<string, string>) {
+				// Simple pass-through for tests (no _fit/ filtering needed in unit tests)
+				return state;
 			},
 
 			// Minimal vault stubs - only implement methods actually used by tests


### PR DESCRIPTION
Adds shouldSyncPath filtering to several code flows that were missing it, and adds test coverage.

---

<!-- kody-pr-summary:start -->
This pull request addresses a bug where files and directories within the `_fit/` path were not correctly excluded from synchronization operations.

The changes ensure that `_fit/` paths are consistently ignored throughout the sync process:

1.  **Introduced `filterSyncedState`:** A new utility method `filterSyncedState` was added to `Fit` to filter a `FileState` object, retaining only paths that are intended for synchronization (i.e., excluding `_fit/` paths).
2.  **Excluded from Sync State Tracking:** The `saveLocalStoreCallback` in `FitPull` and `FitSync` now uses `filterSyncedState` to ensure that the persistent local sync state (which tracks `localSha` and `lastFetchedRemoteSha`) only records paths that should be synced, effectively ignoring `_fit/` paths.
3.  **Excluded from Change Detection and Operations:** In `FitSync`, both local and remote changes are now filtered using `shouldSyncPath` at the beginning of `performPreSyncChecks`. This means that `_fit/` paths will no longer be considered when detecting changes, determining sync status, or identifying clashes.
4.  **Comprehensive Testing:** A new test case was added to verify that `_fit/` files are neither pushed to the remote nor pulled from the remote, and are correctly excluded from the internal sync state.

This fix ensures that `_fit/` paths remain local-only and do not interfere with the synchronization of other vault content.
<!-- kody-pr-summary:end -->