### PR TITLE
feat(#102): Update ribbon command to "Sync to GitHub"

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -213,7 +213,8 @@ export default class FitPlugin extends Plugin {
 
 	loadRibbonIcons() {
 		// Pull from remote then Push to remote if no clashing changes detected during pull
-		this.fitSyncRibbonIconEl = this.addRibbonIcon('github', 'Fit Sync', this.performManualSync);
+		// TODO: Update title from "GitHub" to selected remote service when other services are supported.
+		this.fitSyncRibbonIconEl = this.addRibbonIcon('github', 'Sync to GitHub', this.performManualSync);
 		this.fitSyncRibbonIconEl.addClass('fit-sync-ribbon-el');
 	}
 


### PR DESCRIPTION
Fixes #102.

---

<!-- kody-pr-summary:start -->
Updated the tooltip text for the synchronization ribbon icon from "Fit Sync" to "Sync to GitHub". This change provides a more descriptive label for the action performed when hovering over the icon, clarifying its purpose for GitHub synchronization.
<!-- kody-pr-summary:end -->