### PR TITLE
fix: better error for file/folder conflict

### DIFF
--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -18,6 +18,11 @@ export class TFile {
 	basename!: string;
 }
 
+export class TFolder {
+	path!: string;
+	children: any[] = [];
+}
+
 export class Vault {
 	readBinary = jest.fn();
 }

--- a/src/localVault.ts
+++ b/src/localVault.ts
@@ -4,7 +4,7 @@
  * Implements IVault for Obsidian vault files.
  */
 
-import { TFile, Vault } from "obsidian";
+import { TFile, TFolder, Vault } from "obsidian";
 import { IVault, FileState, VaultError } from "./vault";
 import { FileOpRecord } from "./fitTypes";
 import { fitLogger } from "./logger";
@@ -199,7 +199,12 @@ export class LocalVault implements IVault {
 				await this.vault.createBinary(path, contentToArrayBuffer(content));
 				return {path, status: "created"};
 			}
-			throw new Error(`${path} writeFile operation unsuccessful, vault abstractFile on ${path} is of type ${typeof file}`);
+			// File exists but is not a TFile - check if it's a folder
+			if (file instanceof TFolder) {
+				throw new Error(`Cannot write file to ${path}: a folder with that name already exists`);
+			}
+			// Unknown type - future-proof for new Obsidian abstract file types
+			throw new Error(`Cannot write file to ${path}: path exists but is not a file (type: ${file.constructor.name})`);
 		} catch (error) {
 			// Re-throw VaultError as-is (don't double-wrap)
 			if (error instanceof VaultError) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances error handling in the `LocalVault`'s `writeFile` operation.

Specifically, it introduces a check to detect and report conflicts when attempting to write a file to a path where a folder with the same name already exists. Instead of a generic error, the system will now throw a precise error message: "Cannot write file to [path]: a folder with that name already exists."

This change improves the clarity of error messages for users encountering file/folder name conflicts, making it easier to understand and resolve such issues. New tests have been added to validate this behavior and to cover scenarios where a parent path is a file instead of a folder.
<!-- kody-pr-summary:end -->