### PR TITLE
chore: run CI workflow for every push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Previously, the CI workflow only ran on the main and master branches.
This update allows CI to run on every push, which is more useful for contributors developing on feature branches.

---

<!-- kody-pr-summary:start -->
This pull request modifies the CI workflow configuration to trigger on every push event to any branch. Previously, the CI workflow was configured to run only on pushes to the `main` and `master` branches.
<!-- kody-pr-summary:end -->