### PR TITLE
fix: skip full re-read from remote after sync

### DIFF
--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -493,7 +493,7 @@ describe('FitSync', () => {
 			localStoreState = {
 				localSha: (await localVault.readFromSource()).state,
 				lastFetchedRemoteSha: remoteResult.state,
-				lastFetchedCommitSha: remoteResult.commitSha ?? null
+				lastFetchedCommitSha: remoteResult.commitSha
 			};
 			const fitSync = createFitSync();
 

--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -233,6 +233,7 @@ describe("RemoteGitHubVault", () => {
 					changes: [{ path: "newfile.md", type: "ADDED" }],
 					commitSha: expect.not.stringMatching(PARENTCOMMIT123_SHA),
 					treeSha: expect.not.stringMatching(TREE456_SHA),
+					newState: { 'newfile.md': expect.any(String) }
 				});
 
 				// Verify the file was ADDED to the tree
@@ -259,11 +260,10 @@ describe("RemoteGitHubVault", () => {
 				);
 
 				expect(result).toEqual({
-					changes: [
-						{ path: "existing.md", type: "MODIFIED" }
-					],
+					changes: [{ path: "existing.md", type: "MODIFIED" }],
 					commitSha: expect.not.stringMatching(PARENTCOMMIT123_SHA),
 					treeSha: expect.not.stringMatching(TREE456_SHA),
+					newState: { "existing.md": expect.any(String) },
 				});
 			});
 
@@ -280,11 +280,10 @@ describe("RemoteGitHubVault", () => {
 				);
 
 				expect(result).toEqual({
-					changes: [
-						{ path: "todelete.md", type: "REMOVED" }
-					],
+					changes: [{ path: "todelete.md", type: "REMOVED" }],
 					commitSha: expect.not.stringMatching(PARENTCOMMIT123_SHA),
 					treeSha: expect.not.stringMatching(TREE456_SHA),
+					newState: {},
 				});
 
 				// Verify file was REMOVED from tree
@@ -301,11 +300,10 @@ describe("RemoteGitHubVault", () => {
 				);
 
 				expect(result).toEqual({
-					changes: [
-						{ path: "image.png", type: "ADDED" }
-					],
+					changes: [{ path: "image.png", type: "ADDED" }],
 					commitSha: expect.not.stringMatching(PARENTCOMMIT123_SHA),
 					treeSha: expect.not.stringMatching(TREE456_SHA),
+					newState: { "image.png": expect.any(String) },
 				});
 			});
 
@@ -326,6 +324,7 @@ describe("RemoteGitHubVault", () => {
 					changes: [],
 					commitSha: PARENTCOMMIT123_SHA, // Unchanged when no tree nodes created
 					treeSha: TREE456_SHA, // Unchanged when no tree nodes created
+					newState: { "file.md": expect.any(String) },
 				});
 				// Commit SHA should not have changed
 				expect(fakeOctokit.getLatestCommitSha()).toBe(PARENTCOMMIT123_SHA);
@@ -347,6 +346,7 @@ describe("RemoteGitHubVault", () => {
 					changes: [],
 					commitSha: PARENTCOMMIT123_SHA, // Unchanged when no changes
 					treeSha: TREE456_SHA, // Unchanged when no changes
+					newState: { "other.md": BLOB1_SHA },
 				});
 			});
 
@@ -374,6 +374,10 @@ describe("RemoteGitHubVault", () => {
 					]),
 					commitSha: expect.anything(),
 					treeSha: expect.anything(),
+					newState: {
+						"new.md": expect.any(String),
+						"existing.md": expect.any(String),
+					},
 				});
 			});
 		});


### PR DESCRIPTION
This avoids state corruption risks where it could incorrectly record a newer remote version in local store than it had actually synced, saves a bit of wasteful performance overhead, and aligns the behaviors better between local and remote IVault implementations.

This is parallel to #128 which recently skipped *local* rereads, only instead of skipping local filesystem scanning overhead it skips 3 API calls (for `getLatestCommitSha`, `getCommitTreeSha`, and `getTree`).

Also fixes some cases in applyChanges where cache wasn't getting checked before fetching tree or updated after fetching.

---

<!-- kody-pr-summary:start -->
This pull request optimizes the synchronization process by eliminating a redundant API call to the remote vault after pushing changes.

Previously, after a successful push to the remote, the system would perform an additional `readFromSource()` call to fetch the updated remote state. This introduced an unnecessary API request and a potential race condition where the remote state could change between the push and the subsequent re-read.

With this change:
- The `RemoteGitHubVault.applyChanges()` method now directly computes and returns the `newState` (the updated file states) along with the new commit and tree SHAs after a push.
- `FitSync` now uses this `newState` directly, avoiding the redundant `readFromSource()` call.
- The `RemoteGitHubVault`'s internal cache is immediately updated with the new state, ensuring consistency.
- File change detection within `RemoteGitHubVault` is optimized by using `FileStates` maps for faster lookups.
- Type definitions for `VaultReadResult` and `ApplyChangesResult` have been enhanced for better type safety and clarity, distinguishing between local and remote vault return types.
<!-- kody-pr-summary:end -->