### PR TITLE
fix(#81): handle errors in onload

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -353,14 +353,17 @@ export default class FitPlugin extends Plugin {
 
 	async onload() {
 		try {
-			await this.loadSettings();
-			await this.loadLocalStore();
-
 			// Initialize logger with vault and plugin directory for cross-platform diagnostics
+			// This is done first so the logger is available if later initialization steps fail.
 			fitLogger.setVault(this.app.vault);
 			if (this.manifest.dir) {
 				fitLogger.setPluginDir(this.manifest.dir);
 			}
+
+			await this.loadSettings();
+			await this.loadLocalStore();
+
+			// Now that settings are loaded, enable or disable logging based on user preference.
 			fitLogger.setEnabled(this.settings.enableDebugLogging);
 
 			fitLogger.log('[Plugin] Starting plugin initialization');

--- a/src/util/errorHandling.ts
+++ b/src/util/errorHandling.ts
@@ -8,7 +8,7 @@
 import { Notice } from 'obsidian';
 
 export interface CriticalErrorOptions {
-	logger?: { log: (tag: string, data?: unknown) => void };
+	logger?: { logUnsafe: (tag: string, data?: unknown) => void };
 	showNotice?: boolean;
 }
 
@@ -48,7 +48,7 @@ export function handleCriticalError(
 	// Try to log to file for diagnostics (defensive: never throw)
 	if (options.logger) {
 		try {
-			options.logger.log(`[Plugin] FATAL: ${context}`, {
+			options.logger.logUnsafe(`[Plugin] FATAL: ${context}`, {
 				error: errorMessage,
 				stack: errorStack,
 				timestamp: new Date().toISOString()
@@ -72,7 +72,7 @@ export function handleCriticalError(
 			// If Notice fails but logging worked, try to log the Notice failure
 			if (logError === null && options.logger) {
 				try {
-					options.logger.log('[Plugin] FATAL: Failed to show error notice', {
+					options.logger.logUnsafe('[Plugin] FATAL: Failed to show error notice', {
 						noticeError: noticeError instanceof Error ? noticeError.message : String(noticeError),
 						noticeStack: noticeError instanceof Error ? noticeError.stack : undefined,
 						originalError: errorMessage,


### PR DESCRIPTION
Enhance the plugin's error handling during its `onload` lifecycle, particularly concerning logging.

Fixes #81.

---

<!-- kody-pr-summary:start -->
This pull request enhances the plugin's error handling during its `onload` lifecycle, particularly concerning logging.

Key changes include:

*   **`onload` Method Protection:** The plugin's onload method is now wrapped in a `try...catch` block. Any errors occurring during plugin initialization (e.g., loading settings, initializing components) will be caught and reported using the new `handleCriticalError` utility before being re-thrown.
*   **Enhanced Logger Resilience:** The plugin's internal logger is updated to include a fallback mechanism. If the logger itself encounters an error while attempting to write a log, it will now try to report this failure to the console, preventing silent logging failures.
*   **Initialization Logging:** Added log messages to indicate the start and successful completion of plugin initialization.
*   **Early Logger Initialization:** The logger is now initialized with the vault and plugin directory *before* loading settings and local store. This ensures the logger is available to capture and report any errors that might occur during these critical initialization steps.
*   **Robust Critical Error Logging:**
    *   A new `logUnsafe` method has been introduced in the `FitLogger` class. Unlike the existing `log` method (which is defensive and never throws), `logUnsafe` can throw an error if the logging process itself fails.
    *   The original `log` method now internally calls `logUnsafe` within a `try...catch` block, maintaining its guarantee of never throwing.
    *   The `handleCriticalError` utility function has been updated to use `logUnsafe` when attempting to log critical errors or failures to display notices. This allows the critical error handler to detect and potentially react if logging itself encounters an issue.
*   **Correct Debug Logging Configuration:** The setting to enable or disable debug logging is now applied to the logger *after* the plugin's settings have been successfully loaded, ensuring that user preferences are respected.

These changes ensure that critical errors during plugin startup are gracefully handled and reported through multiple channels, providing better diagnostics for users and developers.
<!-- kody-pr-summary:end -->