### PR TITLE
build: Fix some TS config warnings

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,15 +5,15 @@
  */
 
 import { Plugin, SettingTab } from 'obsidian';
-import { Fit } from 'src/fit';
-import FitNotice from 'src/fitNotice';
-import FitSettingTab from 'src/fitSetting';
-import { FitSync } from 'src/fitSync';
-import { showFileChanges, showUnappliedConflicts } from 'src/utils';
-import { fitLogger } from 'src/logger';
-import { CommitSha } from 'src/util/hashing';
-import { FileStates } from 'src/util/changeTracking';
-import { handleCriticalError } from 'src/util/errorHandling';
+import { Fit } from '@/fit';
+import FitNotice from '@/fitNotice';
+import FitSettingTab from '@/fitSetting';
+import { FitSync } from '@/fitSync';
+import { showFileChanges, showUnappliedConflicts } from '@/utils';
+import { fitLogger } from '@/logger';
+import { CommitSha } from '@/util/hashing';
+import { FileStates } from '@/util/changeTracking';
+import { handleCriticalError } from '@/util/errorHandling';
 
 /**
  * Plugin configuration interface

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -5,7 +5,7 @@
  * (RemoteGitHubVault), and maintains sync state (cached SHAs for change detection).
  */
 
-import { LocalStores, FitSettings } from "main";
+import { LocalStores, FitSettings } from "@main";
 import { FileChange, FileClash, FileStates, compareFileStates } from "./util/changeTracking";
 import { Vault } from "obsidian";
 import { LocalVault } from "./localVault";

--- a/src/fitSetting.ts
+++ b/src/fitSetting.ts
@@ -1,4 +1,4 @@
-import FitPlugin from "main";
+import FitPlugin from "@main";
 import { App, PluginSettingTab, Setting } from "obsidian";
 import { setEqual } from "./utils";
 import { warn } from "console";

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -12,7 +12,7 @@ import { FitSync } from './fitSync';
 import { Fit } from './fit';
 import { Vault } from 'obsidian';
 import { FakeLocalVault, FakeRemoteVault } from './testUtils';
-import { FitSettings, LocalStores } from '../main';
+import { FitSettings, LocalStores } from '@main';
 import { VaultError } from './vault';
 import { fitLogger } from './logger';
 import { FileContent } from './util/contentEncoding';

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -1,7 +1,7 @@
 import { Fit } from "./fit";
 import { FileChange, FileClash, FileStates } from "./util/changeTracking";
 import { extractExtension } from "./utils";
-import { LocalStores } from "main";
+import { LocalStores } from "@main";
 import FitNotice from "./fitNotice";
 import { SyncResult, SyncErrors, SyncError } from "./syncResult";
 import { fitLogger } from "./logger";

--- a/src/util/asyncMonitoring.test.ts
+++ b/src/util/asyncMonitoring.test.ts
@@ -1,9 +1,9 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {withSlowOperationMonitoring} from './asyncMonitoring';
-import {fitLogger} from '../logger';
+import {fitLogger} from '@/logger';
 
 // Mock fitLogger
-vi.mock('../logger', () => ({
+vi.mock('@/logger', () => ({
 	fitLogger: {
 		log: vi.fn()
 	}

--- a/src/util/asyncMonitoring.ts
+++ b/src/util/asyncMonitoring.ts
@@ -1,4 +1,4 @@
-import {fitLogger} from '../logger';
+import {fitLogger} from '@/logger';
 
 /**
  * Monitors a promise and logs a single warning if it takes longer than expected.

--- a/src/util/filePath.ts
+++ b/src/util/filePath.ts
@@ -13,7 +13,7 @@
  *   if (FilePath.isHidden(path)) { ... }
  */
 
-import { fitLogger } from '../logger';
+import { fitLogger } from '@/logger';
 
 /**
  * Branded type for normalized file paths

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,28 @@
 {
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "module": "ESNext",
-    "target": "ES6",
-    "allowJs": true,
-    "noImplicitAny": true,
-    "moduleResolution": "node",
-    "importHelpers": true,
-    "isolatedModules": true,
-	"strictNullChecks": true,
-    "lib": [
-      "DOM",
-      "ES5",
-      "ES6",
-      "ES7"
-    ]
-  },
-  "include": [
-    "**/*.ts"
-  ]
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"paths": {
+			"@/*": ["./src/*"],
+			"@main": ["./main"]
+		},
+		"inlineSourceMap": true,
+		"inlineSources": true,
+		"module": "ESNext",
+		"target": "ES6",
+		"allowJs": true,
+		"noImplicitAny": true,
+		"moduleResolution": "bundler",
+		"importHelpers": true,
+		"isolatedModules": true,
+		"strictNullChecks": true,
+		"lib": [
+			"DOM",
+			"ES5",
+			"ES6",
+			"ES7"
+		]
+	},
+	"include": [
+		"**/*.ts"
+	]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,8 @@ import path from 'path';
 export default defineConfig({
 	resolve: {
 		alias: {
+			'@': path.resolve(__dirname, 'src'),
+			'@main': path.resolve(__dirname, 'main.ts'),
 			'obsidian': path.resolve(__dirname, 'src/__mocks__/obsidian.ts'),
 			'@octokit/core': path.resolve(__dirname, 'src/__mocks__/@octokit/core.ts'),
 			'@octokit/plugin-retry': path.resolve(__dirname, 'src/__mocks__/@octokit/plugin-retry.ts'),


### PR DESCRIPTION
- Fix deprecated moduleResolution and baseUrl in tsconfig.json
- Configure paths aliases for `@/*` and `@main`

---

<!-- kody-pr-summary:start -->
This pull request updates the TypeScript configuration and refactors import paths across the project to address build warnings and improve module resolution.

Key changes include:
*   **`tsconfig.json` updates:**
    *   Introduced path aliases: `@/` now maps to the `src/` directory, and `@main` maps to the `main.ts` file.
    *   Changed the `moduleResolution` strategy from `node` to `bundler`.
*   **Import path refactoring:** All relevant import statements throughout the codebase have been updated to utilize the new `@/` and `@main` aliases, replacing previous relative or direct paths (e.g., `src/module`, `../module`, `main`).

These modifications enhance the build process by resolving TypeScript configuration warnings and providing more robust and concise import paths.
<!-- kody-pr-summary:end -->