### PR TITLE
perf: Optimize GitHub API calls for fetching commit/tree SHAs

### DIFF
--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -63,7 +63,8 @@ describe("RemoteGitHubVault", () => {
 						"file2.txt": BLOB3_SHA
 						// Note: directory is excluded
 					},
-					commitSha: COMMIT123_SHA
+					commitSha: COMMIT123_SHA,
+					treeSha: TREE456_SHA
 				});
 			});
 
@@ -79,7 +80,8 @@ describe("RemoteGitHubVault", () => {
 
 				expect(result).toEqual({
 					state: {},
-					commitSha: COMMIT123_SHA
+					commitSha: COMMIT123_SHA,
+					treeSha: EMPTY_TREE_SHA
 				});
 			});
 
@@ -179,14 +181,15 @@ describe("RemoteGitHubVault", () => {
 				// Read once to populate cache.
 				await vault.readFromSource();
 
-				// Second read is from cache.
-				fakeOctokit.simulateError("GET /repos/{owner}/{repo}/commits/{ref}",
+				// Second read uses cache (only calls commits API to check for changes, not tree API)
+				fakeOctokit.simulateError("GET /repos/{owner}/{repo}/git/trees/{tree_sha}",
 					new Error("Shouldn't reach here if reading from cache"));
 				const result = await vault.readFromSource();
 
 				expect(result).toEqual({
 					state: { "test.md": BLOB123_SHA },
-					commitSha: COMMIT123_SHA
+					commitSha: COMMIT123_SHA,
+					treeSha: TREE456_SHA
 				});
 			});
 
@@ -201,7 +204,8 @@ describe("RemoteGitHubVault", () => {
 				const result1 = await vault.readFromSource();
 				expect(result1).toEqual({
 					state: { "file1.md": BLOB1_SHA },
-					commitSha: COMMIT123_SHA
+					commitSha: COMMIT123_SHA,
+					treeSha: TREE456_SHA
 				});
 
 				// Simulate remote change - new commit with different tree
@@ -218,7 +222,8 @@ describe("RemoteGitHubVault", () => {
 						"file1.md": BLOB2_SHA,
 						"file2.md": BLOB3_SHA
 					},
-					commitSha: COMMIT456_SHA
+					commitSha: COMMIT456_SHA,
+					treeSha: "tree789",
 				});
 			});
 		});

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -16,10 +16,11 @@ type VaultReadResultMap = {
 	"local": {
 		state: FileStates;
 	};
-	/** Remote vault result - includes commit SHA */
+	/** Remote vault result - includes commit SHA and tree SHA */
 	"remote": {
 		state: FileStates;
 		commitSha: CommitSha;
+		treeSha: TreeSha;
 	};
 };
 


### PR DESCRIPTION
Replace 2 API calls per sync (`/repos/{owner}/{repo}/git/ref/{branch}` for commit SHA + `/repos/{owner}/{repo}/commits/{commitSha}` for tree SHA) with a single call `/repos/{owner}/{repo}/commits/{branch}` for both commit SHA and tree SHA.

---

<!-- kody-pr-summary:start -->
This pull request optimizes GitHub API calls for fetching remote vault state, specifically targeting the retrieval of commit and tree SHAs.

Key changes include:

*   **Reduced API Calls:** The `RemoteGitHubVault` now fetches the latest commit SHA and its corresponding tree SHA in a single API call (`GET /repos/{owner}/{repo}/commits/{branch}`). Previously, this required two separate sequential calls: one to get the branch reference's commit SHA (`GET /repos/{owner}/{repo}/git/ref/{ref}`) and another to get the tree SHA from that commit (`GET /repos/{owner}/{repo}/commits/{ref}`).
*   **Performance Improvement:** This change reduces the number of sequential GitHub API calls required for a remote cache miss from three to two, improving sync performance.
*   **Updated Data Structure:** The `readFromSource` method and the `VaultReadResult` type for remote vaults now consistently return both the `commitSha` and `treeSha`.
*   **Documentation and Test Updates:** The `sync-logic.md` documentation has been updated to reflect the new, more efficient API call strategy and the reduced call count. Unit tests for `RemoteGitHubVault` and `FakeOctokit` have been adjusted to align with the new API call patterns and the inclusion of `treeSha` in the results.
<!-- kody-pr-summary:end -->