### PR TITLE
fix: per-file error messaging

### DIFF
--- a/src/vault.ts
+++ b/src/vault.ts
@@ -82,7 +82,11 @@ export class VaultError extends Error {
 	constructor(
 		public type: VaultErrorType,
 		message: string,
-		public details?: { originalError?: unknown }
+		public details?: {
+			originalError?: unknown;
+			failedPaths?: string[];
+			errors?: Array<{ path: string; error: unknown }>;
+		}
 	) {
 		super(message);
 		this.name = 'VaultError';
@@ -90,7 +94,11 @@ export class VaultError extends Error {
 
 	// Generic factory helper
 	private static create(type: VaultErrorType) {
-		return (message: string, details?: { originalError?: unknown }) =>
+		return (message: string, details?: {
+			originalError?: unknown;
+			failedPaths?: string[];
+			errors?: Array<{ path: string; error: unknown }>;
+		}) =>
 			new VaultError(type, message, details);
 	}
 


### PR DESCRIPTION
Make sure to include file paths in the error messaging if one particular file has errors during a sync

---

<!-- kody-pr-summary:start -->
This pull request enhances error reporting for file synchronization by providing more detailed, per-file error messages.

Key changes include:
- **Detailed Error Messages**: When file operations (reading, writing, or deleting) fail during synchronization, the system now collects and reports the specific paths of the files that encountered issues.
- **Improved Error Context**: The `VaultError` class has been extended to include `failedPaths` and associated `errors` in its details, allowing for richer error information.
- **Robust Batch Processing**: File operations in `LocalVault` and `FakeLocalVault` now use `Promise.allSettled` instead of `Promise.all`. This ensures that all file operations are attempted, even if some fail, and all individual failures are collected before reporting.
- **Remote Error Path Attribution**: For remote operations, file paths are now attached to errors to provide context when a remote operation fails for a specific file.
- **Enhanced User Feedback**: The sync failure notice displayed to the user will now include a list of up to three failed file paths, or a summary if more files failed, making it easier to diagnose and resolve sync issues related to specific files.
- **Comprehensive Testing**: New test cases have been added to verify that per-file read and write failures, both local and remote, are correctly captured and reported with detailed error messages.
<!-- kody-pr-summary:end -->