### PR TITLE
fix(#153): unhelpful "Folder already exists" error message for sync to local

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -829,6 +829,28 @@ lastFetchedRemoteSha = {
 
 **Recovery:** All operations are idempotent, safe to retry
 
+### File-at-Folder-Path Conflicts
+
+**Scenario:** A file exists where a folder is needed for nested path creation
+
+**Example from Issue #153:**
+- Conflict file created at `_fit/.obsidian` (a **file**, not folder)
+- Next sync tries to write `_fit/.obsidian/workspace.json`
+- System needs `_fit/.obsidian` to be a folder
+
+**Problem:**
+Obsidian's `getAbstractFileByPath()` returns truthy for both files and folders, causing naive existence checks to miss type mismatches.
+
+**Original Error:**
+"Error: Failed to write to _fit/.obsidian/workspace.json: Folder already exists."
+
+This confusing message comes from Obsidian's Vault API when `createBinary()` finds a file blocking the folder path.
+
+**Fix:**
+`ensureFolderExists()` now validates type with `instanceof TFile` / `instanceof TFolder` checks, explicitly failing fast with clear error message when a file blocks folder creation.
+
+**Related:** PR #108 (race condition fix)
+
 ### Encoding Corruption (Issue #51)
 
 **Scenario:** Filenames with non-ASCII characters (Turkish, etc.) get corrupted during sync on Windows


### PR DESCRIPTION
Fixes #153 (at least the objective bug part).

---

<!-- kody-pr-summary:start -->
This pull request addresses an issue where syncing to the local vault could result in a misleading "Folder already exists" error message.

**Problem:**
When the system attempted to create a nested folder structure (e.g., `_fit/.obsidian/workspace.json`), but an intermediate path (e.g., `_fit/.obsidian`) was occupied by a *file* instead of a *folder*, Obsidian's `getAbstractFileByPath()` method would incorrectly report that the path existed. This led to a confusing error message from the Obsidian Vault API, stating "Folder already exists," even though the conflict was due to a file blocking the folder path.

**Solution:**
The `ensureFolderExists` utility function has been enhanced to explicitly validate the type of existing entries. Before attempting to create a folder, it now checks:
1. If a file already exists at the target folder path (`instanceof TFile`), it throws a clear and specific error: "Cannot create folder at [path]: a file already exists at this path."
2. If a folder already exists at the path (`instanceof TFolder`), it proceeds without attempting to create it.

This change provides a more accurate and helpful error message to the user, preventing confusion and guiding them to resolve the file-at-folder-path conflict.

**Key Changes:**
- Modified `src/localVault.ts` to add explicit `TFile` and `TFolder` type checks within `ensureFolderExists`.
- Added new test cases in `src/localVault.test.ts` to verify the correct error handling for file-at-folder-path conflicts and successful folder creation when the path is clear.
- Updated `docs/sync-logic.md` to document the "File-at-Folder-Path Conflicts" scenario, the original problem, and the implemented fix.
<!-- kody-pr-summary:end -->