### PR TITLE
dev: fix .editorconfig to not force tab sizes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,13 +13,10 @@ trim_trailing_whitespace = true
 # TypeScript/JavaScript
 [*.{ts,js,mjs}]
 indent_style = tab
-indent_size = 4
-tab_width = 4
 
 # JSON
 [*.json]
 indent_style = tab
-indent_size = 4
 
 # YAML
 [*.{yml,yaml}]


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Modifies the `.editorconfig` file to remove explicit `indent_size` and `tab_width` settings for TypeScript/JavaScript (`.ts`, `.js`, `.mjs`) and JSON (`.json`) files. This change prevents the configuration from forcing a specific tab size (previously 4 spaces) for these file types, while still enforcing the use of tabs for indentation.
<!-- kody-pr-summary:end -->