### PR TITLE
Fix LocalVault to handle unindexed files (hidden files)

### DIFF
--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -45,6 +45,18 @@ const text = new TextDecoder('utf-8', { fatal: true }).decode(arrayBuffer);
 - **Browser support:** Universal
 - **Note:** Only handles Latin1 strings, use with TextEncoder/TextDecoder for UTF-8
 
+**⚠️ CRITICAL: Avoid spread operator with large Uint8Arrays**
+
+```typescript
+// ❌ STACK OVERFLOW for arrays > ~128KB
+const str = String.fromCharCode(...uint8Array);
+
+// ✅ SAFE: Use Array.from or iterate
+const str = Array.from(uint8Array, byte => String.fromCharCode(byte)).join('');
+```
+
+**Why:** JavaScript engines limit function arguments (~128,000). Spreading large arrays exceeds this limit, causing "Maximum call stack size exceeded" errors. This applies to ANY function call with spread on large arrays, not just `String.fromCharCode()`.
+
 ### ✅ Obsidian API Functions
 
 **Status:** Safe - Cross-platform guaranteed by Obsidian

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -134,6 +134,7 @@ if (file && file instanceof TFile) {
 }
 
 // File not in index - use adapter (handles hidden files)
+// Note: wrap in try-catch to handle file-not-found and I/O errors
 const arrayBuffer = await vault.adapter.readBinary(path);
 // ... decode as needed
 ```

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -343,6 +343,7 @@ export class FitSync implements IFitSync {
 		const currentShas = new Map<string, BlobSha>();
 		for (const path of pathsNeedingShaCheck) {
 			try {
+				// readFileContent now handles both indexed and unindexed files (hidden files)
 				const content = await this.fit.localVault.readFileContent(path);
 				const sha = await LocalVault.fileSha1(path, content);
 				currentShas.set(path, sha);

--- a/src/localVault.test.ts
+++ b/src/localVault.test.ts
@@ -713,8 +713,10 @@ describe('LocalVault', () => {
 
 			// Update the binary file
 			const newBinaryData = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0]); // JPEG header
+			// Convert to base64 without stack overflow (avoid spread operator for large arrays)
+			const binaryString = Array.from(newBinaryData, byte => String.fromCharCode(byte)).join('');
 			const result = await localVault.applyChanges(
-				[{ path: '.image-cache.png', content: FileContent.fromBase64(btoa(String.fromCharCode(...newBinaryData))) }],
+				[{ path: '.image-cache.png', content: FileContent.fromBase64(btoa(binaryString)) }],
 				[]
 			);
 

--- a/src/localVault.ts
+++ b/src/localVault.ts
@@ -349,8 +349,11 @@ export class LocalVault implements IVault<"local"> {
 
 				if (existsOnDisk) {
 					// File exists but not in index - use adapter to modify
-					const dataToWrite = isPlaintext ? rawContent.content : new TextDecoder().decode(contentToArrayBuffer(content));
-					await this.vault.adapter.write(path, dataToWrite);
+					if (isPlaintext) {
+						await this.vault.adapter.write(path, rawContent.content);
+					} else {
+						await this.vault.adapter.writeBinary(path, contentToArrayBuffer(content));
+					}
 					changeType = 'MODIFIED';
 				} else {
 					// File doesn't exist - create new

--- a/src/util/obsidianHelpers.ts
+++ b/src/util/obsidianHelpers.ts
@@ -10,39 +10,21 @@ export function arrayBufferToContent(buffer: ArrayBuffer): Base64Content {
 }
 
 /**
- * Read file content from Obsidian vault with binary detection.
+ * Decode ArrayBuffer to FileContent with binary detection.
  *
  * Strategy:
- * 1. Read raw bytes via readBinary() (reliable on all platforms)
+ * 1. Check first ~8KB for null bytes (Git's binary detection heuristic)
  * 2. Try UTF-8 decoding with fatal:true
  *    - Success: return as plaintext
  *    - Throws: return as base64 (binary file)
  *
- * The fatal:true flag efficiently detects binary content in one pass by throwing
- * on null bytes (0x00) or invalid UTF-8 sequences, eliminating need for separate
- * null byte scanning.
+ * The fatal:true flag efficiently detects binary content by throwing on
+ * null bytes (0x00) or invalid UTF-8 sequences.
  *
- * Prevents corruption from vault.read() succeeding on binary files (issue #156).
- *
- * @param vault - Obsidian Vault instance
- * @param path - Path to the file to read
+ * @param arrayBuffer - Raw file bytes
  * @returns FileContent with appropriate encoding
  */
-export async function readFileContent(
-	vault: Vault,
-	path: string
-): Promise<FileContent> {
-	const file = vault.getAbstractFileByPath(path);
-	if (!file) {
-		throw new Error(`File not found: ${path}`);
-	}
-	if (!(file instanceof TFile)) {
-		throw new Error(`Path is not a file: ${path}`);
-	}
-
-	// Read raw bytes (reliable on all platforms, unlike vault.read())
-	const arrayBuffer = await vault.readBinary(file);
-
+export function decodeFileContent(arrayBuffer: ArrayBuffer): FileContent {
 	// Check first ~8KB for null bytes (0x00) - Git's proven binary detection heuristic
 	// Null bytes are valid UTF-8 (U+0000) but reliably indicate binary files
 	const bytes = new Uint8Array(arrayBuffer.slice(0, Math.min(8192, arrayBuffer.byteLength)));
@@ -63,4 +45,48 @@ export async function readFileContent(
 		const base64 = arrayBufferToBase64(arrayBuffer);
 		return FileContent.fromBase64(base64);
 	}
+}
+
+/**
+ * Read file content from Obsidian vault with binary detection.
+ *
+ * Prevents corruption from vault.read() succeeding on binary files (issue #156).
+ *
+ * @param vault - Obsidian Vault instance
+ * @param path - Path to the file to read
+ * @returns FileContent with appropriate encoding
+ */
+export async function readFileContent(
+	vault: Vault,
+	path: string
+): Promise<FileContent> {
+	// Try indexed read first (faster if file is in vault index)
+	// Note: getAbstractFileByPath() returns null for hidden files even when they exist
+	// See docs/api-compatibility.md "Reading Untracked Files"
+	const file = vault.getAbstractFileByPath(path);
+
+	let arrayBuffer: ArrayBuffer;
+
+	if (file) {
+		// File found in vault index
+		if (!(file instanceof TFile)) {
+			throw new Error(`Path is not a file: ${path}`);
+		}
+		// Read raw bytes (reliable on all platforms, unlike vault.read())
+		arrayBuffer = await vault.readBinary(file);
+	} else {
+		// File not in index - try reading directly from adapter
+		// This handles hidden files that Obsidian doesn't track
+		try {
+			arrayBuffer = await vault.adapter.readBinary(path);
+		} catch (error) {
+			// Adapter read failed - could be missing file, permissions, I/O error, etc.
+			// Re-throw with context but preserve original error message
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`Failed to read ${path}: ${message}`);
+		}
+	}
+
+	// Decode the content (same path for both indexed and unindexed files)
+	return decodeFileContent(arrayBuffer);
 }


### PR DESCRIPTION
…using vault.adapter for read/write/delete operations

---

<!-- kody-pr-summary:start -->
This pull request enhances LocalVault's file handling to correctly manage files that are present on the filesystem but are not indexed by Obsidian, such as "hidden files" (e.g., `.gitignore`, `.editorconfig`).

Previously, operations on these unindexed files could fail because Obsidian's `vault.getAbstractFileByPath()` does not return them.

Key changes include:
-   **Robust File Reading:** The `readFileContent` utility now first attempts to read files via Obsidian's vault index. If a file is not found in the index (as is common for hidden files), it falls back to reading the file directly from the filesystem using Obsidian's adapter API.
-   **Comprehensive File Operations:** `LocalVault`'s `applyChanges` and `deleteFile` methods have been updated to detect and interact with unindexed files. If a file is not in the vault index, these methods now use the adapter API for modification and deletion, ensuring full CRUD support for these files, **including correctly distinguishing between plaintext and binary content when writing via the adapter.**
-   **Robust Binary Data Conversion:** A critical safeguard has been implemented and documented to prevent stack overflow errors when converting large `Uint8Arrays` to strings (e.g., for base64 encoding). This involves explicitly avoiding the spread operator (`...`) with `String.fromCharCode()` in favor of safer, iterative methods like `Array.from`, ensuring reliable and uncorrupted handling of binary file content during all operations, particularly when writing via the adapter.
-   **Improved Baseline Tracking:** This functionality is critical for accurate baseline SHA tracking of untracked files, preventing unnecessary sync conflicts for files that might be modified remotely.
-   **Enhanced Test Coverage:** New test cases and a `FakeObsidianVault` implementation have been added to rigorously verify the correct handling of hidden files across various operations, **with particular attention to ensuring binary files are handled without corruption.** The `FakeObsidianVault` was also enhanced to more accurately simulate binary file storage and operations.

This ensures that Fit can reliably synchronize all relevant files, including those not explicitly tracked by Obsidian's internal index.
<!-- kody-pr-summary:end -->