### PR TITLE
cleanup(#180): Minor fixes after InputSuggest change

### DIFF
--- a/src/util/obsidianHelpers.ts
+++ b/src/util/obsidianHelpers.ts
@@ -109,8 +109,7 @@ export class GitHubOwnerSuggest extends AbstractInputSuggest<string> {
 
 	constructor(
 		app: App,
-		inputEl: HTMLInputElement,
-		private getSuggestionsCallback: () => string[]
+		inputEl: HTMLInputElement
 	) {
 		super(app, inputEl);
 		this.inputEl = inputEl;


### PR DESCRIPTION
Remove unused getSuggestionsCallback param and suppress 404 logging.

---

<!-- kody-pr-summary:start -->
This pull request introduces minor fixes related to an `InputSuggest` change and improves error logging in the settings.

Key changes include:
*   **Refactored `GitHubOwnerSuggest`:** The `GitHubOwnerSuggest` constructor has been simplified by removing the `getSuggestionsCallback` parameter, indicating a change in how suggestions are provided to this input component.
*   **Suppressed Expected 404 Errors:** The system now prevents logging of 404 "remote not found" errors when attempting to fetch branches in the settings. These errors are expected when a user is typing an incomplete repository name and were previously causing unnecessary log entries. Only unexpected errors will continue to be logged.
<!-- kody-pr-summary:end -->