### PR TITLE
Add subsection in doc on how to trigger sync on Obsidian Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ See [Common Issues](#common-issues) below for detailed conflict resolution steps
 - It is advised to use a new repo for syncing an existing vault, to minimize the chance of file name conflict on the first sync
 - If your existing vault or repo is large, the initial sync would take longer and require a good internet connection
 
+### Manually trigger sync on Obsidian mobile
+
+related issue: [#190](https://github.com/joshuakto/fit/issues/190)
+
+On Obsidian mobile, linking sync to a hotkey which requires the presence of a
+keyboard is not an ideal approach to manually trigger sync. A more intuitive
+set of procedures are:
+
+- Open any repository with FIT configured
+- Swipe down from anywhere on the screen to open command menu
+- Search for "Fit: Fit Sync" and click to sync
+
+Alternative: "Fit Sync" can be pinned to the ribbon menu from "Setting >
+Appearance > Interface > Ribbon menu configuration"
+
+
 ## 🔒 Security
 
 The FIT maintainers make every effort to protect your security and protect against data loss. However, mistakes can happen. Users are highly recommended to do a security review of the code of this project before trusting it with their data. You could use an AI tool for that such as Claude Code.


### PR DESCRIPTION
Add a subsection in README.md on recommended apporaches to trigger sync on Obsidian Mobile.

I found that using the drop-down command menu is the most used way of triggering sync for me. The command will very likely to stays on top if it is commonly used.

<img width="1169" height="1404" alt="image" src="https://github.com/user-attachments/assets/4beb3331-f795-4ff0-95c6-f297c28f59ac" />


---

<!-- kody-pr-summary:start -->
Adds a new subsection to the `README.md` documentation titled "Manually trigger sync on Obsidian mobile". This section provides instructions for Obsidian mobile users on how to initiate a Fit sync, addressing the limitation of hotkeys on mobile devices. It outlines two methods: using the command menu by swiping down and searching for "Fit: Fit Sync", or pinning "Fit Sync" to the ribbon menu.
<!-- kody-pr-summary:end -->