### PR TITLE
fix: remove unsupported Buffer and process usages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,19 @@ export default [
 		},
 	},
 	{
+		// Ban Node.js-only globals in production source — Obsidian mobile has no Node.js runtime.
+		// Test/config files are excluded since they legitimately run in Node.
+		files: ['src/**/*.ts'],
+		ignores: ['src/**/*.test.ts', 'src/**/*.e2e.ts', 'src/__mocks__/**', 'src/testUtils.ts'],
+		rules: {
+			'no-restricted-globals': ['error',
+				{ name: 'Buffer', message: 'Buffer is Node.js-only. Use TextEncoder/arrayBufferToBase64 instead.' },
+				{ name: 'require', message: 'require() is Node.js-only. Use ES module imports.' },
+				{ name: 'process', message: 'process is Node.js-only. Not available on Obsidian mobile.' },
+			],
+		},
+	},
+	{
 		// Test-related files: Allow 'any' type for mocking external libraries
 		// Covers: test files, mock implementations, test utilities, and test setup
 		files: ['**/*.test.ts', '**/__mocks__/**/*.ts', '**/testUtils.ts', '**/vitest.setup.ts'],

--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -23,9 +23,6 @@ export function init(p: FitPlugin) {
 }
 
 export function isEnabled(): boolean {
-	// If this is a test, disable encryption and prevent
-	// errors due to an uninitialized `plugin`
-	if (process.env.NODE_ENV === 'test') return false;
 	return plugin.settings.encryptionPassword !== "";
 }
 

--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -9,6 +9,7 @@ import { FakeOctokit } from "./testUtils";
 import { __setMockOctokitInstance } from "./__mocks__/@octokit/core";
 import { FileContent } from "./util/contentEncoding";
 import { fitLogger } from "./logger";
+import { init as initEncryption } from "./encryption";
 
 const COMMIT123_SHA = "commit123" as CommitSha;
 const COMMIT456_SHA = "commit456" as CommitSha;
@@ -26,6 +27,7 @@ describe("RemoteGitHubVault", () => {
 	beforeEach(() => {
 		// Suppress logging to reduce test noise
 		vi.spyOn(fitLogger, 'log').mockImplementation(() => {});
+		initEncryption({ settings: { encryptionPassword: '' } } as any);
 
 		fakeOctokit = new FakeOctokit("testowner", "testrepo", "main");
 		__setMockOctokitInstance(fakeOctokit);

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -398,14 +398,13 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			let userWarning: string | undefined;
 
 			if (suspiciousMatches.length > 0) {
-				// For diagnostic logging, convert strings to UTF-8 byte arrays
-				// Using Buffer (Node.js/Electron API) which is available in Obsidian desktop & mobile
+				const enc = new TextEncoder();
 				const details = suspiciousMatches.map(({intended, echoed, pattern}) => ({
 					intended,
 					echoed,
 					pattern,
-					intendedBytes: Array.from(Buffer.from(intended, 'utf8')),
-					echoedBytes: Array.from(Buffer.from(echoed, 'utf8'))
+					intendedBytes: Array.from(enc.encode(intended)),
+					echoedBytes: Array.from(enc.encode(echoed))
 				}));
 
 				fitLogger.log(


### PR DESCRIPTION
Fixes #243

---

<!-- kody-pr-summary:start -->
This pull request removes unsupported Node.js-specific APIs (`Buffer` and `process`) from the plugin's production code to enhance compatibility, particularly with Obsidian mobile environments which lack a Node.js runtime.

Key changes include:
*   **Replaced `Buffer` usage with `TextEncoder`**: In `RemoteGitHubVault`, `Buffer.from()` calls used for converting strings to UTF-8 byte arrays have been replaced with `TextEncoder().encode()`, a web-standard API.
*   **Removed `process.env.NODE_ENV` check**: The `isEnabled` function in `encryption.ts` no longer relies on `process.env.NODE_ENV` to automatically disable encryption during tests.
*   **Updated tests**: Tests for `RemoteGitHubVault` now explicitly initialize encryption with an empty password in `beforeEach` to maintain the expected disabled state for testing, aligning with the removal of the `process.env.NODE_ENV` check.
*   **Added ESLint rules**: New ESLint rules have been introduced to ban `Buffer`, `require`, and `process` globals in production source files (`src/**/*.ts`), preventing future accidental use of these Node.js-only APIs.
<!-- kody-pr-summary:end -->