### PR TITLE
fix: avoid showing "Check internet" for low-level errors

### DIFF
--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -10,6 +10,7 @@ import { __setMockOctokitInstance } from "./__mocks__/@octokit/core";
 import { FileContent } from "./util/contentEncoding";
 import { fitLogger } from "./logger";
 import { init as initEncryption } from "./encryption";
+import * as Encryption from "./encryption";
 
 const COMMIT123_SHA = "commit123" as CommitSha;
 const COMMIT456_SHA = "commit456" as CommitSha;
@@ -42,8 +43,8 @@ describe("RemoteGitHubVault", () => {
 	});
 
 	afterEach(() => {
-		// Reset mock to prevent test pollution
 		__setMockOctokitInstance(null);
+		vi.restoreAllMocks();
 	});
 
 	describe("Read Operations", () => {
@@ -104,6 +105,21 @@ describe("RemoteGitHubVault", () => {
 					"_fit/file2.md": BLOB2_SHA,
 					"file3.md": BLOB3_SHA
 				});
+			});
+
+			it("should not wrap missing-global errors as network errors", async () => {
+				// Simulates a mobile runtime where an assumed global (e.g. Buffer, TextEncoder)
+				// is missing — the resulting ReferenceError should propagate as-is rather than
+				// being swallowed and misreported as a network failure.
+				const mockTree: TreeNode[] = [
+					{ path: "file1.md", type: "blob", mode: "100644", sha: BLOB1_SHA }
+				];
+				fakeOctokit.setupInitialState(COMMIT123_SHA, TREE456_SHA, mockTree);
+				vi.spyOn(Encryption, 'isEnabled').mockImplementation(() => {
+					throw new ReferenceError('Encryption is not defined');
+				});
+
+				await expect(vault.readFromSource()).rejects.toBeInstanceOf(ReferenceError);
 			});
 
 			it("should propagate errors from getCommitTreeSha", async () => {

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -119,7 +119,15 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		error: unknown,
 		notFoundStrategy: 'repo' | 'repo-or-branch' | 'ignore'
 	): Promise<never> {
-		const errorObj = error as { status?: number | null; response?: unknown; message?: string };
+		const errorObj = error as { status?: number | null; response?: unknown; message?: string; request?: unknown };
+
+		// Non-Octokit errors (plugin bugs, ReferenceErrors, etc.) — re-throw without misclassifying as network.
+		// Octokit errors always have a numeric status (HTTP errors) or a 'request' property (network failures).
+		const hasNumericStatus = typeof errorObj.status === 'number';
+		const hasOctokitRequest = error != null && typeof error === 'object' && 'request' in error;
+		if (!hasNumericStatus && !hasOctokitRequest) {
+			throw error;
+		}
 
 		// No status or no response indicates network/connectivity issue
 		if (errorObj.status === null || errorObj.status === undefined || !errorObj.response) {
@@ -734,14 +742,14 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			// Only include blobs (files), skip trees (directories)
 			if (node.type === "blob" && node.path && node.sha) {
 				let path = node.path;
-				if (Encryption.isEnabled()) {
-					path = await Encryption.decryptPath(path);
-				}
-
 				try {
+					if (Encryption.isEnabled()) {
+						path = await Encryption.decryptPath(path);
+					}
 					// TODO: Should this notice if there's a collision overwriting same path?
 					state[path] = node.sha;
 				} catch (error) {
+					if (error instanceof ReferenceError) throw error;
 					failedPaths.push({ path: path, error });
 					fitLogger.log(`❌ [RemoteVault] Failed to process file: ${path}`, error);
 				}

--- a/src/remotes/githubConnection.ts
+++ b/src/remotes/githubConnection.ts
@@ -316,7 +316,15 @@ export class GitHubConnection {
 		error: unknown,
 		context?: { owner?: string; repo?: string }
 	): Promise<never> {
-		const errorObj = error as { status?: number | null; response?: unknown; message?: string; };
+		const errorObj = error as { status?: number | null; response?: unknown; message?: string; request?: unknown };
+
+		// Non-Octokit errors (plugin bugs, ReferenceErrors, etc.) — re-throw without misclassifying as network.
+		// Octokit errors always have a numeric status (HTTP errors) or a 'request' property (network failures).
+		const hasNumericStatus = typeof errorObj.status === 'number';
+		const hasOctokitRequest = error != null && typeof error === 'object' && 'request' in error;
+		if (!hasNumericStatus && !hasOctokitRequest) {
+			throw error;
+		}
 
 		// No status or no response indicates network/connectivity issue
 		if (errorObj.status === null || errorObj.status === undefined || !errorObj.response) {


### PR DESCRIPTION
Avoids spurious "Check internet" messaging by looking for Octokit-shaped errors and distinguishing whether they actually indicate a network issue with the vault before propagating as 'network'.

Secondary fix for #243.

---

<!-- kody-pr-summary:start -->
This pull request fixes an issue where low-level, non-network-related errors were being misclassified as network connectivity problems.

Specifically, the changes:
- **Prevent misclassification of non-Octokit errors:** The error handling in `RemoteGitHubVault` and `GitHubConnection` now explicitly checks if an error is an Octokit-specific HTTP/network error (indicated by a numeric status or a `request` property). If it's not, the error is re-thrown directly, preventing it from being incorrectly reported as a network failure (e.g., "Check internet"). This addresses scenarios like `ReferenceError`s that might occur if required global objects (e.g., `Buffer`, `TextEncoder`) are missing in certain JavaScript runtimes.
- **Propagate `ReferenceError`s during encryption:** `ReferenceError`s encountered during the decryption of file paths within `RemoteGitHubVault`'s `readFromSource` method are now explicitly re-thrown, ensuring they are not swallowed or misclassified.
- **Adds a test case:** A new test confirms that `ReferenceError`s are not wrapped as network errors.

These changes ensure that the application provides more accurate error reporting, distinguishing between actual network issues and other underlying runtime problems.
<!-- kody-pr-summary:end -->