### PR TITLE
fix: tighten heuristic for "suspicious filename" logging

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -938,19 +938,12 @@ Corrupted: Same bytes decoded as GBK → "K眉莽眉k"
 - Subsequent syncs see both versions, creating conflicts
 
 **Detection & Logging:**
-FIT includes diagnostic system (v1.4.0-beta.3+) that detects suspicious filename patterns:
-- **Upload detection**: Compares intended paths vs GitHub's echo-back response ([src/remoteGitHubVault.ts](../src/remoteGitHubVault.ts))
-  - Logs: `🔴 [RemoteVault] Encoding corruption detected during upload!`
-  - Shows which files had path mismatches with pattern details
-- **Download detection**: Checks remote files being created against existing local files ([src/localVault.ts](../src/localVault.ts))
-  - Logs: `⚠️ [LocalVault] Suspicious filenames detected during sync!`
-  - Lists matching patterns between remote and local filenames
-- **Pattern matching**: ASCII-sandwich algorithm to find suspicious correspondences ([src/util/pathPattern.ts](../src/util/pathPattern.ts))
+FIT includes a diagnostic system that detects suspicious filename patterns using an ASCII-sandwich algorithm ([src/util/pathPattern.ts](../src/util/pathPattern.ts)): if a wildcard (non-ASCII run) has alphanumeric characters on both sides, two paths sharing that pattern but differing in non-ASCII content are flagged as suspicious.
 
-When detected, FIT:
-1. Logs detailed warnings to debug log (enable in settings)
-2. Shows user notification with link to issue #51
-3. Provides pattern matching details to help identify corrupted filenames
+- **Upload detection** ([src/remoteGitHubVault.ts](../src/remoteGitHubVault.ts)): compares intended paths vs GitHub's echo-back response — ground-truth evidence of corruption. Logs: `🔴 [RemoteVault] Encoding corruption detected during upload!`
+- **Download detection** ([src/localVault.ts](../src/localVault.ts)): checks incoming remote paths against existing local files for suspicious pattern matches. Logs: `⚠️ [LocalVault] Suspicious filenames detected during sync!`
+
+When detected, FIT logs to debug log and shows a user notification with a link to issue #51.
 
 **To help isolate the issue:**
 - Enable debug logging in FIT settings

--- a/src/localVault.ts
+++ b/src/localVault.ts
@@ -491,25 +491,17 @@ export class LocalVault implements IVault<"local"> {
 		options?: { clashPaths?: Set<string> }
 	): Promise<ApplyChangesResult<"local">> {
 		const clashPaths = options?.clashPaths ?? new Set();
-		// Diagnostic logging: detect suspicious filename correspondences (Issue #51)
-		// Check if any files being created have non-ASCII chars and match existing local files
+		// Diagnostic: detect remote paths that share an ASCII-alphanumeric-sandwich pattern
+		// with an existing local file but differ in non-ASCII content (Issue #51).
 		// Note: vault.getFiles() may be unavailable in test mocks
 		const allExistingPaths = this.vault.getFiles?.()?.map(f => f.path) ?? [];
 		const suspiciousWrites: Array<{remote: string, local: string, pattern: string}> = [];
 
 		for (const {path: remotePath} of filesToWrite) {
-			// Only check files with non-ASCII characters that don't already exist
 			if (!/[^\x00-\x7F]/.test(remotePath)) continue;
 			if (this.vault.getAbstractFileByPath(remotePath)) continue;
-
-			// Find correspondences with existing files
-			const matches = findSuspiciousCorrespondences(remotePath, allExistingPaths);
-			for (const match of matches) {
-				suspiciousWrites.push({
-					remote: match.candidate,
-					local: match.existing,
-					pattern: match.pattern
-				});
+			for (const match of findSuspiciousCorrespondences(remotePath, allExistingPaths)) {
+				suspiciousWrites.push({ remote: match.candidate, local: match.existing, pattern: match.pattern });
 			}
 		}
 

--- a/src/util/pathPattern.test.ts
+++ b/src/util/pathPattern.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { toAsciiPattern, detectSuspiciousCorrespondence, findSuspiciousCorrespondences } from './pathPattern';
+
+describe('toAsciiPattern', () => {
+	it('replaces each non-ASCII run with a single wildcard', () => {
+		expect(toAsciiPattern('Küçük.md')).toBe('K*k.md');
+		expect(toAsciiPattern('İstanbul.md')).toBe('*stanbul.md');
+		expect(toAsciiPattern('Merhaba dünya.md')).toBe('Merhaba d*nya.md');
+	});
+
+	it('leaves all-ASCII paths unchanged', () => {
+		expect(toAsciiPattern('test.md')).toBe('test.md');
+		expect(toAsciiPattern('notes/file.md')).toBe('notes/file.md');
+	});
+
+	it('collapses adjacent non-ASCII chars into one wildcard', () => {
+		// ü, ç, ü are three separate non-ASCII chars forming one contiguous run
+		expect(toAsciiPattern('Küçük.md')).toBe('K*k.md');
+	});
+});
+
+describe('detectSuspiciousCorrespondence', () => {
+	it('matches a Turkish filename against its GBK-corrupted version', () => {
+		const result = detectSuspiciousCorrespondence('Küçük.md', 'K眉莽眉k.md');
+		expect(result).not.toBeNull();
+		expect(result?.pattern).toBe('K*k.md');
+	});
+
+	it('returns null for exact matches', () => {
+		expect(detectSuspiciousCorrespondence('Küçük.md', 'Küçük.md')).toBeNull();
+	});
+
+	it('returns null for paths with different ASCII structure', () => {
+		expect(detectSuspiciousCorrespondence('Küçük.md', 'other.md')).toBeNull();
+	});
+
+	it('returns null for all-ASCII paths (no wildcards)', () => {
+		expect(detectSuspiciousCorrespondence('test.md', 'test.md')).toBeNull();
+	});
+
+	// The fix: whitespace/punctuation alone cannot anchor a sandwich
+	it('returns null when the only ASCII between wildcards is whitespace — no false positive for Russian files', () => {
+		// "Письмо Ивану.md" and "Письмо Марии.md" both map to "* *.md"
+		// The space between the two wildcard positions must not count as a sandwich
+		expect(detectSuspiciousCorrespondence('Письмо Ивану.md', 'Письмо Марии.md')).toBeNull();
+	});
+
+	it('returns null when non-ASCII leads with no alphanumeric before the wildcard', () => {
+		// Pattern "*.md" — no alphanumeric before the wildcard
+		expect(detectSuspiciousCorrespondence('あ.md', 'い.md')).toBeNull();
+	});
+
+	it('matches when alphanumeric appears on both sides of a wildcard', () => {
+		// "file ş.md" vs "file 艧.md" → "file *.md" — "e" before *, "m" after *
+		const result = detectSuspiciousCorrespondence('file ş.md', 'file 艧.md');
+		expect(result).not.toBeNull();
+		expect(result?.pattern).toBe('file *.md');
+	});
+});
+
+describe('findSuspiciousCorrespondences', () => {
+	it('finds a corrupted match in a list of paths', () => {
+		const existing = ['notes.md', 'Küçük.md', 'other.md'];
+		const results = findSuspiciousCorrespondences('K眉莽眉k.md', existing);
+		expect(results).toHaveLength(1);
+		expect(results[0].existing).toBe('Küçük.md');
+	});
+
+	it('returns empty array when no suspicious correspondences exist', () => {
+		const existing = ['notes.md', 'other.md'];
+		expect(findSuspiciousCorrespondences('Письмо.md', existing)).toHaveLength(0);
+	});
+
+	it('does not flag Russian files against each other', () => {
+		const existing = ['Письмо Ивану.md'];
+		expect(findSuspiciousCorrespondences('Письмо Марии.md', existing)).toHaveLength(0);
+	});
+});

--- a/src/util/pathPattern.ts
+++ b/src/util/pathPattern.ts
@@ -72,10 +72,10 @@ export function detectSuspiciousCorrespondence(
 		return null;
 	}
 
-	// Must have at least one ASCII-NONASCII-ASCII sandwich
-	// Pattern: non-wildcard, then wildcard, then non-wildcard
-	// Regex: [^*]+\*[^*]+ means "1+ non-wildcards, wildcard, 1+ non-wildcards"
-	if (!/[^*]+\*[^*]+/.test(pattern)) {
+	// Must have at least one wildcard with alphanumeric characters on both sides.
+	// Whitespace and punctuation alone don't count — "* *.md" would be a false positive
+	// for any two non-ASCII-prefixed filenames sharing an extension.
+	if (!/[a-zA-Z0-9][^*]*\*[^*]*[a-zA-Z0-9]/.test(pattern)) {
 		return null;
 	}
 


### PR DESCRIPTION
Improvement for #51 to prevent spam logging from non-suspicious cases.

---

<!-- kody-pr-summary:start -->
This pull request refines the heuristic used by FIT's diagnostic system to detect "suspicious filename patterns," specifically addressing potential false positives related to Issue #51.

The core change tightens the "ASCII-sandwich algorithm" for pattern matching. Previously, the algorithm could flag files as suspicious if their ASCII patterns differed only by non-alphanumeric characters (such as whitespace or punctuation) surrounding a non-ASCII segment. This could lead to incorrect warnings for legitimate filenames that share a common structure but differ in their non-ASCII parts (e.g., "Письмо Ивану.md" vs "Письмо Марии.md").

With this update, a pattern is now considered suspicious only if a wildcard (representing a non-ASCII run) is explicitly "sandwiched" by *alphanumeric* characters. This ensures that the detection focuses more accurately on patterns indicative of actual encoding corruption (like the GBK example "Küçük.md" vs "K眉莽眉k.md").

Key changes include:
-   **Refined Pattern Matching Logic:** The `detectSuspiciousCorrespondence` function in `src/util/pathPattern.ts` has been updated with a more precise regular expression that requires alphanumeric characters to anchor the "sandwich" around a wildcard.
-   **Updated Documentation:** The `docs/sync-logic.md` file has been revised to clearly explain the new "ASCII-alphanumeric-sandwich" algorithm.
-   **New Test Cases:** A new test file `src/util/pathPattern.test.ts` has been added, including specific tests to validate the tightened heuristic and prevent previous false positives.
<!-- kody-pr-summary:end -->