### PR TITLE
fix(#227): handle a few potential sources of undefined content for 'replace' err

### DIFF
--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -186,6 +186,25 @@ describe("RemoteGitHubVault", () => {
 				const content2 = await vault.readFileContent("file2.md");
 				expect(content2).toEqual(FileContent.fromBase64("content2"));
 			});
+
+			it("should give a clear error when blob content is missing, including the encoding the API reported", async () => {
+				const mockTree: TreeNode[] = [
+					{ path: "huge-file.bin", mode: "100644", type: "blob", sha: BLOB1_SHA }
+				];
+				fakeOctokit.setupInitialState(COMMIT123_SHA, TREE456_SHA, mockTree);
+				await vault.readFromSource();
+
+				// Simulate a blob response with no content field — e.g. encoding 'none'
+				// returned by GitHub for unsupported blobs. We don't know the exact cause;
+				// we just want the error to surface the encoding the API reported rather
+				// than crashing with a meaningless TypeError.
+				vi.spyOn(fakeOctokit, 'request').mockResolvedValueOnce({
+					data: { encoding: 'none', sha: BLOB1_SHA, size: 150_000_000 }
+				} as any);
+
+				await expect(vault.readFileContent("huge-file.bin"))
+					.rejects.toThrow(/huge-file\.bin.*none|none.*huge-file\.bin/);
+			});
 		});
 
 		describe("Caching", () => {

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -251,6 +251,12 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 					file_sha: blobSha,
 					headers: this.headers
 				});
+			if (typeof blob.content !== 'string') {
+				throw new Error(
+					`Cannot read '${path}': blob content is ${typeof blob.content} (encoding: '${blob.encoding ?? 'unknown'}'). ` +
+					`GitHub may not support this blob format.`
+				);
+			}
 			let content = blob.content;
 			if (Encryption.isEnabled()) {
 				content = await Encryption.decryptContent(content);

--- a/src/util/contentEncoding.ts
+++ b/src/util/contentEncoding.ts
@@ -137,6 +137,9 @@ export class FileContent {
 	 * @param content - Base64-encoded string (will be branded as Base64Content)
 	 */
 	static fromBase64(content: string | Base64Content): FileContent {
+		if (typeof content !== 'string') {
+			throw new TypeError(`FileContent.fromBase64: expected a string but got ${typeof content}`);
+		}
 		const normalized = removeLineEndingsFromBase64String(content);
 		return new FileContent({ encoding: 'base64', content: Content.asBase64(normalized) });
 	}


### PR DESCRIPTION
Guard to check if content fields returned from APIs may be null, undefined, or other non-string types before passing it to content handling code that might blow up trying to handle non-string values.

Partial/possible fix for #227

---

<!-- kody-pr-summary:start -->
This pull request addresses potential issues with undefined or non-string content when reading files and processing content.

Key changes include:
-   **Improved GitHub Blob Content Handling**: When fetching file content from GitHub, the system now explicitly checks if the `blob.content` field is a string. If it's not (e.g., `undefined` or `null`), it throws a descriptive error indicating that GitHub might not support the blob format and includes the reported encoding. This prevents generic `TypeError` crashes and provides clearer diagnostics.
-   **Robust `FileContent.fromBase64` Input Validation**: A type check has been added to the `FileContent.fromBase64` method to ensure that the provided content is always a string. If a non-string value is passed, it now throws a `TypeError` to prevent subsequent processing errors.
-   **New Test Case**: A test has been added to verify the improved error handling for GitHub blobs, simulating a scenario where the GitHub API returns an encoding like 'none' without actual content, and asserting that the system provides a clear error message.
<!-- kody-pr-summary:end -->