### PR TITLE
docs: fix outdated statuses about eslint/validation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -138,6 +138,6 @@ Please use your judgement and try to follow conventions from surrounding code to
 
 If you'd like to help set up more automated checking, there are a few quality aspects we don't have automated checks for but would like to:
 
-- [ ] **ESLint rules** for TypeScript strict mode
+- [ ] **ESLint rules** for more known problematic code patterns
 - [ ] **Consistent documentation** to ensure comments and architecture docs stay up-to-date with code changes
 - [ ] **Release automation/validation** to ensure releases are correctly configured & versioned

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -155,23 +155,14 @@ const arrayBuffer = await vault.adapter.readBinary(path);
 
 **Related:** Issue #169 - Baseline tracking for untracked files requires reading hidden files for SHA comparison
 
-## Automated Validation (TODO)
+## Automated Validation
 
 Currently, compatibility issues are caught by:
 1. ✅ **CI test matrix** - Detects missing Node.js APIs at runtime
-2. ⚠️ **Manual code review** - Detects unsafe patterns
+2. ✅ **ESLint `no-restricted-globals`** - Bans non-mobile-compatible `Buffer`, `require`, `process` in plugin code
+3. ⚠️ **Manual code review** - Catches other unsafe patterns
 
-### Future Improvements
-
-**TODO:** Add eslint rule to detect Node.js imports:
-```javascript
-// .eslintrc.js
-rules: {
-  'no-restricted-imports': ['error', {
-    patterns: ['util', 'fs', 'path', 'buffer', 'stream']
-  }]
-}
-```
+### Remaining TODOs
 
 **TODO:** Add eslint rule to detect TextDecoder without fatal:
 ```javascript


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the documentation to reflect the current status of ESLint rules and automated validation.

Key changes include:
*   **`docs/CONTRIBUTING.md`**: The description for desired ESLint rules has been generalized from "TypeScript strict mode" to "more known problematic code patterns."
*   **`docs/api-compatibility.md`**:
    *   The "Automated Validation" section title no longer includes "(TODO)," indicating progress in this area.
    *   `ESLint no-restricted-globals` has been added as an implemented automated validation step (marked with ✅) to ban non-mobile-compatible `Buffer`, `require`, and `process` in plugin code.
    *   The previous "Future Improvements" section, which contained a `TODO` for `no-restricted-imports` rules, has been removed, as the `no-restricted-globals` rule now addresses similar concerns.
    *   Remaining `TODO` items have been reorganized under a new "Remaining TODOs" heading.
<!-- kody-pr-summary:end -->