### PR TITLE
fix: TextDecoder needs fatal:true

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,6 +51,12 @@ export default [
 				{ name: 'require', message: 'require() is Node.js-only. Use ES module imports.' },
 				{ name: 'process', message: 'process is Node.js-only. Not available on Obsidian mobile.' },
 			],
+			'no-restricted-syntax': ['error',
+				{
+					selector: "NewExpression[callee.name='TextDecoder'][arguments.length < 2]",
+					message: "Use new TextDecoder(encoding, { fatal: true }) to prevent silent data corruption on invalid UTF-8.",
+				},
+			],
 		},
 	},
 	{

--- a/src/encryption.ts
+++ b/src/encryption.ts
@@ -14,7 +14,7 @@ import FitPlugin from "@main";
 import { arrayBufferToBase64, base64ToArrayBuffer } from "obsidian";
 
 const encoder = new TextEncoder();
-const decoder = new TextDecoder();
+const decoder = new TextDecoder('utf-8', { fatal: true });
 
 let plugin: FitPlugin;
 


### PR DESCRIPTION
Robustness fix for #265 as follow-up after implementation #212.

Makes decryption fail cleanly with an error on corrupted input instead of the default `fatal:false` behavior of silently substituting malformed data with a replacement character.

Also adds an eslint to require the 2-arg constructor passing `options` (which doesn't technically guarantee code is passing `fatal:true` but in practice makes it very unlikely to just forget since passing options without explicit `fatal` would be very uncommon in practice).

---

<!-- kody-pr-summary:start -->
This pull request addresses potential silent data corruption when decoding text.

Key changes include:
*   **Updated TextDecoder usage:** The `TextDecoder` instance in `src/encryption.ts` has been updated to explicitly use `'utf-8'` encoding and the `{ fatal: true }` option. This ensures that the decoder will throw an error if it encounters invalid UTF-8 sequences, preventing silent replacement of corrupted data.
*   **Added ESLint rule:** A new ESLint rule has been introduced to enforce the use of `fatal: true` with `TextDecoder`. This rule will flag any `TextDecoder` instantiation that does not include the options object (specifically encouraging `new TextDecoder(encoding, { fatal: true })`), thereby preventing future instances of silent data corruption due to invalid UTF-8.
<!-- kody-pr-summary:end -->