### PR TITLE
feat(#92): Respect local .gitignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ NOTE: For security, it's recommended to limit the token scope to only the necess
 **❌ NOT synced (protected paths):**
 - `.obsidian/` folder (Obsidian settings and plugins)
 - `_fit/` folder (conflict resolution area)
-- Hidden files like `.gitignore`, `.env` (not currently supported - see [#92](https://github.com/joshuakto/fit/issues/92) for planned opt-in support)
+- Hidden files like `.env`, `.gitignore` (not synced — see [#92](https://github.com/joshuakto/fit/issues/92) for planned opt-in support)
+  - Note: `.gitignore` **rules** are respected — files matched by your patterns are excluded from sync
 
 ### Conflict handling
 
@@ -107,7 +108,7 @@ You should also take care with security tokens you use to ensure they don't leak
 **Solutions:**
 - Move large files (>20MB) outside your vault before syncing
 - Manually sync large files to GitHub using other tools (to create them and any time they're modified)
-- Add the files to .gitignore to exclude them from sync (once .gitignore is supported, #92)
+- Add the files to `.gitignore` to exclude them from sync
 
 </details>
 

--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -213,7 +213,7 @@ currentLocalSha = {}  // File doesn't exist
 
 ## Path Filtering and Safety
 
-FIT implements two layers of filtering to protect critical files and handle untrackable files safely:
+FIT implements three layers of path filtering:
 
 ### 1. Protected Paths (`shouldSyncPath`) - Never Sync
 
@@ -286,6 +286,34 @@ lastFetchedRemoteSha = { ".gitignore": "abc123" }
 // - User manually resolves if needed
 ```
 
+### 3. Gitignore Patterns (`GitignoreFilter`) - User-Defined Exclusions
+
+- **Filtered by:** `GitignoreFilter` in `LocalVault.readFromSource()`
+- **Applied to:** 💾 Local vault only (before SHA computation)
+- **Reason:** Respect user-defined exclusion rules, consistent with git behavior
+
+**How it works:**
+- Reads `.gitignore` files from the vault root and any ancestor directories of tracked files
+- Uses the `ignore` package for standard gitignore pattern semantics (negation, directory patterns, etc.)
+- Only probes paths derived from the tracked file set — no full filesystem scan
+
+**Behavior:**
+- Files matched by any applicable `.gitignore` are excluded from `localSha` and never pushed
+- Patterns scope correctly: a `build/.gitignore` only affects files under `build/`
+- If no `.gitignore` files exist, this layer is a no-op
+
+**Example:**
+```
+# Root .gitignore
+*.log
+node_modules/
+
+# Result: debug.log and node_modules/pkg/index.js excluded from sync
+#         README.md, src/main.ts included as normal
+```
+
+**Implementation:** [`src/util/gitignore.ts` — `GitignoreFilter`](../src/util/gitignore.ts)
+
 ### Combined Filtering: `.obsidian/` Files
 
 Files in `.obsidian/` are filtered by BOTH:
@@ -302,21 +330,23 @@ Files in `.obsidian/` are filtered by BOTH:
 **Path filtering:**
 - [`Fit.shouldSyncPath()`](../src/fit.ts) - Protected path check
 - [`LocalVault.shouldTrackState()`](../src/localVault.ts) - Hidden file check
+- [`GitignoreFilter`](../src/util/gitignore.ts) - User-defined exclusions (local only)
 - [`FitSync.sync()`](../src/fitSync.ts) - Filters local changes before sync
 - [`FitSync.applyRemoteChanges()`](../src/fitSync.ts) - Handles remote protected/hidden files with safety checks
 
-**Decision flow:**
+**Decision flow (local files):**
 ```mermaid
 flowchart TD
-    Start[File from Remote] --> Protected{shouldSyncPath?}
-    Protected -->|No| SaveClash[📁 Save to _fit/path]
-    Protected -->|Yes| Trackable{shouldTrackState?}
+    Start[Local file] --> Trackable{shouldTrackState?}
+    Trackable -->|No| Skip[Excluded from localSha]
+    Trackable -->|Yes| Gitignore{GitignoreFilter?}
+    Gitignore -->|Ignored| Skip
+    Gitignore -->|Not ignored| Protected{shouldSyncPath?}
+    Protected -->|No| Skip
+    Protected -->|Yes| Tracked[Included in localSha / pushed to remote]
 
-    Trackable -->|No| SaveClash
-    Trackable -->|Yes| Normal[Apply normally]
-
-    SaveClash --> End[Done]
-    Normal --> End
+    Skip --> End[Done]
+    Tracked --> End
 ```
 
 ### Version Migration Safety
@@ -434,7 +464,7 @@ flowchart TD
 **Key Benefits:**
 - **Principled boundaries**: Each phase has clear inputs/outputs
 - **Efficient batching**: Single filesystem stat for all verification needs
-- **Future-proof**: Supports planned features (`.gitignore`, continuous sync, explicit tracking)
+- **Future-proof**: Supports planned features (continuous sync, explicit tracking, full hidden file sync)
 - **Testable**: Phases can be tested independently
 
 **Implementation:** [`FitSync.performSync()` in fitSync.ts](../src/fitSync.ts)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/core": "^7.0.6",
-				"@octokit/plugin-retry": "^8.0.3"
+				"@octokit/plugin-retry": "^8.0.3",
+				"ignore": "^7.0.5"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.39.2",
@@ -1662,6 +1663,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/@eslint/js": {
@@ -3655,16 +3666,6 @@
 				"@typescript-eslint/parser": "^8.53.0",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -11605,6 +11606,16 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/espree": {
 			"version": "10.4.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -13129,10 +13140,10 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-			"dev": true,
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -19352,6 +19363,12 @@
 					"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
 					"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 					"dev": true
+				},
+				"ignore": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+					"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+					"dev": true
 				}
 			}
 		},
@@ -20491,14 +20508,6 @@
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.4.0"
-			},
-			"dependencies": {
-				"ignore": {
-					"version": "7.0.5",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-					"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-					"dev": true
-				}
 			}
 		},
 		"@typescript-eslint/parser": {
@@ -25841,6 +25850,12 @@
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
 					"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 					"dev": true
+				},
+				"ignore": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+					"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+					"dev": true
 				}
 			}
 		},
@@ -26888,10 +26903,9 @@
 			"devOptional": true
 		},
 		"ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-			"dev": true
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
 		},
 		"immediate": {
 			"version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
 	},
 	"dependencies": {
 		"@octokit/core": "^7.0.6",
-		"@octokit/plugin-retry": "^8.0.3"
+		"@octokit/plugin-retry": "^8.0.3",
+		"ignore": "^7.0.5"
 	},
 	"optionalDependencies": {
 		"@wdio/appium-service": "^9.23.0",

--- a/src/localVault.test.ts
+++ b/src/localVault.test.ts
@@ -937,4 +937,52 @@ describe('LocalVault', () => {
 			expect(new TextDecoder().decode(created)).toBe('fake-image');
 		});
 	});
+
+	describe('.gitignore filtering in readFromSource', () => {
+		it('should exclude files matched by root .gitignore', async () => {
+			const fakeVault = new FakeObsidianVault();
+
+			// Set up .gitignore (hidden file, use adapter)
+			await fakeVault.adapter.write('.gitignore', '*.log\nnode_modules/');
+
+			// Set up visible files (use create to add to vault index)
+			await fakeVault.create('README.md', 'readme');
+			await fakeVault.create('debug.log', 'log content');
+			await fakeVault.create('src/main.ts', 'code');
+			await fakeVault.create('node_modules/pkg/index.js', 'module');
+
+			const localVault = new LocalVault(fakeVault as any);
+			const { state } = await localVault.readFromSource();
+
+			expect(Object.keys(state).sort()).toEqual(['README.md', 'src/main.ts']);
+		});
+
+		it('should exclude files matched by nested .gitignore', async () => {
+			const fakeVault = new FakeObsidianVault();
+
+			// Nested .gitignore only affects its directory
+			await fakeVault.adapter.write('build/.gitignore', '*.map\n*.tmp');
+
+			await fakeVault.create('build/app.js', 'code');
+			await fakeVault.create('build/app.js.map', 'sourcemap');
+			await fakeVault.create('src/app.js.map', 'not ignored - no gitignore in src/');
+
+			const localVault = new LocalVault(fakeVault as any);
+			const { state } = await localVault.readFromSource();
+
+			expect(Object.keys(state).sort()).toEqual(['build/app.js', 'src/app.js.map']);
+		});
+
+		it('should include all files when no .gitignore exists', async () => {
+			const fakeVault = new FakeObsidianVault();
+
+			await fakeVault.create('file.log', 'log');
+			await fakeVault.create('file.md', 'doc');
+
+			const localVault = new LocalVault(fakeVault as any);
+			const { state } = await localVault.readFromSource();
+
+			expect(Object.keys(state).sort()).toEqual(['file.log', 'file.md']);
+		});
+	});
 });

--- a/src/localVault.ts
+++ b/src/localVault.ts
@@ -14,6 +14,7 @@ import { BlobSha, computeSha1 } from "./util/hashing";
 import { FilePath, detectNormalizationIssues } from "./util/filePath";
 import { withSlowOperationMonitoring } from "./util/asyncMonitoring";
 import { findSuspiciousCorrespondences } from "./util/pathPattern";
+import { GitignoreFilter } from "./util/gitignore";
 
 /**
  * Helper to process Promise.allSettled results and collect failures
@@ -136,33 +137,50 @@ export class LocalVault implements IVault<"local"> {
 	async readFromSource(): Promise<VaultReadResult> {
 		const allFiles = this.vault.getFiles();
 
-		// Filter to only tracked paths
+		// Filter to only tracked paths (excludes hidden files that Vault API can't read)
 		const allPaths = allFiles.map(f => f.path);
 		const trackedPaths = allPaths.filter(path => this.shouldTrackState(path));
-		const ignoredPaths = allPaths.filter(path => !this.shouldTrackState(path));
+		const untrackedPaths = allPaths.filter(path => !this.shouldTrackState(path));
 
 		// Create map for quick file size lookups
 		const fileSizeMap = new Map(allFiles.map(f => [f.path, f.stat.size]));
 
-		if (ignoredPaths.length > 0) {
-			fitLogger.log('[LocalVault] Ignored paths in local scan', {
-				count: ignoredPaths.length,
-				paths: ignoredPaths
+		if (untrackedPaths.length > 0) {
+			fitLogger.log('[LocalVault] Untracked paths in local scan (hidden files)', {
+				paths: untrackedPaths
 			});
 		}
 
-		// Compute SHAs for all tracked files
+		// Load .gitignore filters; pass allPaths so already-scanned .gitignore
+		// entries skip a redundant stat (future-proof for when vault.getFiles()
+		// exposes hidden files).
+		const allPathsSet = new Set(allPaths);
+		const gitignoreFilter = await GitignoreFilter.load(this.vault.adapter, trackedPaths, allPathsSet);
+
+		// Filter out paths matched by .gitignore patterns
+		let pathsToScan: string[];
+		if (!gitignoreFilter.isEmpty) {
+			const { kept, ignored } = gitignoreFilter.filter(trackedPaths);
+			pathsToScan = kept;
+			if (ignored.length > 0) {
+				fitLogger.log('[LocalVault] Paths ignored by .gitignore', { paths: ignored });
+			}
+		} else {
+			pathsToScan = trackedPaths;
+		}
+
+		// Compute SHAs for all non-ignored files
 		// Monitor for slow operations that could cause mobile crashes
 		// Use allSettled to collect both successes and failures per file
 		const shaResults = await withSlowOperationMonitoring(
 			Promise.allSettled(
-				trackedPaths.map(async (path): Promise<[string, BlobSha]> => {
+				pathsToScan.map(async (path): Promise<[string, BlobSha]> => {
 					const sha = await LocalVault.fileSha1(
 						path, await readFileContent(this.vault, path));
 					return [path, sha];
 				})
 			),
-			`Local vault SHA computation (${trackedPaths.length} files)`,
+			`Local vault SHA computation (${pathsToScan.length} files)`,
 			{ warnAfterMs: 10000 }
 		);
 
@@ -171,7 +189,7 @@ export class LocalVault implements IVault<"local"> {
 		const failedPaths: Array<{path: string, error: unknown}> = [];
 
 		shaResults.forEach((result, index) => {
-			const path = trackedPaths[index];
+			const path = pathsToScan[index];
 			if (result.status === 'fulfilled') {
 				shaEntries.push(result.value);
 			} else {

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -69,7 +69,7 @@ export class FakeObsidianVault {
 	getAbstractFileByPath(path: string) {
 		// Simulate: vault index never returns hidden files
 		if (path.startsWith('.') || !this.vaultIndex.has(path)) return null;
-		return { path } as TFile;
+		return StubTFile.ofPath(path);
 	}
 
 	adapter = {
@@ -87,6 +87,11 @@ export class FakeObsidianVault {
 		},
 		mkdir: async (_path: string) => {
 			// No-op for fake vault - folders are implicit
+		},
+		read: async (path: string) => {
+			const content = this.filesOnDisk.get(path);
+			if (!content) throw new Error('ENOENT: no such file');
+			return new TextDecoder('utf-8', { fatal: true }).decode(content);
 		},
 		readBinary: async (path: string) => {
 			const content = this.filesOnDisk.get(path);
@@ -136,7 +141,13 @@ export class FakeObsidianVault {
 		this.vaultIndex.delete(file.path);
 	};
 
-	getFiles = () => Array.from(this.vaultIndex).map(path => ({ path } as TFile));
+	getFiles = () => Array.from(this.vaultIndex).map(path => {
+		const content = this.filesOnDisk.get(path);
+		return {
+			path,
+			stat: { size: content?.byteLength ?? 0, mtime: 0, ctime: 0 }
+		} as TFile;
+	});
 	createFolder = async () => {};
 }
 

--- a/src/util/gitignore.test.ts
+++ b/src/util/gitignore.test.ts
@@ -1,0 +1,118 @@
+/**
+ * GitignoreFilter unit tests
+ *
+ * Covers pattern semantics, nested .gitignore scoping, knownPaths stat-skip optimization,
+ * and the filter/ignores public API. Uses a mock adapter — no real filesystem or vault.
+ * Integration with LocalVault (loading filters during readFromSource) is in localVault.test.ts.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { GitignoreFilter } from './gitignore';
+
+function mockAdapter(files: Record<string, string>) {
+	return {
+		stat: vi.fn().mockImplementation(async (path: string) =>
+			path in files ? { type: 'file' } : null
+		),
+		read: vi.fn().mockImplementation(async (path: string) => {
+			if (path in files) return files[path];
+			throw new Error('File not found');
+		})
+	};
+}
+
+describe('GitignoreFilter.load', () => {
+	it('returns an empty filter when no .gitignore files exist', async () => {
+		const filter = await GitignoreFilter.load(mockAdapter({}) as any, ['README.md', 'src/main.ts']);
+		expect(filter.isEmpty).toBe(true);
+	});
+
+	it('skips stat for paths in knownPaths', async () => {
+		const adapter = mockAdapter({ '.gitignore': '*.log' });
+		const knownPaths = new Set(['.gitignore']);
+
+		await GitignoreFilter.load(adapter as any, ['a.log'], knownPaths);
+
+		// stat should not have been called for .gitignore since it's in knownPaths
+		expect(adapter.stat).not.toHaveBeenCalledWith('.gitignore');
+		expect(adapter.read).toHaveBeenCalledWith('.gitignore');
+	});
+
+	it('falls back to stat for paths not in knownPaths', async () => {
+		const adapter = mockAdapter({ '.gitignore': '*.log' });
+
+		await GitignoreFilter.load(adapter as any, ['a.log']);
+
+		expect(adapter.stat).toHaveBeenCalledWith('.gitignore');
+	});
+});
+
+describe('GitignoreFilter.ignores', () => {
+	it('returns false when filter is empty', async () => {
+		const filter = await GitignoreFilter.load(mockAdapter({}) as any, []);
+		expect(filter.ignores('anything.log')).toBe(false);
+	});
+
+	describe('root .gitignore patterns', () => {
+		it.each([
+			{ pattern: '*.log', path: 'debug.log', ignored: true },
+			{ pattern: '*.log', path: 'nested/debug.log', ignored: true },
+			{ pattern: '*.log', path: 'README.md', ignored: false },
+			{ pattern: 'node_modules/', path: 'node_modules/pkg/index.js', ignored: true },
+			{ pattern: '*.log\n!important.log', path: 'debug.log', ignored: true },
+			{ pattern: '*.log\n!important.log', path: 'important.log', ignored: false },
+			{ pattern: '# comment\n\n*.tmp', path: 'cache.tmp', ignored: true },
+		])('pattern "$pattern" vs "$path" → ignored=$ignored', async ({ pattern, path, ignored }) => {
+			const filter = await GitignoreFilter.load(
+				mockAdapter({ '.gitignore': pattern }) as any,
+				[path]
+			);
+			expect(filter.ignores(path)).toBe(ignored);
+		});
+	});
+
+	describe('nested .gitignore scoping', () => {
+		it('applies patterns relative to .gitignore location', async () => {
+			const adapter = mockAdapter({ 'src/.gitignore': '*.generated.ts' });
+
+			const filter = await GitignoreFilter.load(
+				adapter as any,
+				['src/file.generated.ts', 'src/nested/file.generated.ts', 'file.generated.ts']
+			);
+
+			expect(filter.ignores('src/file.generated.ts')).toBe(true);
+			expect(filter.ignores('src/nested/file.generated.ts')).toBe(true);
+			expect(filter.ignores('file.generated.ts')).toBe(false);
+		});
+	});
+});
+
+describe('GitignoreFilter.filter', () => {
+	it('separates kept and ignored paths preserving order', async () => {
+		const filter = await GitignoreFilter.load(
+			mockAdapter({ '.gitignore': '*.log' }) as any,
+			['c.md', 'a.log', 'b.md', 'd.log']
+		);
+
+		expect(filter.filter(['c.md', 'a.log', 'b.md', 'd.log'])).toEqual({
+			kept: ['c.md', 'b.md'],
+			ignored: ['a.log', 'd.log'],
+		});
+	});
+
+	it('derives gitignore paths only from filePaths passed to load, not filter', async () => {
+		// deriveGitignorePaths uses the filePaths from load() to know which
+		// ancestor dirs to probe. If a nested .gitignore exists but no file
+		// under that dir was passed to load(), the .gitignore won't be loaded.
+		const adapter = mockAdapter({
+			'.gitignore': '*.log',
+			'deep/.gitignore': '*.md',
+		});
+
+		// Only root-level files passed to load — deep/.gitignore not probed
+		const filter = await GitignoreFilter.load(adapter as any, ['a.log', 'b.md']);
+
+		expect(filter.ignores('deep/note.md')).toBe(false); // deep/.gitignore wasn't loaded
+		expect(filter.ignores('a.log')).toBe(true);         // root .gitignore applies
+	});
+});

--- a/src/util/gitignore.ts
+++ b/src/util/gitignore.ts
@@ -1,0 +1,110 @@
+import ignore, { Ignore } from "ignore";
+import { DataAdapter } from "obsidian";
+
+export class GitignoreFilter {
+	private constructor(private readonly filters: Map<string, Ignore>) {}
+
+	/**
+	 * Load .gitignore files relevant to filePaths and build a filter.
+	 *
+	 * knownPaths (from vault.getFiles()) is used as a hint: if a .gitignore
+	 * path is already known to exist, the stat round-trip is skipped.
+	 * Once Obsidian exposes hidden files via getFiles(), this will automatically
+	 * avoid redundant scanning for any .gitignore already in the vault index.
+	 */
+	static async load(
+		adapter: DataAdapter,
+		filePaths: string[],
+		knownPaths?: ReadonlySet<string>
+	): Promise<GitignoreFilter> {
+		const gitignorePaths = deriveGitignorePaths(filePaths);
+		const filters = await loadFilters(adapter, gitignorePaths, knownPaths);
+		return new GitignoreFilter(filters);
+	}
+
+	get isEmpty(): boolean {
+		return this.filters.size === 0;
+	}
+
+	ignores(filePath: string): boolean {
+		const parts = filePath.split('/');
+		const dirsToCheck: string[] = [''];
+
+		for (let i = 1; i < parts.length; i++) {
+			dirsToCheck.push(parts.slice(0, i).join('/'));
+		}
+
+		for (const dirPath of dirsToCheck) {
+			const filter = this.filters.get(dirPath);
+			if (!filter) continue;
+
+			const relativePath = dirPath === ''
+				? filePath
+				: filePath.substring(dirPath.length + 1);
+
+			if (filter.ignores(relativePath)) return true;
+		}
+
+		return false;
+	}
+
+	filter(filePaths: string[]): { kept: string[]; ignored: string[] } {
+		const kept: string[] = [];
+		const ignored: string[] = [];
+
+		for (const path of filePaths) {
+			if (this.ignores(path)) {
+				ignored.push(path);
+			} else {
+				kept.push(path);
+			}
+		}
+
+		return { kept, ignored };
+	}
+}
+
+function deriveGitignorePaths(filePaths: string[]): Set<string> {
+	const gitignorePaths = new Set<string>();
+	gitignorePaths.add('.gitignore');
+
+	for (const filePath of filePaths) {
+		const parts = filePath.split('/');
+		for (let i = 1; i < parts.length; i++) {
+			const dirPath = parts.slice(0, i).join('/');
+			gitignorePaths.add(`${dirPath}/.gitignore`);
+		}
+	}
+
+	return gitignorePaths;
+}
+
+async function loadFilters(
+	adapter: DataAdapter,
+	gitignorePaths: Set<string>,
+	knownPaths?: ReadonlySet<string>
+): Promise<Map<string, Ignore>> {
+	const filters = new Map<string, Ignore>();
+
+	await Promise.all(
+		Array.from(gitignorePaths).map(async (gitignorePath) => {
+			try {
+				const knownToExist = knownPaths?.has(gitignorePath);
+				if (!knownToExist) {
+					const stat = await adapter.stat(gitignorePath);
+					if (!stat || stat.type !== 'file') return;
+				}
+
+				const content = await adapter.read(gitignorePath);
+				const dirPath = gitignorePath === '.gitignore'
+					? ''
+					: gitignorePath.replace(/\/.gitignore$/, '');
+				filters.set(dirPath, ignore().add(content));
+			} catch {
+				// file doesn't exist or unreadable — skip
+			}
+		})
+	);
+
+	return filters;
+}


### PR DESCRIPTION
Detects local .gitignore files if present and skips tracking/syncing gitignored paths to remote.

Part of implementation for #92. This does not actually SYNC any new hidden files to remote yet, but it's important groundwork in two ways:
1. For the implementation, it's the first case of proactively scanning for any local hidden files
2. It's an important mechanism to have along with the feature for syncing hidden files so it's possible to exclude important hidden files (such as .obsidian/ paths)

---

<!-- kody-pr-summary:start -->
This pull request introduces support for `.gitignore` files, allowing users to define patterns for files and directories that should be excluded from synchronization.

Key changes include:

*   **Respect `.gitignore` Rules**: The application now reads `.gitignore` files located in the vault root and any ancestor directories of tracked files. Any local files matching these patterns will be excluded from the local SHA computation and will not be synced to the remote.
*   **Local-Only Filtering**: This filtering layer is applied to the local vault before SHA computation, ensuring that unwanted files are never considered for upload.
*   **Standard Gitignore Semantics**: The implementation uses the `ignore` package to correctly interpret `.gitignore` patterns, including wildcards, directory exclusions, and negations, with proper scoping for nested `.gitignore` files.
*   **Documentation Updates**: The `README.md` and `docs/sync-logic.md` have been updated to reflect this new filtering layer, explaining its purpose, behavior, and integration into the overall sync process.
*   **Enhanced Test Coverage**: New unit tests have been added for the `GitignoreFilter` itself and for its integration into `LocalVault.readFromSource`, verifying correct exclusion behavior for various `.gitignore` patterns and nested structures.
*   **`.gitignore` Files Not Synced**: While their rules are respected, the `.gitignore` files themselves are still not synced to the remote, consistent with the handling of other hidden configuration files.

This feature provides users with greater control over what content is synchronized, enabling them to easily exclude temporary files, build artifacts, or other irrelevant data using a familiar and widely adopted mechanism.
<!-- kody-pr-summary:end -->