### PR TITLE
test: release guideline docs + pr-checks for version metadata

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -65,7 +65,7 @@ jobs:
         git fetch origin ${{ github.base_ref }} --depth=1
         BASE="origin/${{ github.base_ref }}"
 
-        CHANGED=$(git diff --name-only "${BASE}...HEAD")
+        CHANGED=$(git diff --name-only "${BASE}" HEAD)
         VERSION_FILES=$(echo "$CHANGED" | grep -E '^(manifest\.json|package\.json|versions\.json)$' || true)
         CODE_FILES=$(echo "$CHANGED" | grep -vE '^(manifest\.json|package\.json|versions\.json)$' | grep -E '\.(ts|js|css|mjs)$' || true)
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,6 +57,57 @@ jobs:
       run: npm test -- --coverage
       continue-on-error: true
 
+    - name: Check for release anti-patterns
+      id: release_check
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git fetch origin ${{ github.base_ref }} --depth=1
+        BASE="origin/${{ github.base_ref }}"
+
+        CHANGED=$(git diff --name-only "${BASE}...HEAD")
+        VERSION_FILES=$(echo "$CHANGED" | grep -E '^(manifest\.json|package\.json|versions\.json)$' || true)
+        CODE_FILES=$(echo "$CHANGED" | grep -vE '^(manifest\.json|package\.json|versions\.json)$' | grep -E '\.(ts|js|css|mjs)$' || true)
+
+        FAILED=false
+
+        if [ -n "$VERSION_FILES" ]; then
+          if [ -n "$CODE_FILES" ]; then
+            echo "::error::Version files changed alongside code files. Version bumps must be in dedicated commits/PRs — see docs/CONTRIBUTING.md for the release process."
+            FAILED=true
+          fi
+
+          NEW_VERSION=$(jq -r '.version' manifest.json)
+          PKG_VERSION=$(jq -r '.version' package.json)
+
+          if [ "$NEW_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::manifest.json version (${NEW_VERSION}) does not match package.json version (${PKG_VERSION})."
+            FAILED=true
+          fi
+
+          if [ "${{ github.base_ref }}" = "main" ] && echo "$NEW_VERSION" | grep -q -- '-beta'; then
+            echo "::error::Beta version (${NEW_VERSION}) must not appear in manifest.json on main. Beta bumps happen on the beta branch only."
+            FAILED=true
+          fi
+
+          BASE_VERSION=$(git show "${BASE}:manifest.json" | jq -r '.version')
+          if [ "${{ github.base_ref }}" = "main" ] && [ "$NEW_VERSION" != "$BASE_VERSION" ] && ! echo "$NEW_VERSION" | grep -q -- '-'; then
+            echo "Checking GitHub Release exists for ${NEW_VERSION}..."
+            if ! gh release view "$NEW_VERSION" > /dev/null 2>&1; then
+              echo "::error::No GitHub Release found for version ${NEW_VERSION}. Create the GitHub Release (tag: ${NEW_VERSION}, no 'v' prefix) before merging this version bump."
+              FAILED=true
+            else
+              echo "✅ GitHub Release ${NEW_VERSION} exists"
+            fi
+          fi
+        fi
+
+        if $FAILED; then
+          exit 1
+        fi
+        echo "✅ No release anti-patterns detected"
+      continue-on-error: true
+
     - name: Generate status summary
       id: summary
       run: |
@@ -117,7 +168,7 @@ jobs:
           echo "✅ PR comment posted successfully"
         else
           echo "ℹ️ Skipped PR comment - external fork lacks write permissions"
-          echo "Check results above: Lint: ${{ steps.lint.outcome }}, TypeCheck: ${{ steps.typecheck.outcome }}, Tests: ${{ steps.test.outcome }}"
+          echo "Check results above: Lint: ${{ steps.lint.outcome }}, TypeCheck: ${{ steps.typecheck.outcome }}, Tests: ${{ steps.test.outcome }}, Release: ${{ steps.release_check.outcome }}"
         fi
 
     - name: Fail workflow if critical checks failed
@@ -128,6 +179,10 @@ jobs:
         fi
         if [[ "${{ steps.typecheck.outcome }}" != "success" ]]; then
           echo "❌ TypeScript compilation failed - blocking PR merge"
+          exit 1
+        fi
+        if [[ "${{ steps.release_check.outcome }}" != "success" ]]; then
+          echo "❌ Release anti-patterns detected - blocking PR merge"
           exit 1
         fi
         echo "✅ All critical checks passed"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -112,21 +112,65 @@ Please try to avoid breaking functionality (on desktop or mobile), and test majo
 
 ## Release Process
 
-**Quick Release**:
-```shell
-# Update minAppVersion in manifest.json first, then:
-npm version patch   # bug fixes
-npm version minor   # new features
-npm version major   # breaking changes
-```
+**Rules that apply to all releases:**
+- Version numbers never have a `v` prefix (`1.5.0`, not `v1.5.0`)
+- `manifest.json` and `package.json` versions must always match
+- Version bumps must be in **dedicated commits**, never mixed with feature or bug-fix changes
+- The `main` branch manifest always shows the current **stable** version; beta versions never appear there
 
-**Manual Steps**:
-1. Push that version bump commit and tag to GitHub
-2. Run `npm run build`
-3. Create GitHub release (use `1.0.1`, not `v1.0.1` with "v" prefix)
-4. Upload `manifest.json`, `main.js`, `styles.css` as artifacts on the release
+### Stable Release
 
-See [Obsidian Hub instructions](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/Guides/How+to+release+a+new+version+of+your+plugin) for details.
+Beta testing is recommended before a stable release. When ready:
+
+1. **Build artifacts**: `npm run build` produces `main.js`
+
+2. **Create the GitHub Release** via the GitHub UI:
+   - Tag: `X.Y.Z` — no `v` prefix; mark as a full release (not pre-release)
+   - Upload `manifest.json`, `main.js`, `styles.css` as release assets
+   - The GitHub Release must exist **before** the version bump PR is merged (automated PR checks enforce this)
+
+3. **Open a PR to `main`** containing only these changes:
+   - `manifest.json`: bump `version` to `X.Y.Z`
+   - `package.json`: bump `version` to `X.Y.Z`
+   - `versions.json`: add `"X.Y.Z": "<minAppVersion>"`
+   - Commit message: `Bump version to X.Y.Z`
+
+4. **Merge the PR** — automated checks verify the GitHub Release exists
+
+### Beta Release
+
+Beta releases are for early testing via [BRAT](https://github.com/TfTHacker/obsidian42-brat). They live only on the `beta` branch and are invisible to regular plugin users (never reflected in `main`'s manifest).
+
+1. **Merge `main` into `beta`** (using jj):
+   ```shell
+   jj new beta main -m "Merge branch 'main' into beta"
+   ```
+
+2. **Bump the beta version** directly on the `beta` branch (not via PR to main):
+   - `manifest.json`: set `version` to `X.Y.Z-beta.N`, update `minAppVersion` if needed
+   - `package.json`: set `version` to `X.Y.Z-beta.N`
+   - `versions.json`: add `"X.Y.Z-beta.N": "<minAppVersion>"`
+   - Commit message: `Bump version to X.Y.Z-beta.N (minAppVersion: A.B.C)`
+
+3. **Push `beta`** to GitHub
+
+4. **Create a GitHub Pre-release** via the GitHub UI:
+   - Tag: `X.Y.Z-beta.N` — no `v` prefix (created here via the GH UI); mark as pre-release
+   - Build and upload the same three artifacts as a stable release
+
+BRAT users who point to `joshuakto/fit` receive the latest pre-release automatically.
+
+### Anti-Patterns
+
+| ❌ Anti-pattern | Why it's a problem |
+|---|---|
+| Bumping version in a feature/bug PR | Blocks doc reviews and makes rollback harder; automated checks will reject it |
+| `v` prefix on version tag (e.g. `v1.4.0`) | Breaks the Obsidian plugin registry and BRAT version detection |
+| Bumping `manifest.json` on `main` before the GH Release exists | Plugin installed from `main` references a non-existent release ([#59](https://github.com/joshuakto/fit/issues/59)); automated checks will reject it |
+| Beta version in `main`'s `manifest.json` | Exposes pre-release to all users; automated checks will reject it |
+| `manifest.json` and `package.json` versions out of sync | Confuses tooling and reviewers; automated checks will reject it |
+
+See [Obsidian Hub release guide](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/Guides/How+to+release+a+new+version+of+your+plugin) for general Obsidian plugin release context.
 
 ---
 
@@ -140,4 +184,3 @@ If you'd like to help set up more automated checking, there are a few quality as
 
 - [ ] **ESLint rules** for more known problematic code patterns
 - [ ] **Consistent documentation** to ensure comments and architecture docs stay up-to-date with code changes
-- [ ] **Release automation/validation** to ensure releases are correctly configured & versioned


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces automated checks and updated documentation to enforce a more robust and consistent release process.

Key changes include:
*   **New PR Checks**: A new GitHub Actions job has been added to validate pull requests against common release anti-patterns. These checks ensure:
    *   Version file changes (`manifest.json`, `package.json`, `versions.json`) are isolated to dedicated commits/PRs, separate from code changes.
    *   The `version` fields in `manifest.json` and `package.json` always match.
    *   Beta versions are not introduced into the `main` branch's `manifest.json`.
    *   For stable version bumps on `main`, a corresponding GitHub Release with the new version tag exists *before* the PR is merged.
*   **Updated Release Guidelines**: The `docs/CONTRIBUTING.md` file has been comprehensively revised to detail the new stable and beta release workflows. It now includes:
    *   Clear rules applicable to all releases (e.g., no `v` prefix, matching versions).
    *   Step-by-step instructions for creating stable releases, emphasizing the pre-existence of GitHub Releases.
    *   Detailed guidance for managing beta releases on a dedicated `beta` branch.
    *   A new "Anti-Patterns" section that explicitly lists common release mistakes and explains why they are problematic, directly correlating with the new automated checks.

These changes aim to standardize the release process, prevent common versioning and deployment errors, and improve overall release quality and consistency.
<!-- kody-pr-summary:end -->