### PR TITLE
fix(#265): fix settings manual sync icon + mention advanced

### DIFF
--- a/src/fitSetting.ts
+++ b/src/fitSetting.ts
@@ -564,9 +564,9 @@ export default class FitSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Sync local cache')
-			.setDesc('Update the local cache with the actual remote state.')
+			.setDesc('Re-read remote state into local cache. (Advanced use only — encryption migration or cache recovery)')
 			.addExtraButton(button => button
-				.setIcon('trash-2')
+				.setIcon('refresh-cw')
 				.setTooltip("Sync local cache")
 				.onClick(async () => {
 					button.setDisabled(true);
@@ -598,7 +598,7 @@ export default class FitSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Clear repository')
-			.setDesc('Delete all files from the repository. Previous commits will not be affected.')
+			.setDesc('Delete all files from the repository. Previous commits unaffected. (Advanced use only — encryption migration)')
 			.addExtraButton(button => button
 				.setIcon('trash-2')
 				.setTooltip("Clear repository")


### PR DESCRIPTION
Minor bugfix for encryption feature #265.

@beachvisitor FYI

---

<!-- kody-pr-summary:start -->
Refined the settings interface by:

*   Changing the "Sync local cache" button icon from a trash icon to a refresh icon for better visual representation.
*   Updating the descriptions for both "Sync local cache" and "Clear repository" settings to clarify their advanced nature and specific use cases, such as encryption migration or cache recovery.
<!-- kody-pr-summary:end -->