### PR TITLE
fix(#146): failed large files cleanly message size errors instead of failing whole sync

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -67,6 +67,12 @@ export interface LocalStores {
 	localSha: FileStates                   // File path -> SHA cache
 	lastFetchedCommitSha: CommitSha | null // Last synced commit
 	lastFetchedRemoteSha: FileStates       // Remote file path -> SHA cache
+	// Files that were skipped due to GitHub API size limits (422) and haven't reached
+	// remote yet. Maps path → FIT SHA at time of skip, so we can detect when the file
+	// has been modified locally (and should re-enter the normal sync queue) or reconciled
+	// on remote (and should be removed from this list).
+	// Note: transient failures like rate limits (#179) should be tracked separately when needed since they SHOULD retry on subsequent syncs.
+	unpushedFiles?: FileStates
 }
 
 /**
@@ -82,7 +88,8 @@ type SyncOutcome =
 const DEFAULT_LOCAL_STORE: LocalStores = {
 	localSha: {},
 	lastFetchedCommitSha: null,
-	lastFetchedRemoteSha: {}
+	lastFetchedRemoteSha: {},
+	unpushedFiles: {}
 };
 
 
@@ -191,7 +198,7 @@ export default class FitPlugin extends Plugin {
 		const syncStartTime = Date.now();
 		fitLogger.log(`🚀 [SYNC START] ${triggerType === 'manual' ? 'Manual' : 'Auto'} sync requested`);
 
-		const syncResult = await this.fitSync.sync(this.currentSyncNotice!);
+		const syncResult = await this.fitSync.sync(this.currentSyncNotice!, { isAutoSync: triggerType === 'auto' });
 
 		if (syncResult.success) {
 			const duration = Date.now() - syncStartTime;

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -32,6 +32,7 @@ export class Fit {
 	localSha: FileStates;                   // Cache of local file SHAs
 	lastFetchedCommitSha: CommitSha | null; // Last synced commit SHA
 	lastFetchedRemoteSha: FileStates;       // Cache of remote file SHAs
+	unpushedFiles: FileStates;              // Files skipped due to API size limit (422)
 	localVault: LocalVault;                 // Local vault (tracks local file state)
 	remoteVault: RemoteGitHubVault;
 
@@ -82,6 +83,7 @@ export class Fit {
 		this.localSha = localStore.localSha;
 		this.lastFetchedCommitSha = localStore.lastFetchedCommitSha;
 		this.lastFetchedRemoteSha = localStore.lastFetchedRemoteSha;
+		this.unpushedFiles = localStore.unpushedFiles ?? {};
 		// Detect potentially corrupted/suspicious cache states
 		const localCount = Object.keys(this.localSha).length;
 		const remoteCount = Object.keys(this.lastFetchedRemoteSha).length;

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -266,7 +266,8 @@ describe('FitSync', () => {
 			lastFetchedRemoteSha: {
 				'fileA.md': expect.anything(),
 				'fileB.md': expect.anything()
-			}
+			},
+			unpushedFiles: {}
 		});
 
 		// Verify: Remote has new commit and both files
@@ -1792,6 +1793,123 @@ describe('FitSync', () => {
 			expect(fit.remoteVault.getOwner()).toBe(v13settings.owner);
 			expect(fit.remoteVault.getRepo()).toBe(v13settings.repo);
 			expect(fit.remoteVault.getBranch()).toBe(v13settings.branch);
+		});
+	});
+
+	describe('unpushedFiles — partial sync tracking for 422 size-limit skips', () => {
+		it('first sync with skipped file: populates unpushedFiles, syncs other files, returns success', async () => {
+			// Arrange: one normal file + one that will be skipped
+			const fitSync = createFitSync();
+			localVault.setFile('normal.md', 'normal content');
+			localVault.setFile('huge.mp4', 'big file content');
+			remoteVault.setSkippedPaths(['huge.mp4']);
+			const fitNoticeSpy = vi.spyOn(FitNotice.prototype, 'show').mockImplementation(() => {});
+
+			// Act
+			const mockNotice = createMockNotice();
+			const result = await fitSync.sync(mockNotice as any);
+
+			// Assert: sync succeeded
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+
+			// Assert: first-encounter sticky notice was shown
+			expect(fitNoticeSpy).toHaveBeenCalled();
+
+			// Assert: normal file was pushed, huge.mp4 was not
+			expect(remoteVault.getAllFilesAsRaw()).toEqual({ 'normal.md': 'normal content' });
+
+			// Assert: unpushedFiles tracks the skipped path
+			expect(localStoreState.unpushedFiles).toEqual({
+				'huge.mp4': expect.any(String)
+			});
+
+			// Assert: localSha cache includes both files (huge.mp4 treated as "synced" by cache
+			// so sync engine won't retry it — unpushedFiles is the tracking mechanism)
+			expect(localStoreState.localSha).toMatchObject({
+				'huge.mp4': expect.any(String),
+				'normal.md': expect.any(String),
+			});
+		});
+
+		it('subsequent manual sync with unchanged skipped file: brief reminder in notice, no upload attempted', async () => {
+			// Arrange: pre-populate unpushedFiles as if previous sync had already skipped the file
+			localVault.setFile('huge.mp4', 'big file content');
+			const hugeFileContent = FileContent.fromPlainText('big file content');
+			const hugeFileSha = await LocalVault.fileSha1('huge.mp4', hugeFileContent);
+			localStoreState = {
+				...localStoreState,
+				localSha: { 'huge.mp4': hugeFileSha as BlobSha },
+				lastFetchedRemoteSha: {},
+				unpushedFiles: { 'huge.mp4': hugeFileSha as BlobSha }
+			};
+			const fitSync = createFitSync();
+			// Do NOT set skippedPaths — no upload attempt should happen
+			const remoteApplySpy = vi.spyOn(remoteVault, 'applyChanges');
+
+			// Act
+			const mockNotice = createMockNotice();
+			const result = await fitSync.sync(mockNotice as any);
+
+			// Assert: sync succeeded
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+
+			// Assert: no upload was attempted (huge.mp4 has no local change vs cache)
+			expect(remoteApplySpy).not.toHaveBeenCalled();
+
+			// Assert: unpushedFiles still tracks the file
+			expect(localStoreState.unpushedFiles).toHaveProperty('huge.mp4');
+
+			// Assert: brief reminder in success message (not a separate popup)
+			expect(mockNotice.setMessage).toHaveBeenCalledWith(
+				expect.stringContaining('still need manual sync')
+			);
+		});
+
+		it('file modified locally after skip: removed from unpushedFiles on next sync', async () => {
+			// Arrange: file was previously skipped with old SHA
+			localVault.setFile('huge.mp4', 'modified content'); // Different content = new SHA
+			const oldSha = 'old-sha-from-before-modification' as BlobSha;
+			localStoreState = {
+				...localStoreState,
+				localSha: { 'huge.mp4': oldSha }, // Out of date — will cause localChanges detection
+				lastFetchedRemoteSha: {},
+				unpushedFiles: { 'huge.mp4': oldSha }
+			};
+			const fitSync = createFitSync();
+			// Don't skip this time — let the file attempt to push (simulates user modified file)
+			// The new content will be written normally
+
+			// Act
+			const mockNotice = createMockNotice();
+			const result = await fitSync.sync(mockNotice as any);
+
+			// Assert: sync succeeded and file was pushed, no longer stuck
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+			expect(remoteVault.getAllFilesAsRaw()).toMatchObject({ 'huge.mp4': expect.any(String) });
+			expect(localStoreState.unpushedFiles).not.toHaveProperty('huge.mp4');
+		});
+
+		it('remote change for skipped file: removed from unpushedFiles (user pushed via git)', async () => {
+			// Arrange: file was previously skipped; now it appears as a remote change
+			// (simulates user running `git push` outside Obsidian)
+			await remoteVault.setFile('huge.mp4', 'manually pushed content');
+			localVault.setFile('huge.mp4', 'manually pushed content'); // Same content locally
+			const hugeFileSha = 'some-sha' as BlobSha;
+			localStoreState = {
+				...localStoreState,
+				localSha: { 'huge.mp4': hugeFileSha },
+				lastFetchedRemoteSha: {}, // Remote SHA unknown → will be detected as remote add
+				unpushedFiles: { 'huge.mp4': hugeFileSha }
+			};
+			const fitSync = createFitSync();
+
+			// Act
+			const mockNotice = createMockNotice();
+			const result = await fitSync.sync(mockNotice as any);
+
+			// Assert: sync succeeded and unpushedFiles entry cleared
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+			expect(localStoreState.unpushedFiles).not.toHaveProperty('huge.mp4');
 		});
 	});
 });

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1831,6 +1831,30 @@ describe('FitSync', () => {
 			});
 		});
 
+		it('first sync with only the skipped file (no other local changes): still succeeds and tracks it', async () => {
+			// Arrange: only the large file — no other local changes
+			const fitSync = createFitSync();
+			localVault.setFile('huge.mp4', 'big file content');
+			remoteVault.setSkippedPaths(['huge.mp4']);
+			const fitNoticeSpy = vi.spyOn(FitNotice.prototype, 'show').mockImplementation(() => {});
+
+			// Act
+			const mockNotice = createMockNotice();
+			const result = await fitSync.sync(mockNotice as any);
+
+			// Assert: sync succeeds (not a failure)
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+
+			// Assert: sticky notice shown for first encounter
+			expect(fitNoticeSpy).toHaveBeenCalled();
+
+			// Assert: nothing pushed to remote
+			expect(remoteVault.getAllFilesAsRaw()).toEqual({});
+
+			// Assert: file is tracked as unpushed
+			expect(localStoreState.unpushedFiles).toEqual({ 'huge.mp4': expect.any(String) });
+		});
+
 		it('subsequent manual sync with unchanged skipped file: brief reminder in notice, no upload attempted', async () => {
 			// Arrange: pre-populate unpushedFiles as if previous sync had already skipped the file
 			localVault.setFile('huge.mp4', 'big file content');

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -78,6 +78,10 @@ type SyncExecutionResult = {
 	remoteOps: FileChange[];
 	/** Unresolved conflicts (context-dependent: new conflicts or all conflicts) */
 	conflicts: FileClash[];
+	/** Paths freshly added to unpushedFiles this sync (not previously known) */
+	newlySkippedPaths: string[];
+	/** Pre-built first-encounter notice for newly skipped files */
+	skippedWarning?: string;
 };
 
 export type ConflictResolutionResult = {
@@ -466,6 +470,20 @@ export class FitSync implements IFitSync {
 			fitLogger.log(`.. ⬆️ [Push] Pushed ${pushResult.pushedChanges.length} changes to remote`);
 		}
 
+		// Record any files skipped due to API size limit (422) into unpushedFiles.
+		// localSha is updated normally for these files (sync engine won't retry),
+		// so unpushedFiles is the sole tracking mechanism for them.
+		// Capture which paths are freshly added (not already known) for the tiered warning.
+		const previousUnpushedKeys = new Set(Object.keys(this.fit.unpushedFiles));
+		if (pushResult?.skippedPaths?.length) {
+			for (const path of pushResult.skippedPaths) {
+				this.fit.unpushedFiles[path] = currentLocalState[path];
+			}
+			fitLogger.log(`[FitSync] ${pushResult.skippedPaths.length} file(s) added to unpushedFiles (API size limit)`, {
+				paths: pushResult.skippedPaths
+			});
+		}
+
 		let latestRemoteTreeSha: FileStates;
 		let latestCommitSha: CommitSha;
 		let pushedChanges: Array<FileChange>;
@@ -537,23 +555,44 @@ export class FitSync implements IFitSync {
 			{ localOpsApplied: localFileOpsRecord.changes.length, remoteOpsPushed: pushedChanges.length }
 		);
 
+		// Clean stale unpushedFiles entries before persisting.
+		// A file leaves the list when: locally modified (SHA changed → re-enters normal sync),
+		// reconciled on remote (remote change detected → normal pull handles it), deleted
+		// locally, or excluded by shouldSyncPath (e.g. added to .gitignore).
+		const remoteChangesForCleanup = remoteUpdate.remoteChanges ?? [];
+		for (const [path, sha] of Object.entries(this.fit.unpushedFiles)) {
+			const isModified = newLocalState[path] !== sha;
+			const isRemoteReconciled = remoteChangesForCleanup.some(c => c.path === path);
+			const isGone = newLocalState[path] === undefined;
+			const isIgnored = !this.fit.shouldSyncPath(path);
+			if (isModified || isRemoteReconciled || isGone || isIgnored) {
+				delete this.fit.unpushedFiles[path];
+			}
+		}
+
+		const newlySkippedPaths = pushResult?.skippedPaths?.filter(p => !previousUnpushedKeys.has(p)) ?? [];
+
 		await this.saveLocalStoreCallback({
 			lastFetchedRemoteSha: latestRemoteTreeSha, // Unfiltered - must track ALL remote files to detect changes
 			lastFetchedCommitSha: latestCommitSha,
 			// TODO: Remove filterSyncedState after fixing bug where remote _fit/ files are passed to applyChanges
 			// Currently remote _fit/ paths bypass shouldSyncPath filtering and get SHAs computed.
 			// Once fixed, newBaselineStates will only contain syncable paths (no filtering needed).
-			localSha: this.fit.filterSyncedState(newLocalState)
+			localSha: this.fit.filterSyncedState(newLocalState),
+			unpushedFiles: this.fit.unpushedFiles,
 		});
 
 		return {
 			localOps: localFileOpsRecord.changes,
 			remoteOps: pushedChanges,
-			conflicts: clashes
+			conflicts: clashes,
+			newlySkippedPaths,
+			skippedWarning: pushResult?.skippedWarning,
 		};
 	}
 
-	async sync(syncNotice: FitNotice): Promise<SyncResult> {
+	async sync(syncNotice: FitNotice, options?: { isAutoSync?: boolean }): Promise<SyncResult> {
+		const isAutoSync = options?.isAutoSync ?? false;
 		// Check if already syncing
 		if (this.isSyncing) {
 			fitLogger.log('[FitSync] Sync already in progress - aborting new sync request');
@@ -628,7 +667,7 @@ export class FitSync implements IFitSync {
 			);
 
 			// Phase 3: Execute - push, pull, persist (atomic operation)
-			const { localOps, remoteOps, conflicts } = await this.executeSync(
+			const { localOps, remoteOps, conflicts, newlySkippedPaths, skippedWarning } = await this.executeSync(
 				currentLocalState,
 				{
 					remoteChanges,
@@ -662,13 +701,31 @@ export class FitSync implements IFitSync {
 				}
 			}
 
-			// Set appropriate success message
-			if (conflicts.length === 0) {
-				syncNotice.setMessage(`Sync successful`);
-			} else if (conflicts.some(f => f.remoteOp !== "REMOVED")) {
-				syncNotice.setMessage(`Synced with remote, unresolved conflicts written to _fit`);
-			} else {
-				syncNotice.setMessage(`Synced with remote, ignored remote deletion of locally changed files`);
+			// Show tiered warning for files still awaiting manual sync
+			const remainingUnpushed = Object.keys(this.fit.unpushedFiles);
+			if (remainingUnpushed.length > 0) {
+				if (newlySkippedPaths.length > 0 && skippedWarning) {
+					// First encounter: full sticky notice with git CLI instructions
+					new FitNotice(this.fit, [], skippedWarning, 0).show();
+				} else if (!isAutoSync) {
+					// Subsequent manual sync: brief reminder in the success message
+					syncNotice.setMessage(
+						`Sync successful — ${remainingUnpushed.length} file(s) still need manual sync`
+					);
+				}
+				// Auto-sync with no new skips: log only, no notice
+				fitLogger.log('[FitSync] Files still awaiting manual sync', { paths: remainingUnpushed });
+			}
+
+			// Set success message (only when not already replaced by the unpushed-files reminder)
+			if (remainingUnpushed.length === 0 || isAutoSync || newlySkippedPaths.length > 0) {
+				if (conflicts.length === 0) {
+					syncNotice.setMessage(`Sync successful`);
+				} else if (conflicts.some(f => f.remoteOp !== "REMOVED")) {
+					syncNotice.setMessage(`Synced with remote, unresolved conflicts written to _fit`);
+				} else {
+					syncNotice.setMessage(`Synced with remote, ignored remote deletion of locally changed files`);
+				}
 			}
 
 			return {
@@ -706,7 +763,7 @@ export class FitSync implements IFitSync {
 			parentCommitSha: CommitSha
 		},
 		existenceMap: Map<string, 'file' | 'folder' | 'nonexistent'>
-	): Promise<{pushedChanges: FileChange[], lastFetchedRemoteSha: FileStates, lastFetchedCommitSha: CommitSha}|null> {
+	): Promise<{pushedChanges: FileChange[], lastFetchedRemoteSha: FileStates, lastFetchedCommitSha: CommitSha, skippedPaths?: string[], skippedWarning?: string}|null> {
 		if (localUpdate.localChanges.length === 0) {
 			return null;
 		}
@@ -748,14 +805,28 @@ export class FitSync implements IFitSync {
 			warningNotice.show();
 		}
 
-		// If no operations were performed, return null
+		// If no operations were performed, return null (or with skipped paths if applicable)
 		// This can happen when local SHA differs from cache but content matches remote
-		// (spurious change due to SHA normalization or caching issues)
+		// (spurious change due to SHA normalization or caching issues), or when all files
+		// were skipped due to size limits.
 		if (result.changes.length === 0) {
-			fitLogger.log('[FitSync] No remote changes needed - content already matches', {
+			fitLogger.log('[FitSync] No remote changes needed - content already matches or all files skipped', {
 				localChangesDetected: localUpdate.localChanges.length,
-				reason: 'Local content matches remote despite SHA cache mismatch (likely SHA normalization or cache inconsistency)'
+				skippedCount: result.skippedPaths?.length ?? 0,
+				reason: result.skippedPaths?.length
+					? 'All files skipped due to API size limit (422)'
+					: 'Local content matches remote despite SHA cache mismatch (likely SHA normalization or cache inconsistency)'
 			});
+			if (result.skippedPaths?.length) {
+				// Return minimal push result so caller can update unpushedFiles
+				return {
+					pushedChanges: [],
+					lastFetchedRemoteSha: result.newState,
+					lastFetchedCommitSha: result.commitSha,
+					skippedPaths: result.skippedPaths,
+					skippedWarning: result.skippedWarning,
+				};
+			}
 			return null;
 		}
 
@@ -768,6 +839,8 @@ export class FitSync implements IFitSync {
 			pushedChanges,
 			lastFetchedRemoteSha: result.newState,
 			lastFetchedCommitSha: result.commitSha,
+			skippedPaths: result.skippedPaths,
+			skippedWarning: result.skippedWarning,
 		};
 	}
 

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -709,8 +709,9 @@ export class FitSync implements IFitSync {
 					new FitNotice(this.fit, [], skippedWarning, 0).show();
 				} else if (!isAutoSync) {
 					// Subsequent manual sync: brief reminder in the success message
+					const fileList = remainingUnpushed.map(p => `• ${p}`).join('\n');
 					syncNotice.setMessage(
-						`Sync successful — ${remainingUnpushed.length} file(s) still need manual sync`
+						`Sync successful — ${remainingUnpushed.length} file(s) still need manual sync:\n${fileList}`
 					);
 				}
 				// Auto-sync with no new skips: log only, no notice
@@ -893,7 +894,7 @@ export class FitSync implements IFitSync {
 				}
 
 				// Add recovery guidance for per-file errors
-				baseMessage += '\n\n💡 To sync other files: Move problematic file(s) out of your vault temporarily, or use git to sync them manually. .gitignore support coming soon.';
+				baseMessage += '\n\n💡 To exclude a file from sync, add it to .gitignore.';
 			}
 		} else {
 			// Handle SyncOrchestrationError (type === 'unknown' | 'already-syncing')

--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -427,6 +427,94 @@ describe("RemoteGitHubVault", () => {
 					},
 				});
 			});
+
+			describe("422 size-limit partial skip", () => {
+				function make422Error(): Error {
+					// Must include response: {} so wrapOctokitError treats it as an HTTP error
+					// and re-throws as-is, preserving status === 422.
+					const err: any = new Error("input file size too large to process");
+					err.status = 422;
+					err.response = {};
+					return err;
+				}
+
+				it("should skip a single file that returns 422, returning skippedPaths and skippedWarning", async () => {
+					fakeOctokit.setupInitialState(PARENTCOMMIT123_SHA, TREE456_SHA, []);
+					fakeOctokit.simulateError("POST /repos/{owner}/{repo}/git/blobs", make422Error());
+
+					const result = await vault.applyChanges(
+						[{ path: "huge.mp4", content: FileContent.fromPlainText("x".repeat(100)) }],
+						[]
+					);
+
+					expect(result.changes).toEqual([]);
+					expect(result.skippedPaths).toEqual(["huge.mp4"]);
+					expect(result.skippedWarning).toContain("huge.mp4");
+					expect(result.skippedWarning).toContain(".gitignore");
+					expect(result.skippedWarning).toContain("git push");
+					// Commit and tree should be unchanged (no-op)
+					expect(result.commitSha).toBe(PARENTCOMMIT123_SHA);
+					expect(result.treeSha).toBe(TREE456_SHA);
+				});
+
+				it("should skip only the 422 file and commit the rest when uploading multiple files", async () => {
+					fakeOctokit.setupInitialState(PARENTCOMMIT123_SHA, TREE456_SHA, []);
+					// First blob creation (huge.mp4) will fail; second (small.md) will succeed
+					fakeOctokit.simulateError("POST /repos/{owner}/{repo}/git/blobs", make422Error());
+
+					const result = await vault.applyChanges(
+						[
+							{ path: "huge.mp4", content: FileContent.fromPlainText("x".repeat(100)) },
+							{ path: "small.md", content: FileContent.fromPlainText("tiny note") },
+						],
+						[]
+					);
+
+					expect(result.skippedPaths).toEqual(["huge.mp4"]);
+					expect(result.changes).toEqual([{ path: "small.md", type: "ADDED" }]);
+					expect(result.newState).toEqual({ "small.md": expect.any(String) });
+					// A new commit was created for the file that succeeded
+					expect(result.commitSha).not.toBe(PARENTCOMMIT123_SHA);
+				});
+
+				it("should skip all upload files and still apply deletions when all uploads return 422", async () => {
+					const existingTree: TreeNode[] = [
+						{ path: "todelete.md", type: "blob", mode: "100644", sha: BLOB1_SHA }
+					];
+					fakeOctokit.setupInitialState(PARENTCOMMIT123_SHA, TREE456_SHA, existingTree);
+					fakeOctokit.simulatePersistentError("POST /repos/{owner}/{repo}/git/blobs", make422Error());
+
+					const result = await vault.applyChanges(
+						[
+							{ path: "huge1.mp4", content: FileContent.fromPlainText("x") },
+							{ path: "huge2.mp4", content: FileContent.fromPlainText("y") },
+						],
+						["todelete.md"]
+					);
+
+					fakeOctokit.clearError("POST /repos/{owner}/{repo}/git/blobs");
+					expect([...result.skippedPaths!].sort()).toEqual(["huge1.mp4", "huge2.mp4"]);
+					// Deletion still committed
+					expect(result.changes).toEqual([{ path: "todelete.md", type: "REMOVED" }]);
+					expect(result.newState).not.toHaveProperty("todelete.md");
+					expect(result.commitSha).not.toBe(PARENTCOMMIT123_SHA);
+				});
+
+				it("should throw VaultError for non-422 upload failures (unchanged behaviour)", async () => {
+					fakeOctokit.setupInitialState(PARENTCOMMIT123_SHA, TREE456_SHA, []);
+					const serverError: any = new Error("Internal server error");
+					serverError.status = 500;
+					serverError.response = {};
+					fakeOctokit.simulateError("POST /repos/{owner}/{repo}/git/blobs", serverError);
+
+					await expect(
+						vault.applyChanges(
+							[{ path: "file.md", content: FileContent.fromPlainText("content") }],
+							[]
+						)
+					).rejects.toThrow(expect.objectContaining({ name: "VaultError" }));
+				});
+			});
 		});
 	});
 

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -565,31 +565,30 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		// Wait for all tree nodes, collecting both successes and failures
 		const results = await Promise.allSettled(operations.map(op => op.promise));
 
-		// Extract successful nodes and collect per-file errors
+		// Extract successful nodes, collect per-file errors, and separate 422 skips
 		const treeNodes: TreeNode[] = [];
 		const perFileErrors: Array<{ path: string; error: unknown }> = [];
+		const skippedFiles: Array<{ path: string; sizeMB: string }> = [];
 
 		results.forEach((result, index) => {
 			const { path, sizeBytes } = operations[index];
 			if (result.status === 'fulfilled' && result.value !== null) {
 				treeNodes.push(result.value);
 			} else if (result.status === 'rejected') {
-				let error = result.reason;
-				// Enhance 422 errors (input too large) with file size
-				if (sizeBytes !== null) {
-					const errorObj = error as { status?: number };
-					if (errorObj.status === 422) {
-						const sizeMB = (sizeBytes / (1024 * 1024)).toFixed(1);
-						const enhancedError = error instanceof Error ? error : new Error(String(error));
-						enhancedError.message = `${enhancedError.message} (file size: ${sizeMB} MB)`;
-						error = enhancedError;
-					}
+				const error = result.reason;
+				const errorObj = error as { status?: number };
+				// 422 = GitHub validation error; most commonly file too large, but not guaranteed.
+				// Skip and let the caller track it in unpushedFiles rather than aborting everything.
+				if (errorObj.status === 422 && sizeBytes !== null) {
+					const sizeMB = (sizeBytes / (1024 * 1024)).toFixed(1);
+					skippedFiles.push({ path, sizeMB });
+				} else {
+					perFileErrors.push({ path, error });
 				}
-				perFileErrors.push({ path, error });
 			}
 		});
 
-		// If any files failed, throw VaultError with per-file details
+		// Non-422 errors abort the sync entirely (unchanged behaviour)
 		if (perFileErrors.length > 0) {
 			const failedPaths = perFileErrors.map(e => e.path);
 			throw VaultError.network(
@@ -598,13 +597,37 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			);
 		}
 
-		// If no changes needed, return empty result (currentState already from cache)
+		// Build first-encounter warning for skipped files (shown by caller only when
+		// the file is newly added to unpushedFiles, not on every subsequent sync)
+		let skippedPathsList: string[] | undefined;
+		let skippedWarning: string | undefined;
+		if (skippedFiles.length > 0) {
+			skippedPathsList = skippedFiles.map(f => f.path);
+			const fileLines = skippedFiles.map(f => `  • ${f.path} (~${f.sizeMB} MB)`).join('\n');
+			skippedWarning = [
+				`${skippedFiles.length} file(s) skipped — GitHub API rejected (possibly too large):`,
+				fileLines,
+				'',
+				'To resolve, choose one:',
+				'  1. Exclude permanently: add path(s) to .gitignore',
+				`  2. Sync via git (desktop):`,
+				`       cd <your-repo> && git checkout ${this.branch}`,
+				`       git add <file> && git commit -m "sync large file" && git push`,
+				// TODO(#116): once local SHA uses canonical git blob format, FIT can detect content
+				// parity on the next sync and auto-clear unpushedFiles without downloading.
+				// At that point, restore "run a sync to confirm" and remove the caveat below.
+				'     Note: FIT may still be unable to download the file — option 1 is safer.',
+			].join('\n');
+		}
+
+		// If no changes needed (all files skipped or no-ops), return without committing
 		if (treeNodes.length === 0) {
 			return {
 				changes: [],
 				commitSha: parentCommitSha,
 				treeSha: parentTreeSha,
-				newState: currentState
+				newState: currentState,
+				...(skippedPathsList && { skippedPaths: skippedPathsList, skippedWarning }),
 			};
 		}
 
@@ -649,7 +672,8 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			commitSha: newCommitSha,
 			treeSha: newTreeSha,
 			newState,
-			userWarning
+			userWarning,
+			...(skippedPathsList && { skippedPaths: skippedPathsList, skippedWarning }),
 		};
 	}
 

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -170,6 +170,22 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		throw error;
 	}
 
+	/**
+	 * Returns true if the HTTP status code indicates a file-specific rejection that
+	 * should be skipped rather than treated as a sync-aborting error.
+	 *
+	 * 401/403: auth rejection — unlikely here since auth is pre-verified by readFromSource(),
+	 *          so more likely a size-based policy enforcement
+	 * 413: request entity too large
+	 * 422: unprocessable entity (GitHub's documented blob-too-large code)
+	 *
+	 * Excluded: 429 (rate limit — transient, not file-specific) and other 4xx codes
+	 * that indicate systemic API misuse or transient failures.
+	 */
+	private isBlobRejectionStatus(status: number): boolean {
+		return [401, 403, 413, 422].includes(status);
+	}
+
 	// ===== Read Operations =====
 
 	/**
@@ -296,6 +312,12 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			);
 			return blob.sha as BlobSha;
 		} catch (error) {
+			const status = (error as { status?: number }).status;
+			// Re-throw so applyChanges can treat this as a skippable file rejection.
+			// wrapOctokitError would lose the status code by converting to VaultError.
+			if (typeof status === 'number' && this.isBlobRejectionStatus(status)) {
+				throw error;
+			}
 			return await this.wrapOctokitError(error, 'repo');
 		}
 	}
@@ -577,9 +599,8 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			} else if (result.status === 'rejected') {
 				const error = result.reason;
 				const errorObj = error as { status?: number };
-				// 422 = GitHub validation error; most commonly file too large, but not guaranteed.
-				// Skip and let the caller track it in unpushedFiles rather than aborting everything.
-				if (errorObj.status === 422 && sizeBytes !== null) {
+				const isFileRejection = typeof errorObj.status === 'number' && this.isBlobRejectionStatus(errorObj.status);
+				if (isFileRejection && sizeBytes !== null) {
 					const sizeMB = (sizeBytes / (1024 * 1024)).toFixed(1);
 					skippedFiles.push({ path, sizeMB });
 				} else {
@@ -703,7 +724,7 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 	 * Note: Sync policy filtering (e.g., excluding _fit/, .obsidian/) is handled
 	 * by the caller (Fit), not by the vault.
 	 */
-	shouldTrackState(path: string): boolean {
+	shouldTrackState(_path: string): boolean {
 		return true;
 	}
 

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -214,6 +214,23 @@ export class FakeOctokit {
 	}
 
 	/**
+	 * Simulate a persistent error for a specific route.
+	 * Every call to this route will throw the specified error until clearError is called.
+	 */
+	simulatePersistentError(route: string, error: Error): void {
+		this.errorSimulations.set(route, error);
+		// Override request to keep the error in place (not consumed)
+		this._persistentErrors.add(route);
+	}
+
+	clearError(route: string): void {
+		this.errorSimulations.delete(route);
+		this._persistentErrors.delete(route);
+	}
+
+	private _persistentErrors: Set<string> = new Set();
+
+	/**
 	 * Add a blob to the fake repository.
 	 */
 	addBlob(sha: BlobSha, content: string): void {
@@ -247,7 +264,9 @@ export class FakeOctokit {
 		// Check for simulated errors first
 		const simulatedError = this.errorSimulations.get(route);
 		if (simulatedError) {
-			this.errorSimulations.delete(route); // Clear after throwing once
+			if (!this._persistentErrors.has(route)) {
+				this.errorSimulations.delete(route); // Clear after throwing once (non-persistent)
+			}
 			throw simulatedError;
 		}
 
@@ -741,6 +760,7 @@ export class FakeRemoteVault implements IVault<"remote"> {
 	private blobShas: Map<BlobSha, Base64Content> = new Map(); // blob SHA -> content
 	private commitSha: CommitSha = 'initial-commit' as CommitSha;
 	private failureError: Error | null = null;
+	private _skippedPaths: Set<string> = new Set(); // Paths that return 422 on next applyChanges
 	private owner: string;
 	private repo: string;
 	private branch: string;
@@ -763,6 +783,14 @@ export class FakeRemoteVault implements IVault<"remote"> {
 	 */
 	clearFailure(): void {
 		this.failureError = null;
+	}
+
+	/**
+	 * Configure paths that should be skipped on the next applyChanges call (simulates 422).
+	 * The skipped paths are included in the result's skippedPaths array instead of being written.
+	 */
+	setSkippedPaths(paths: string[]): void {
+		this._skippedPaths = new Set(paths);
 	}
 
 	/**
@@ -896,12 +924,18 @@ export class FakeRemoteVault implements IVault<"remote"> {
 		}
 
 		const changes: FileChange[] = [];
+		const skippedPaths: string[] = [];
 
 		for (const file of filesToWrite) {
+			if (this._skippedPaths.has(file.path)) {
+				skippedPaths.push(file.path);
+				continue; // Simulate 422 skip
+			}
 			const existed = this.files.has(file.path);
 			this.setFile(file.path, file.content);
 			changes.push({ path: file.path, type: existed ? 'MODIFIED' : 'ADDED' });
 		}
+		this._skippedPaths.clear(); // Consume after one applyChanges call
 
 		for (const path of filesToDelete) {
 			if (this.files.has(path)) {
@@ -928,11 +962,16 @@ export class FakeRemoteVault implements IVault<"remote"> {
 		// This mimics RemoteGitHubVault.buildStateFromTree behavior
 		const newState = await this.buildCurrentState(false);
 
+		const skippedWarning = skippedPaths.length > 0
+			? `${skippedPaths.length} file(s) skipped — GitHub API rejected (possibly too large):\n  • ${skippedPaths.join('\n  • ')}\n\nTo resolve, choose one:\n  1. Exclude permanently: add path(s) to .gitignore\n  2. Sync via git (desktop):\n       git push\n     Note: FIT may still be unable to download the file — option 1 is safer.`
+			: undefined;
+
 		return {
 			changes: changes,
 			commitSha: this.commitSha,
 			treeSha,
-			newState
+			newState,
+			...(skippedPaths.length > 0 && { skippedPaths, skippedWarning }),
 		};
 	}
 

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -53,6 +53,12 @@ type ApplyChangesResultMap = {
 		treeSha: TreeSha;
 		/** FileStates computed from the new tree (for cache updates) */
 		newState: FileStates;
+		/** Paths skipped because GitHub returned 422 (file too large for API).
+		 * Caller must add these to unpushedFiles — they are NOT in newState. */
+		skippedPaths?: string[];
+		/** Pre-built first-encounter notice for skipped files (includes git CLI instructions
+		 * with repo/branch substituted). Show only when path is newly added to unpushedFiles. */
+		skippedWarning?: string;
 	};
 };
 


### PR DESCRIPTION
This fails more gracefully with 3 improvements over previous behavior:
1. Overall sync succeeds, cleanly syncing all other files if 422 was the only failure type
2. Clearly communicates workaround options in the user warning (which now include .gitignore finally!)
3. Subsequent syncs won't keep retrying the same expensive push of the large file unless the file content actually changes

Note there is still one pain point not fixed yet here: even if you do use a workaround to manually upload large files, the plugin will not be able to detect that the remote file matches the local file because it currently uses nonstandard SHA calculations (see #116). That's a solvable problem, but will take additional nontrivial work to solve it.

Fixes most of #146.

---

<!-- kody-pr-summary:start -->
This pull request introduces a robust mechanism to handle files that exceed GitHub API size limits (e.g., 422 "Unprocessable Entity" errors) during synchronization.

Key changes include:

*   **Partial Sync Success**: The system will now skip files that are too large for the GitHub API, allowing other valid changes to be pushed successfully. The overall sync operation will report success, rather than failing entirely due to a single large file.
*   **Dedicated Tracking for Skipped Files**: A new `unpushedFiles` store is introduced to track files that were skipped due to size limits. This prevents the sync engine from repeatedly attempting to push the same large, unchanged file on subsequent syncs.
*   **Tiered User Notifications**:
    *   **First Encounter**: When a file is *newly* skipped, a prominent, sticky notice is displayed. This notice explains the reason for the skip (API size limit), shows the file path and size, and provides clear instructions on how to resolve the issue (either by adding the file to `.gitignore` or by manually pushing it via the Git CLI).
    *   **Subsequent Manual Syncs**: For manual syncs, if previously skipped files remain unpushed and unchanged, a brief reminder is appended to the regular sync success message.
    *   **Auto Syncs**: During automatic syncs, if no *new* files are skipped, only a log entry is made, avoiding disruptive notifications.
*   **Automatic Reconciliation of Skipped Files**: The `unpushedFiles` list is automatically cleared for a file if:
    *   The file is modified locally (it will then re-enter the normal sync queue).
    *   The file is detected as having been pushed to the remote repository by other means (e.g., via `git push` outside of Obsidian).
    *   The file is deleted locally.
    *   The file is added to the `.gitignore` file, explicitly excluding it from sync.
*   **Improved Error Handling**: The remote vault now specifically identifies and handles HTTP 4xx status codes (401, 403, 413, 422) during file uploads as skippable file rejections, allowing the sync to continue for other files. Other types of errors (e.g., 500 server errors) will still cause a full sync failure.
*   **Updated Guidance**: General error messages for per-file issues now explicitly recommend using `.gitignore` to exclude files from synchronization.

This enhancement significantly improves the robustness and user experience by preventing large files from blocking the entire synchronization process and providing clear, actionable guidance for users to manage such files.
<!-- kody-pr-summary:end -->