### PR TITLE
fix local SHA calculations to use canonical SHAs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,38 +52,32 @@ A "vault" represents a complete collection of synced files, whether stored local
 
 ### SHA Algorithms and Change Detection
 
-**CRITICAL: Local and Remote SHAs are INCOMPATIBLE**
+Both local and remote caches use the canonical Git blob SHA format: `SHA1("blob " + byteLength + "\0" + rawBytes)`.
 
-FIT uses different SHA algorithms for local and remote file tracking:
-
-- **Local SHA** (`LocalVault.fileSha1`): `SHA1(normalizedPath + content)`
+- **Local SHA** (`LocalVault.fileSha1`): canonical git blob SHA
   - Used for detecting local changes between syncs
-  - Stored in `localSha` cache (part of LocalStores in data.json)
-  - Custom algorithm designed for consistent cross-platform hashing
-  - Does NOT match Git's blob SHA format
+  - Stored in `localShas` cache (part of LocalStores in data.json)
+  - Matches GitHub's blob SHA — enables SHA parity optimization (skip download when local SHA equals remote SHA)
 
-- **Remote SHA** (from GitHub API): Git blob SHA format `SHA1("blob " + size + "\0" + content)`
+- **Remote SHA** (from GitHub API): same git blob SHA format
   - Used for detecting remote changes between syncs
-  - Stored in `lastFetchedRemoteSha` cache (part of LocalStores in data.json)
-  - Standard Git blob object format
-  - Computed by GitHub when files are committed
+  - Stored in `lastFetchedRemoteShas` cache (part of LocalStores in data.json)
+  - Returned directly by the GitHub tree API
 
-**Why different algorithms?**
-- Local SHA predates understanding of Git blob format
-- Changing local SHA algorithm would invalidate all existing caches
-- Local SHA includes path in hash (helps with Unicode normalization tracking, issue #51)
-- Both algorithms serve the same purpose: detect when file content changed
+**Important:**
+- ✅ Local and remote SHAs can be directly compared when encryption is off
+- ❌ **NEVER copy remote SHA into `localShas` as a baseline** — baseline must be computed from the file bytes actually written to disk, not from the remote tree entry (which may differ under encryption)
+- ✅ When recording baseline for remote content, compute via `LocalVault.fileSha1()` from the bytes written
 
-**Important consequences:**
-- ❌ **NEVER compare local SHA directly with remote SHA** - they will never match even for identical files
-- ❌ **NEVER copy remote SHA into localSha** - will break change detection
-- ✅ When recording baseline for remote content, always compute using `LocalVault.fileSha1()`
-- ✅ Each SHA cache uses its own algorithm consistently
+**Legacy migration (`localSha` singular):**
+- Pre-v1.6 used `SHA1(normalizedPath + content)` stored in `localSha` (singular)
+- On first sync after upgrade, `getLocalChanges()` batch-migrates all legacy files: re-reads each to verify the legacy SHA still matches, then promotes the canonical SHA to `localShas`
+- `localSha` is omitted from storage once fully migrated
 
 **Code references:**
-- Local SHA: [src/localVault.ts:228 `fileSha1()`](../src/localVault.ts#L228)
-- Algorithm note: [src/util/hashing.ts:22](../src/util/hashing.ts#L22)
-- Baseline recording: [src/fitSync.ts:538-547](../src/fitSync.ts#L538)
+- Local SHA: [`src/localVault.ts` `fileSha1()`](../src/localVault.ts)
+- Canonical SHA computation: [`src/util/hashing.ts` `computeGitBlobSha()`](../src/util/hashing.ts)
+- Baseline recording: [`src/fitSync.ts`](../src/fitSync.ts)
 
 ### Sync Engine (fitSync.ts, fit.ts)
 **Purpose**: Core synchronization logic
@@ -169,9 +163,10 @@ sequenceDiagram
 │   ├── autoSync preferences
 │   └── notification settings
 └── localStore (sync state cache)
-    ├── localSha (file path -> SHA map)
+    ├── localShas (file path -> canonical git blob SHA)
+    ├── localSha? (legacy field, present only during migration from pre-v1.6)
     ├── lastFetchedCommitSha
-    └── lastFetchedRemoteSha (remote file path -> SHA map)
+    └── lastFetchedRemoteShas (remote file path -> git blob SHA)
 
 .obsidian/plugins/fit/debug.log:
 └── Debug logs (when enabled in settings)

--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -17,7 +17,7 @@ This document explains the detailed sync logic in FIT - the nuts and bolts of ho
 
 FIT uses SHA-based change detection to maintain **baseline state** versions (`LocalStores` - persisted to disk):
 
-  - `localSha`, `lastFetchedRemoteSha`, `lastFetchedCommitSha`
+  - `localShas`, `lastFetchedRemoteShas`, `lastFetchedCommitSha`
   - Reference point from last **successful** sync
   - Updated only on sync success
 
@@ -29,11 +29,11 @@ FIT uses SHA-based change detection to maintain **baseline state** versions (`Lo
 
 ```typescript
 {
-  localSha: {
+  localShas: {
     "file1.md": "abc123...",
     "file2.md": "def456..."
   },
-  lastFetchedRemoteSha: {
+  lastFetchedRemoteShas: {
     "file1.md": "abc123...",
     "file3.md": "ghi789..."
   },
@@ -52,7 +52,7 @@ sequenceDiagram
 
     Note over Storage,Remote: Plugin Load
     Storage->>Fit: Load SHA caches
-    Note over Fit: localSha, lastFetchedRemoteSha,<br/>lastFetchedCommitSha
+    Note over Fit: localShas, lastFetchedRemoteShas,<br/>lastFetchedCommitSha
 
     Note over Storage,Remote: Sync Operation
     par Read States (from Local/Remote in parallel)
@@ -97,7 +97,7 @@ See [SHA Computation Strategy](#sha-computation-strategy) below for detailed rat
 
 This enables future syncs to compare current local SHA vs baseline to determine if the file changed locally.
 
-**CRITICAL:** Must use local SHA algorithm (`SHA1(normalizedPath + content)`), NOT remote SHA from GitHub API. See [docs/architecture.md](./architecture.md) "SHA Algorithms and Change Detection".
+**CRITICAL:** Must use `LocalVault.fileSha1()` (canonical git blob SHA), NOT the raw SHA from the GitHub tree API. See [docs/architecture.md](./architecture.md) "SHA Algorithms and Change Detection".
 
 **Note:** Reading hidden files for baseline comparison requires using `vault.adapter` API instead of `vault.getAbstractFileByPath()`. See [docs/api-compatibility.md](./api-compatibility.md) "Reading Untracked Files".
 
@@ -118,12 +118,12 @@ This enables future syncs to compare current local SHA vs baseline to determine 
 
 ### 💾 Local Change Detection
 
-FIT compares current local file SHAs against the cached `localSha` to detect changes since the last sync.
+FIT compares current local file SHAs against the cached `localShas` to detect changes since the last sync.
 
 ```mermaid
 flowchart TD
     Start[Scan Vault Files] --> ComputeSHA[Compute SHA for each file]
-    ComputeSHA --> Compare{Compare with<br/>cached localSha}
+    ComputeSHA --> Compare{Compare with<br/>cached localShas}
 
     Compare -->|File in cache,<br/>SHA differs| Modified[✏️ MODIFIED]
     Compare -->|File not in cache| Added[🟢 ADDED]
@@ -155,7 +155,7 @@ cachedLocalSha = {
 
 ### ☁️ Remote Change Detection
 
-Same logic applies for remote changes, comparing `currentRemoteTreeSha` against `lastFetchedRemoteSha`.
+Same logic applies for remote changes, comparing `currentRemoteTreeSha` against `lastFetchedRemoteShas`.
 
 **How the remote vault provides file states:**
 
@@ -180,7 +180,7 @@ currentRemoteTreeSha = {
   "file3.md": "new789"  // New file
 }
 
-lastFetchedRemoteSha = {
+lastFetchedRemoteShas = {
   "file1.md": "old999",  // SHA changed
   "file2.md": "def456"   // No longer exists remotely
 }
@@ -202,8 +202,8 @@ If a cache becomes stale or corrupted:
 
 **Example Bug Scenario:**
 ```typescript
-// User deletes file locally, but localSha cache is lost/corrupted
-localSha = {}  // STALE: Should have "deleted.md"
+// User deletes file locally, but localShas cache is lost/corrupted
+localShas = {}  // STALE: Should have "deleted.md"
 
 currentLocalSha = {}  // File doesn't exist
 
@@ -228,7 +228,7 @@ FIT implements three layers of path filtering:
 **Behavior:**
 - **⬆️ Local→Remote:** Never push protected paths to remote
 - **⬇️ Remote→Local:** Save to 📁 `_fit/` for user transparency (e.g., `_fit/.obsidian/app.json`)
-- **📦 SHA Caches:** Excluded from both `localSha` and `lastFetchedRemoteSha`
+- **📦 SHA Caches:** Excluded from both `localShas` and `lastFetchedRemoteShas`
 
 **Why save remote protected paths to `_fit/`?**
 - User can see what exists on remote without risk
@@ -261,8 +261,8 @@ if (!this.fit.shouldSyncPath(".obsidian/app.json")) {
 **Hidden files:** Any path component starting with `.` (e.g., `.gitignore`, `.hidden-config.json`)
 
 **Behavior:**
-- **💾 Local tracking:** Excluded from `localSha` (can't reliably scan)
-- **☁️ Remote tracking:** Included in `lastFetchedRemoteSha` (can read from GitHub API)
+- **💾 Local tracking:** Excluded from `localShas` (can't reliably scan)
+- **☁️ Remote tracking:** Included in `lastFetchedRemoteShas` (can read from GitHub API)
 - **⬇️ Remote→Local:** Save to 📁 `_fit/` for safety (can't verify local state)
 - **⬆️ Local→Remote:** Silently ignored (never synced)
 
@@ -277,8 +277,8 @@ if (!this.fit.shouldSyncPath(".obsidian/app.json")) {
 // We can't read local .gitignore to compare
 // Solution: Save remote version to _fit/.gitignore (no overwrite risk)
 
-localSha = {}  // .gitignore not tracked
-lastFetchedRemoteSha = { ".gitignore": "abc123" }
+localShas = {}  // .gitignore not tracked
+lastFetchedRemoteShas = { ".gitignore": "abc123" }
 
 // On sync:
 // - Remote .gitignore saved to _fit/.gitignore
@@ -298,7 +298,7 @@ lastFetchedRemoteSha = { ".gitignore": "abc123" }
 - Only probes paths derived from the tracked file set — no full filesystem scan
 
 **Behavior:**
-- Files matched by any applicable `.gitignore` are excluded from `localSha` and never pushed
+- Files matched by any applicable `.gitignore` are excluded from `localShas` and never pushed
 - Patterns scope correctly: a `build/.gitignore` only affects files under `build/`
 - If no `.gitignore` files exist, this layer is a no-op
 
@@ -323,7 +323,7 @@ Files in `.obsidian/` are filtered by BOTH:
 **Result:**
 - Never synced in either direction
 - Remote `.obsidian/` files saved to `_fit/.obsidian/` for transparency
-- Excluded from both `localSha` and `lastFetchedRemoteSha`
+- Excluded from both `localShas` and `lastFetchedRemoteShas`
 
 ### Implementation Locations
 
@@ -338,12 +338,12 @@ Files in `.obsidian/` are filtered by BOTH:
 ```mermaid
 flowchart TD
     Start[Local file] --> Trackable{shouldTrackState?}
-    Trackable -->|No| Skip[Excluded from localSha]
+    Trackable -->|No| Skip[Excluded from localShas]
     Trackable -->|Yes| Gitignore{GitignoreFilter?}
     Gitignore -->|Ignored| Skip
     Gitignore -->|Not ignored| Protected{shouldSyncPath?}
     Protected -->|No| Skip
-    Protected -->|Yes| Tracked[Included in localSha / pushed to remote]
+    Protected -->|Yes| Tracked[Included in localShas / pushed to remote]
 
     Skip --> End[Done]
     Tracked --> End
@@ -359,12 +359,12 @@ flowchart TD
 
 ```typescript
 // v2 tracked .gitignore via DataAdapter, cache state:
-localSha = { ".gitignore": "abc123" }  // v2 tracked it
-lastFetchedRemoteSha = { ".gitignore": "abc123" }
+localShas = { ".gitignore": "abc123" }  // v2 tracked it
+lastFetchedRemoteShas = { ".gitignore": "abc123" }
 
 // After v3 upgrade or setting disabled:
 newScan = {}  // Reverted to Vault API (can't read hidden files)
-compareFileStates(newScan, localSha) // // → reports ".gitignore" as REMOVED
+compareFileStates(newScan, localShas) // → reports ".gitignore" as REMOVED
 // ⚠️ Risk: Plugin pushes deletion to remote → DATA LOSS
 ```
 
@@ -481,8 +481,8 @@ flowchart TD
 
 **Actions:**
 1. Push local changes to remote
-2. Update `localSha` to current local state
-3. Update `lastFetchedRemoteSha` with new remote tree
+2. Update `localShas` to current local state
+3. Update `lastFetchedRemoteShas` with new remote tree
 4. Update `lastFetchedCommitSha` with new commit
 
 #### 3. Only Remote Changed
@@ -491,8 +491,8 @@ flowchart TD
 
 **Actions:**
 1. Pull remote changes to local
-2. Update `localSha` with new local state
-3. Update `lastFetchedRemoteSha` to current remote
+2. Update `localShas` with new local state
+3. Update `lastFetchedRemoteShas` to current remote
 4. Update `lastFetchedCommitSha` with latest commit
 
 #### 4. Only Commit SHA Changed
@@ -610,14 +610,14 @@ flowchart TD
 
 **State:**
 ```typescript
-localSha = {}  // No baseline yet
-lastFetchedRemoteSha = {}  // No baseline yet
+localShas = {}  // No baseline yet
+lastFetchedRemoteShas = {}  // No baseline yet
 lastFetchedCommitSha = "initial"
 ```
 
 **Behavior:**
-1. **All local files** appear as "ADDED" (not in `localSha` cache)
-2. **All remote files** appear as "ADDED" (not in `lastFetchedRemoteSha` cache)
+1. **All local files** appear as "ADDED" (not in `localShas` cache)
+2. **All remote files** appear as "ADDED" (not in `lastFetchedRemoteShas` cache)
 3. **Files existing both locally and remotely** are detected as conflicts
 4. **Conflict resolution applies:**
    - If content is identical → Auto-resolved (no action needed)
@@ -660,7 +660,7 @@ FIT uses a specialized SHA computation approach during sync operations to maximi
 **1. Full Vault Scan (Pre-Sync)**
 - **When:** Before each sync to detect local changes
 - **Method:** Read all vault files from disk and compute SHAs
-- **Purpose:** Compare current state to cached baseline (`localSha`)
+- **Purpose:** Compare current state to cached baseline (`localShas`)
 - **Implementation:** [`LocalVault.readFromSource()`](../src/localVault.ts)
 
 **2. Specialized Updates (During Sync)**
@@ -846,12 +846,12 @@ This is not an error - it's a self-healing mechanism that corrects cache inconsi
 
 ### Lost SHA Cache
 
-**Scenario:** `localSha` cache is empty/corrupted but files exist in vault
+**Scenario:** `localShas` cache is empty/corrupted but files exist in vault
 
 **Problem:**
 ```typescript
 // CORRUPTED STATE
-localSha = {}  // Should contain cached SHAs
+localShas = {}  // Should contain cached SHAs
 
 currentLocalSha = {
   "existing-file.md": "abc123"
@@ -871,13 +871,13 @@ currentLocalSha = {
 **Problem:**
 ```typescript
 // User deleted file, but cache not updated
-localSha = {
+localShas = {
   "deleted-file.md": "old-sha"  // STALE
 }
 
 currentLocalSha = {}  // File doesn't exist
 
-lastFetchedRemoteSha = {
+lastFetchedRemoteShas = {
   "deleted-file.md": "old-sha"
 }
 

--- a/main.ts
+++ b/main.ts
@@ -64,11 +64,18 @@ const DEFAULT_SETTINGS: FitSettings = {
  * Tracks sync state between plugin sessions to enable incremental sync
  */
 export interface LocalStores {
-	localSha: FileStates                   // File path -> SHA cache
+	localShas: FileStates                  // Canonical git blob SHA cache (primary)
+	// SHAs here use a legacy formula (SHA1(path + content)) that differs from canonical git blob SHA,
+	// with content encoded as base64 for png/jpg/jpeg/pdf and as plaintext for everything else.
+	// Downgrade notice: old client versions may find this field missing and see spurious local file
+	// changes, but those trigger re-upload overhead only and rarely clash unless the same files were
+	// also updated on remote during the same sync.
+	localSha?: FileStates                  // Legacy path+content SHA cache (migration source only)
 	lastFetchedCommitSha: CommitSha | null // Last synced commit
-	lastFetchedRemoteSha: FileStates       // Remote file path -> SHA cache
+	lastFetchedRemoteShas: FileStates      // Canonical remote SHA cache
+	lastFetchedRemoteSha?: FileStates      // Legacy field name — read-only fallback when loading old data
 	// Files that were skipped due to GitHub API size limits (422) and haven't reached
-	// remote yet. Maps path → FIT SHA at time of skip, so we can detect when the file
+	// remote yet. Maps path → SHA at time of skip, so we can detect when the file
 	// has been modified locally (and should re-enter the normal sync queue) or reconciled
 	// on remote (and should be removed from this list).
 	// Note: transient failures like rate limits (#179) should be tracked separately when needed since they SHOULD retry on subsequent syncs.
@@ -86,10 +93,11 @@ type SyncOutcome =
 	| { status: 'not-configured' };
 
 const DEFAULT_LOCAL_STORE: LocalStores = {
-	localSha: {},
+	localShas: {},
 	lastFetchedCommitSha: null,
-	lastFetchedRemoteSha: {},
+	lastFetchedRemoteShas: {},
 	unpushedFiles: {}
+	// Note: no localSha — absent means no legacy data to migrate
 };
 
 
@@ -529,15 +537,15 @@ export default class FitPlugin extends Plugin {
 	}
 
 	async loadLocalStore() {
-		const localStore = Object.assign({}, DEFAULT_LOCAL_STORE, await this.loadData());
-		const localStoreObj: LocalStores = Object.keys(DEFAULT_LOCAL_STORE).reduce(
-			(obj, key: keyof LocalStores) => {
-				if (localStore.hasOwnProperty(key)) {
-					obj[key] = localStore[key];
-				}
-				return obj;
-			}, {} as LocalStores);
-		this.localStore = localStoreObj;
+		const storedData = (await this.loadData()) ?? {};
+		this.localStore = {
+			localShas: storedData.localShas ?? {},
+			localSha: storedData.localSha,                          // undefined if absent → omitted by JSON.stringify
+			lastFetchedCommitSha: storedData.lastFetchedCommitSha ?? null,
+			lastFetchedRemoteShas: storedData.lastFetchedRemoteSha ?? storedData.lastFetchedRemoteShas ?? {},
+			lastFetchedRemoteSha: undefined,                        // consume legacy field name → omitted by JSON.stringify, removing it from storage
+			unpushedFiles: storedData.unpushedFiles ?? {}
+		};
 	}
 
 	// allow saving of local stores property, passed in properties will override existing stored value

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -28,10 +28,10 @@ import { CommitSha } from "./util/hashing";
  * @see RemoteGitHubVault - Remote GitHub repository operations
  */
 export class Fit {
-	// TODO: Rename these for clarity: localFileShas, remoteCommitSha, remoteFileShas
-	localSha: FileStates;                   // Cache of local file SHAs
+	localShas: FileStates;                  // Canonical git blob SHA cache (primary, v2)
+	localSha: FileStates;                   // Legacy path+content SHA cache (migration source)
 	lastFetchedCommitSha: CommitSha | null; // Last synced commit SHA
-	lastFetchedRemoteSha: FileStates;       // Cache of remote file SHAs
+	lastFetchedRemoteShas: FileStates;      // Canonical remote SHA cache
 	unpushedFiles: FileStates;              // Files skipped due to API size limit (422)
 	localVault: LocalVault;                 // Local vault (tracks local file state)
 	remoteVault: RemoteGitHubVault;
@@ -80,30 +80,29 @@ export class Fit {
 	}
 
 	loadLocalStore(localStore: LocalStores) {
-		this.localSha = localStore.localSha;
+		this.localShas = localStore.localShas ?? {};
+		this.localSha = localStore.localSha ?? {};
 		this.lastFetchedCommitSha = localStore.lastFetchedCommitSha;
-		this.lastFetchedRemoteSha = localStore.lastFetchedRemoteSha;
+		this.lastFetchedRemoteShas = localStore.lastFetchedRemoteShas;
 		this.unpushedFiles = localStore.unpushedFiles ?? {};
-		// Detect potentially corrupted/suspicious cache states
-		const localCount = Object.keys(this.localSha).length;
-		const remoteCount = Object.keys(this.lastFetchedRemoteSha).length;
+
+		const localCount = Object.keys(this.localShas).length;
+		const legacyCount = Object.keys(this.localSha).length;
+		const remoteCount = Object.keys(this.lastFetchedRemoteShas).length;
 		const warnings: string[] = [];
 
-		// Warn if caches are empty but commit SHA exists (possible cache corruption)
-		if (localCount === 0 && remoteCount === 0 && this.lastFetchedCommitSha) {
+		if (localCount === 0 && legacyCount === 0 && remoteCount === 0 && this.lastFetchedCommitSha) {
 			warnings.push('Empty SHA caches but commit SHA exists - possible cache corruption or first sync after data loss');
 		}
-
-		// Warn if local cache is empty but remote cache has files (asymmetric state)
-		if (localCount === 0 && remoteCount > 0) {
+		if (localCount === 0 && legacyCount === 0 && remoteCount > 0) {
 			warnings.push('Local SHA cache empty but remote cache has files - may incorrectly pull files as "new" that were deleted locally');
 		}
 
-		// Log SHA cache provenance for debugging
 		fitLogger.log('.. 📦 [Cache] Loaded SHA caches from storage', {
 			source: 'plugin data.json',
-			localShaCount: localCount,
-			remoteShaCount: remoteCount,
+			localShasCount: localCount,
+			legacyShaCount: legacyCount,
+			remoteShasCount: remoteCount,
 			lastCommit: this.lastFetchedCommitSha,
 			...(warnings.length > 0 && { warnings })
 		});
@@ -161,23 +160,59 @@ export class Fit {
 		fitLogger.log('.. 💾 [LocalVault] Scanning files...');
 		const readResult = await this.localVault.readFromSource();
 		const currentState = readResult.state;
-		// Filter both states to only trackable files for comparison (#169)
-		// This prevents hidden files (stored for baseline checking) from appearing as spurious changes
-		// Filter cached state to exclude hidden files
-		const trackableLocalSha: FileStates = {};
-		for (const [path, sha] of Object.entries(this.localSha)) {
-			if (this.localVault.shouldTrackState(path)) {
-				trackableLocalSha[path] = sha;
+
+		// Clean up orphaned legacy entries for files no longer present locally.
+		for (const path of Object.keys(this.localSha)) {
+			if (currentState[path] === undefined) {
+				delete this.localSha[path];
 			}
 		}
-		// Filter current state to exclude hidden files (defensive against bugs)
+
+		// Batch migration on first sync after upgrade: promote all legacy SHAs to canonical.
+		// Re-reads each legacy file to compute the legacy SHA and verify content is unchanged,
+		// then adopts the canonical SHA from readFromSource() as the new baseline.
+		// This doubles file reads for legacy files on this sync. Canonical-only and neither cases
+		// are handled normally by compareFileStates below.
+		const pendingLegacyPaths = Object.keys(this.localSha).filter(p => currentState[p] !== undefined);
+		if (pendingLegacyPaths.length > 0) {
+			const rePromotingPaths = pendingLegacyPaths.filter(p => this.localShas[p] !== undefined);
+			if (rePromotingPaths.length > 0) {
+				fitLogger.log('[Fit] Discarding stale canonical SHAs for re-promotion', {
+					count: rePromotingPaths.length,
+					reason: 'localSha and localShas both present — old client wrote legacy SHAs after a downgrade; treating localSha as more recent and re-running migration'
+				});
+			}
+			fitLogger.log('[Fit] Promoting legacy SHAs to canonical', { count: pendingLegacyPaths.length });
+			for (const path of pendingLegacyPaths) {
+				try {
+					const content = await this.localVault.readFileContent(path);
+					const legacySha = await LocalVault.fileLegacySha1(path, content);
+					if (legacySha === this.localSha[path]) {
+						// Content unchanged since legacy sync — adopt canonical SHA as baseline.
+						this.localShas[path] = currentState[path];
+					}
+					// On mismatch: file changed, no canonical baseline set → appears as ADDED below.
+				} catch {
+					// File unreadable — leave unresolved, re-tries next sync.
+				}
+				delete this.localSha[path];
+			}
+		}
+
+		// Filter both states to trackable paths only (#169)
+		const trackableLocalShas: FileStates = {};
+		for (const [path, sha] of Object.entries(this.localShas)) {
+			if (this.localVault.shouldTrackState(path)) {
+				trackableLocalShas[path] = sha;
+			}
+		}
 		const trackableCurrentState: FileStates = {};
 		for (const [path, sha] of Object.entries(currentState)) {
 			if (this.localVault.shouldTrackState(path)) {
 				trackableCurrentState[path] = sha;
 			}
 		}
-		const changes = compareFileStates(trackableCurrentState, trackableLocalSha);
+		const changes = compareFileStates(trackableCurrentState, trackableLocalShas);
 		return { changes, state: currentState };
 	}
 
@@ -195,7 +230,7 @@ export class Fit {
 		if (!commitSha) {
 			throw new Error("Expected RemoteGitHubVault to provide commitSha");
 		}
-		const changes = compareFileStates(state, this.lastFetchedRemoteSha);
+		const changes = compareFileStates(state, this.lastFetchedRemoteShas);
 
 		// Diagnostic logging for tracking remote cache state
 		if (changes.length > 0) {

--- a/src/fitSetting.ts
+++ b/src/fitSetting.ts
@@ -583,7 +583,7 @@ export default class FitSettingTab extends PluginSettingTab {
 						const { state } = await this.plugin.fit.remoteVault.readFromSource(true);
 
 						await this.plugin.saveLocalStoreCallback({
-							lastFetchedRemoteSha: state,
+							lastFetchedRemoteShas: state,
 						});
 
 						message(notice, "Cache has been updated");

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1926,10 +1926,12 @@ describe('FitSync', () => {
 
 		it('remote change for skipped file: removed from unpushedFiles (user pushed via git)', async () => {
 			// Arrange: file was previously skipped; now it appears as a remote change
-			// (simulates user running `git push` outside Obsidian)
-			await remoteVault.setFile('huge.mp4', 'manually pushed content');
-			localVault.setFile('huge.mp4', 'manually pushed content'); // Same content locally
-			const hugeFileSha = 'some-sha' as BlobSha;
+			// (simulates user running `git push` outside Obsidian to upload the same content)
+			const content = 'manually pushed content';
+			await remoteVault.setFile('huge.mp4', content);
+			localVault.setFile('huge.mp4', content);
+			// Use real canonical SHA — parity optimization will detect match and skip download
+			const hugeFileSha = await LocalVault.fileSha1('huge.mp4', FileContent.fromPlainText(content));
 			localStoreState = makeLocalStore({
 				...localStoreState,
 				localShas: { 'huge.mp4': hugeFileSha },

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -20,6 +20,17 @@ import { FileContent } from './util/contentEncoding';
 import { BlobSha, CommitSha } from './util/hashing';
 import FitNotice from './fitNotice';
 
+/** Build a LocalStores object with sensible defaults, overriding as needed. */
+function makeLocalStore(overrides: Partial<LocalStores> = {}): LocalStores {
+	return {
+		localShas: {},
+		lastFetchedRemoteShas: {},
+		lastFetchedCommitSha: null,
+		unpushedFiles: {},
+		...overrides
+	};
+}
+
 describe('FitSync', () => {
 	let localVault: FakeLocalVault;
 	let remoteVault: FakeRemoteVault;
@@ -138,11 +149,11 @@ describe('FitSync', () => {
 
 		// Initialize local store state (empty/synced state)
 		// Note: localStoreState is hoisted to test scope so assertions can verify its updates
-		localStoreState = {
-			localSha: {},
-			lastFetchedRemoteSha: {},
+		localStoreState = makeLocalStore({
+			localShas: {},
+			lastFetchedRemoteShas: {},
 			lastFetchedCommitSha: 'commit-initial' as CommitSha
-		};
+		});
 
 		// Capture console output for debugging failed tests
 		const consoleLogCapture: any[] = [];
@@ -219,11 +230,11 @@ describe('FitSync', () => {
 		]);
 
 		// Verify: LocalStores NOT updated
-		expect(localStoreState).toEqual({
-			localSha: {}, // Still empty
+		expect(localStoreState).toEqual(expect.objectContaining({
+			localShas: {}, // Still empty
 			lastFetchedCommitSha: 'commit-initial', // Unchanged
-			lastFetchedRemoteSha: {}, // Still empty
-		});
+			lastFetchedRemoteShas: {}, // Still empty
+		}));
 
 		// Verify: Remote not updated
 		expect(remoteVault.getAllFilesAsRaw()).toEqual({}); // Still empty
@@ -257,18 +268,18 @@ describe('FitSync', () => {
 		});
 
 		// Verify: LocalStores updated with BOTH files
-		expect(localStoreState).toEqual({
-			localSha: {
+		expect(localStoreState).toEqual(expect.objectContaining({
+			localShas: {
 				'fileA.md': expect.anything(),
 				'fileB.md': expect.anything()
 			},
 			lastFetchedCommitSha: expect.not.stringMatching('initial-commit'),
-			lastFetchedRemoteSha: {
+			lastFetchedRemoteShas: {
 				'fileA.md': expect.anything(),
 				'fileB.md': expect.anything()
 			},
 			unpushedFiles: {}
-		});
+		}));
 
 		// Verify: Remote has new commit and both files
 		expect(remoteVault.getAllFilesAsRaw()).toEqual({
@@ -323,10 +334,10 @@ describe('FitSync', () => {
 			// Verify: LocalStores - .obsidian/ files NOT tracked (filtered by shouldSyncPath)
 			// Protected paths (.obsidian/, _fit/) are excluded from both local and remote caches
 			expect(localStoreState).toMatchObject({
-				localSha: {
+				localShas: {
 					'normal.md': expect.any(String)  // Only normal file
 				},
-				lastFetchedRemoteSha: {
+				lastFetchedRemoteShas: {
 					'normal.md': expect.any(String)  // Only normal file (protected paths filtered)
 				}
 			});
@@ -401,10 +412,10 @@ describe('FitSync', () => {
 			// NOT present: '_fit/remote-conflict.md' (would conflict with our conflict resolution area)
 
 			// Verify: LocalStores track different files:
-			// - localSha: Only synced files (excludes _fit/ and other protected paths)
-			// - lastFetchedRemoteSha: ALL remote files (unfiltered to detect changes correctly)
-			expect(Object.keys(localStoreState.localSha).sort()).toEqual(['normal.md', 'remote-normal.md']);
-			expect(Object.keys(localStoreState.lastFetchedRemoteSha).sort()).toEqual([
+			// - localShas: Only synced files (excludes _fit/ and other protected paths)
+			// - lastFetchedRemoteShas: ALL remote files (unfiltered to detect changes correctly)
+			expect(Object.keys(localStoreState.localShas).sort()).toEqual(['normal.md', 'remote-normal.md']);
+			expect(Object.keys(localStoreState.lastFetchedRemoteShas).sort()).toEqual([
 				'_fit/remote-conflict.md',  // Protected path - tracked in remote cache but not local cache
 				'normal.md',
 				'remote-normal.md'
@@ -453,8 +464,8 @@ describe('FitSync', () => {
 			expect(Object.keys(remoteVault.getAllFilesAsRaw())).toEqual(['visible.md']);
 
 			// Verify: LocalStores only track visible file
-			expect(Object.keys(localStoreState.localSha)).toEqual(['visible.md']);
-			expect(Object.keys(localStoreState.lastFetchedRemoteSha)).toEqual(['visible.md']);
+			expect(Object.keys(localStoreState.localShas)).toEqual(['visible.md']);
+			expect(Object.keys(localStoreState.lastFetchedRemoteShas)).toEqual(['visible.md']);
 
 			// === STEP 3: Modify hidden file locally ===
 			localVault.setFile('.hidden-file.md', 'Updated hidden content');
@@ -491,11 +502,11 @@ describe('FitSync', () => {
 			localVault.setFile('normal.md', 'Normal content');
 			await remoteVault.setFile('normal.md', 'Normal content');
 			const remoteResult = await remoteVault.readFromSource();
-			localStoreState = {
-				localSha: (await localVault.readFromSource()).state,
-				lastFetchedRemoteSha: remoteResult.state,
+			localStoreState = makeLocalStore({
+				localShas: (await localVault.readFromSource()).state,
+				lastFetchedRemoteShas: remoteResult.state,
 				lastFetchedCommitSha: remoteResult.commitSha
-			};
+			});
 			const fitSync = createFitSync();
 
 			// === STEP 1: Create hidden file locally (not tracked by LocalVault) ===
@@ -530,12 +541,12 @@ describe('FitSync', () => {
 			expect(remoteVault.getFile('.hidden-config.json')).toBe('Remote version');
 
 			// Verify: LocalStores updated with both files (issue #169 fix)
-			// Hidden file IS now in localSha (SHA keyed by original path, not _fit/ path)
-			expect(localStoreState.localSha).toMatchObject({
+			// Hidden file IS now in localShas (SHA keyed by original path, not _fit/ path)
+			expect(localStoreState.localShas).toMatchObject({
 				'normal.md': expect.any(String),
 				'.hidden-config.json': expect.any(String)
 			});
-			expect(localStoreState.lastFetchedRemoteSha).toMatchObject({
+			expect(localStoreState.lastFetchedRemoteShas).toMatchObject({
 				'normal.md': expect.any(String),
 				'.hidden-config.json': expect.any(String)
 			});
@@ -545,11 +556,11 @@ describe('FitSync', () => {
 			// Test: Clash → User accepts _fit/ version → Next sync updates directly
 			//
 			// === SETUP: Start from empty state, then create clash ===
-			localStoreState = {
-				localSha: {},
-				lastFetchedRemoteSha: {},
+			localStoreState = makeLocalStore({
+				localShas: {},
+				lastFetchedRemoteShas: {},
 				lastFetchedCommitSha: (await remoteVault.readFromSource()).commitSha
-			};
+			});
 
 			// Local has hidden file, remote adds same file with different content
 			localVault.setFile('.hidden', 'Local content');
@@ -564,7 +575,7 @@ describe('FitSync', () => {
 				'.hidden': 'Local content', // Local version preserved
 				'_fit/.hidden': 'Remote content v1' // Remote version saved to _fit/
 			});
-			expect(localStoreState.localSha['.hidden']).toBeDefined(); // Baseline recorded
+			expect(localStoreState.localShas['.hidden']).toBeDefined(); // Baseline recorded
 
 			// === STEP 2: User accepts remote version and deletes _fit/ file ===
 			localVault.setFile('.hidden', 'Remote content v1');
@@ -589,11 +600,11 @@ describe('FitSync', () => {
 			await remoteVault.setFile('normal.md', 'Normal content');
 
 			let remoteResult = await remoteVault.readFromSource();
-			localStoreState = {
-				localSha: await localVault.readFromSource().then(r => r.state),
-				lastFetchedRemoteSha: remoteResult.state,
+			localStoreState = makeLocalStore({
+				localShas: await localVault.readFromSource().then(r => r.state),
+				lastFetchedRemoteShas: remoteResult.state,
 				lastFetchedCommitSha: remoteResult.commitSha
-			};
+			});
 			const fitSync = createFitSync();
 
 			// === STEP 1: Device A creates hidden file and syncs ===
@@ -611,7 +622,7 @@ describe('FitSync', () => {
 				'normal.md': 'Normal content'
 			});
 			// Baseline SHA now stored for future syncs
-			expect(localStoreState.localSha).toHaveProperty('.hidden-config.json');
+			expect(localStoreState.localShas).toHaveProperty('.hidden-config.json');
 
 			// === STEP 3: Device A modifies hidden file and pushes ===
 			const updatedContent = 'Updated config v2';
@@ -633,12 +644,12 @@ describe('FitSync', () => {
 			// No second clash file created
 			expect(localVault.getAllFilesAsRaw()).not.toHaveProperty('_fit/.hidden-config.json');
 
-			// Verify: LocalStores updated with hidden file SHA (now includes hidden files in localSha)
+			// Verify: LocalStores updated with hidden file SHA (now includes hidden files in localShas)
 			expect(localStoreState).toMatchObject({
-				localSha: {
+				localShas: {
 					'.hidden-config.json': expect.anything(),
 				},
-				lastFetchedRemoteSha: {
+				lastFetchedRemoteShas: {
 					'.hidden-config.json': expect.anything(),
 					'normal.md': expect.anything(),
 				},
@@ -647,7 +658,7 @@ describe('FitSync', () => {
 
 		it('should write remote hidden files directly when no local version exists (#169)', async () => {
 			// Test: Remote adds hidden file → written directly (not to _fit/)
-			// Baseline SHA recorded in localSha for future comparison
+			// Baseline SHA recorded in localShas for future comparison
 			//
 			// === SETUP: Initial synced state ===
 			const fitSync = createFitSync();
@@ -673,11 +684,11 @@ describe('FitSync', () => {
 
 			// Verify: Baseline SHA recorded for hidden file (#169)
 			expect(localStoreState).toMatchObject({
-				localSha: {
+				localShas: {
 					'.hidden-config.json': expect.any(String),  // NEW: Baseline recorded for direct write
 					'visible.md': expect.any(String)
 				},
-				lastFetchedRemoteSha: {
+				lastFetchedRemoteShas: {
 					'.hidden-config.json': expect.any(String),
 					'visible.md': expect.any(String)
 				}
@@ -686,20 +697,20 @@ describe('FitSync', () => {
 	});
 
 	describe('🚨 Data loss prevention (safety nets for bugs/migrations)', () => {
-		it('should never overwrite local file when remote MODIFIED but file missing from localSha', async () => {
+		it('should never overwrite local file when remote MODIFIED but file missing from localShas', async () => {
 			// === CRITICAL DATA LOSS SCENARIO ===
 			// This simulates TWO dangerous scenarios:
 			//
 			// SCENARIO 1 (future risk): Future plugin version adds full hidden file tracking via DataAdapter.
 			//   - shouldTrackState() returns true for hidden files
-			//   - But during version upgrade, localSha doesn't have the file yet (not in baseline)
+			//   - But during version upgrade, localShas doesn't have the file yet (not in baseline)
 			//   - Remote has modifications to the hidden file
 			//   - Plugin thinks file is tracked but has no SHA to compare against
 			//   - Could blindly overwrite local file with remote version → DATA LOSS
 			//
 			// SCENARIO 2 (current risk): Bug where we misunderstand Obsidian's Vault API contract.
 			//   - We think a path type is trackable and call shouldTrackState(path) → true
-			//   - But Vault API actually filters/hides it, so it never appears in localSha
+			//   - But Vault API actually filters/hides it, so it never appears in localShas
 			//   - Remote has modifications to the file
 			//   - Same result: no SHA to compare, blind overwrite → DATA LOSS
 			//
@@ -707,11 +718,11 @@ describe('FitSync', () => {
 			// using vault.adapter.exists() (bypasses Vault API filtering, sees ALL files).
 
 			// === SETUP: Simulate state mismatch ===
-			// Remote has a hidden file (exists in lastFetchedRemoteSha)
-			localStoreState.lastFetchedRemoteSha = {
+			// Remote has a hidden file (exists in lastFetchedRemoteShas)
+			localStoreState.lastFetchedRemoteShas = {
 				'.env': 'fake-sha-for-old-remote-value' as BlobSha
 			};
-			localStoreState.localSha = {}; // File NOT in localSha (not tracked during scan)
+			localStoreState.localShas = {}; // File NOT in localShas (not tracked during scan)
 
 			// Local vault has the file with user modifications (exists on filesystem)
 			localVault.setFile('.env', 'API_KEY=local-secret-data');
@@ -755,7 +766,7 @@ describe('FitSync', () => {
 			// Verify: SHA keyed by original path ".env", NOT "_fit/.env" (issue #169)
 			// This enables proper change detection on subsequent syncs
 			const expectedSha = await LocalVault.fileSha1('.env', FileContent.fromPlainText('API_KEY=new-remote-value'));
-			expect(localStoreState.localSha).toEqual({
+			expect(localStoreState.localShas).toEqual({
 				'.env': expectedSha,
 				// Must NOT have '_fit/.env'
 			});
@@ -764,17 +775,17 @@ describe('FitSync', () => {
 			// for hidden files, triggering the clash detection logic in FitSync.applyRemoteChanges().
 			//
 			// However, the DANGEROUS scenarios (future hidden file tracking OR API misunderstanding)
-			// where shouldTrackState returns TRUE but file is not in localSha would BYPASS this protection.
+			// where shouldTrackState returns TRUE but file is not in localShas would BYPASS this protection.
 			// In those cases, FitSync.applyRemoteChanges() would think the file is trackable,
-			// see it's not in localSha, and blindly overwrite local file with remote version.
+			// see it's not in localShas, and blindly overwrite local file with remote version.
 			//
 			// REQUIRED ADDITIONAL PROTECTION:
 			// Before applying remote changes in FitSync.applyRemoteChanges():
-			//   if (change.type === 'MODIFIED' && !localSha.hasOwnProperty(path)) {
-			//     // File MODIFIED remotely but not in localSha - could be version migration issue
+			//   if (change.type === 'MODIFIED' && !localShas.hasOwnProperty(path)) {
+			//     // File MODIFIED remotely but not in localShas - could be version migration issue
 			//     const exists = await vault.adapter.exists(path);
 			//     if (exists) {
-			//       fitLogger.log('[FitSync] File exists locally but not in localSha - treating as clash');
+			//       fitLogger.log('[FitSync] File exists locally but not in localShas - treating as clash');
 			//       // Save to _fit/ instead of overwriting
 			//       return false; // Skip overwrite
 			//     }
@@ -784,10 +795,10 @@ describe('FitSync', () => {
 			// is implemented, this test would also verify it prevents data loss in the dangerous scenarios.
 		});
 
-		it('should never delete local file when remote deleted but file missing from localSha', async () => {
+		it('should never delete local file when remote deleted but file missing from localShas', async () => {
 			// Scenario: Hidden file exists locally, gets deleted from remote
 			// Expected: Local file preserved (not deleted) because we can't verify it's safe to delete
-			// This prevents data loss when a file isn't tracked in localSha
+			// This prevents data loss when a file isn't tracked in localShas
 
 			// === SETUP: Initial synced state with hidden file ===
 			const hiddenFileContent = 'important local config';
@@ -799,18 +810,18 @@ describe('FitSync', () => {
 
 			const { state: initialRemoteState } = await remoteVault.readFromSource();
 			const { state: initialLocalState } = await localVault.readFromSource();
-			localStoreState = {
-				// localSha: .gitignore NOT tracked (hidden file)
-				localSha: {
+			localStoreState = makeLocalStore({
+				// localShas: .gitignore NOT tracked (hidden file)
+				localShas: {
 					'README.md': initialLocalState['README.md']
 				},
-				// lastFetchedRemoteSha: .gitignore IS tracked (asymmetric)
-				lastFetchedRemoteSha: {
+				// lastFetchedRemoteShas: .gitignore IS tracked (asymmetric)
+				lastFetchedRemoteShas: {
 					'.gitignore': initialRemoteState['.gitignore'],
 					'README.md': initialRemoteState['README.md']
 				},
 				lastFetchedCommitSha: remoteVault.getCommitSha()
-			};
+			});
 
 			// === STEP 1: Remote deletes .gitignore ===
 			await remoteVault.applyChanges(
@@ -857,18 +868,18 @@ describe('FitSync', () => {
 			// This represents old buggy behavior where hidden files weren't indexed
 			const { state: initialRemoteState } = await remoteVault.readFromSource();
 			const { state: initialLocalState } = await localVault.readFromSource();
-			localStoreState = {
-				localSha: {
+			localStoreState = makeLocalStore({
+				localShas: {
 					// README.md IS tracked locally (so it won't appear as "ADDED")
 					'README.md': initialLocalState['README.md']
 				},
-				lastFetchedRemoteSha: {
+				lastFetchedRemoteShas: {
 					// BUG: .gitignore is missing even though it exists in the commit
 					'README.md': initialRemoteState['README.md']
 					// '.gitignore' is missing from cache
 				},
 				lastFetchedCommitSha: remoteVault.getCommitSha()
-			};
+			});
 
 			// === STEP 1: Remote modifies README.md (triggers sync) ===
 			// This also causes us to re-scan remote and discover .gitignore
@@ -894,15 +905,15 @@ describe('FitSync', () => {
 				'_fit/.gitignore': remoteGitignoreContent
 			});
 
-			// Verify stat performance: README.md already in localSha (no stat), .gitignore not in localSha (needs stat)
-			// Note: .gitignore gets stat checked because it's not in localSha (was missing from cache)
+			// Verify stat performance: README.md already in localShas (no stat), .gitignore not in localShas (needs stat)
+			// Note: .gitignore gets stat checked because it's not in localShas (was missing from cache)
 			const statLog = localVault.getStatLog();
-			// Should not stat README.md (already tracked in localSha)
+			// Should not stat README.md (already tracked in localShas)
 			expect(statLog).not.toContain('README.md');
 		});
 
 		it('should save remote file to _fit/ when stat fails to check local existence (addition)', async () => {
-			// Hidden files aren't in localSha but DO pass shouldSyncPath(), so we stat() them.
+			// Hidden files aren't in localShas but DO pass shouldSyncPath(), so we stat() them.
 			// If stat() fails, conservatively treat file as "may exist" → save to _fit/.
 
 			// === SETUP: Empty initial state ===
@@ -1062,15 +1073,15 @@ describe('FitSync', () => {
 			const initialRemoteState = await remoteVault.readFromSource();
 			const initialLocalState = await localVault.readFromSource();
 
-			localStoreState = {
-				localSha: {
+			localStoreState = makeLocalStore({
+				localShas: {
 					'.hidden': initialLocalState.state['.hidden']
 				},
-				lastFetchedRemoteSha: {
+				lastFetchedRemoteShas: {
 					'.hidden': initialRemoteState.state['.hidden']
 				},
 				lastFetchedCommitSha: remoteVault.getCommitSha()
-			};
+			});
 
 			// Simulate v2: filtering rule changed (now excludes hidden files)
 			localVault.shouldTrackState = originalShouldTrackState;
@@ -1088,8 +1099,8 @@ describe('FitSync', () => {
 			// File should NOT be deleted from remote (safeguard prevents data loss)
 			expect(remoteVault.getFile('.hidden')).toBe(hiddenFileContent);
 
-			// localSha should exclude .hidden (new filtering rules)
-			expect(localStoreState.localSha).not.toHaveProperty('.hidden');
+			// localShas should exclude .hidden (new filtering rules)
+			expect(localStoreState.localShas).not.toHaveProperty('.hidden');
 		});
 	});
 
@@ -1670,11 +1681,11 @@ describe('FitSync', () => {
 
 			// Setup a simple sync scenario
 			remoteVault.setFile('test.md', 'content');
-			localStoreState = {
-				localSha: {},
-				lastFetchedRemoteSha: {},
+			localStoreState = makeLocalStore({
+				localShas: {},
+				lastFetchedRemoteShas: {},
 				lastFetchedCommitSha: remoteVault.getCommitSha()
-			};
+			});
 
 			const fitSync = createFitSync();
 			const mockNotice = createMockNotice();
@@ -1823,9 +1834,9 @@ describe('FitSync', () => {
 				'huge.mp4': expect.any(String)
 			});
 
-			// Assert: localSha cache includes both files (huge.mp4 treated as "synced" by cache
+			// Assert: localShas cache includes both files (huge.mp4 treated as "synced" by cache
 			// so sync engine won't retry it — unpushedFiles is the tracking mechanism)
-			expect(localStoreState.localSha).toMatchObject({
+			expect(localStoreState.localShas).toMatchObject({
 				'huge.mp4': expect.any(String),
 				'normal.md': expect.any(String),
 			});
@@ -1860,12 +1871,12 @@ describe('FitSync', () => {
 			localVault.setFile('huge.mp4', 'big file content');
 			const hugeFileContent = FileContent.fromPlainText('big file content');
 			const hugeFileSha = await LocalVault.fileSha1('huge.mp4', hugeFileContent);
-			localStoreState = {
+			localStoreState = makeLocalStore({
 				...localStoreState,
-				localSha: { 'huge.mp4': hugeFileSha as BlobSha },
-				lastFetchedRemoteSha: {},
+				localShas: { 'huge.mp4': hugeFileSha as BlobSha },
+				lastFetchedRemoteShas: {},
 				unpushedFiles: { 'huge.mp4': hugeFileSha as BlobSha }
-			};
+			});
 			const fitSync = createFitSync();
 			// Do NOT set skippedPaths — no upload attempt should happen
 			const remoteApplySpy = vi.spyOn(remoteVault, 'applyChanges');
@@ -1893,12 +1904,12 @@ describe('FitSync', () => {
 			// Arrange: file was previously skipped with old SHA
 			localVault.setFile('huge.mp4', 'modified content'); // Different content = new SHA
 			const oldSha = 'old-sha-from-before-modification' as BlobSha;
-			localStoreState = {
+			localStoreState = makeLocalStore({
 				...localStoreState,
-				localSha: { 'huge.mp4': oldSha }, // Out of date — will cause localChanges detection
-				lastFetchedRemoteSha: {},
+				localShas: { 'huge.mp4': oldSha }, // Out of date — will cause localChanges detection
+				lastFetchedRemoteShas: {},
 				unpushedFiles: { 'huge.mp4': oldSha }
-			};
+			});
 			const fitSync = createFitSync();
 			// Don't skip this time — let the file attempt to push (simulates user modified file)
 			// The new content will be written normally
@@ -1919,12 +1930,12 @@ describe('FitSync', () => {
 			await remoteVault.setFile('huge.mp4', 'manually pushed content');
 			localVault.setFile('huge.mp4', 'manually pushed content'); // Same content locally
 			const hugeFileSha = 'some-sha' as BlobSha;
-			localStoreState = {
+			localStoreState = makeLocalStore({
 				...localStoreState,
-				localSha: { 'huge.mp4': hugeFileSha },
-				lastFetchedRemoteSha: {}, // Remote SHA unknown → will be detected as remote add
+				localShas: { 'huge.mp4': hugeFileSha },
+				lastFetchedRemoteShas: {}, // Remote SHA unknown → will be detected as remote add
 				unpushedFiles: { 'huge.mp4': hugeFileSha }
-			};
+			});
 			const fitSync = createFitSync();
 
 			// Act
@@ -1934,6 +1945,167 @@ describe('FitSync', () => {
 			// Assert: sync succeeded and unpushedFiles entry cleared
 			expect(result).toEqual(expect.objectContaining({ success: true }));
 			expect(localStoreState.unpushedFiles).not.toHaveProperty('huge.mp4');
+		});
+	});
+
+	describe('SHA migration (localSha → localShas)', () => {
+		describe('loadLocalStore field mapping', () => {
+			it('localShas only (clean v2) — no migration, localSha empty', () => {
+				const canonicalShas = { 'note.md': 'canonical-sha' as BlobSha };
+				const fit = createFit(makeLocalStore({
+					localShas: canonicalShas,
+				}));
+
+				expect(fit.localShas).toEqual(canonicalShas);
+				expect(fit.localSha).toEqual({});
+			});
+
+			it('localSha only (legacy data) — localShas empty, localSha populated', () => {
+				const legacyShas = { 'note.md': 'legacy-sha' as BlobSha };
+				const fit = createFit(makeLocalStore({
+					localShas: {},
+					localSha: legacyShas,
+				}));
+
+				expect(fit.localShas).toEqual({});
+				expect(fit.localSha).toEqual(legacyShas);
+			});
+
+			it('both present (downgrade scenario) — both populated', () => {
+				const canonicalShas = { 'file1.md': 'canonical-sha' as BlobSha };
+				const legacyShas = { 'file2.md': 'legacy-sha' as BlobSha };
+				const fit = createFit(makeLocalStore({
+					localShas: canonicalShas,
+					localSha: legacyShas,
+				}));
+
+				expect(fit.localShas).toEqual(canonicalShas);
+				expect(fit.localSha).toEqual(legacyShas);
+			});
+		});
+
+		describe('getLocalChanges: per-file migration', () => {
+			it('unchanged file with legacy SHA — promoted silently, not in changes', async () => {
+				const content = FileContent.fromPlainText('hello world');
+				localVault.setFile('note.md', content);
+				const legacySha = await LocalVault.fileLegacySha1('note.md', content);
+
+				const fit = createFit(makeLocalStore({
+					localShas: {},
+					localSha: { 'note.md': legacySha },
+					lastFetchedRemoteShas: {},
+					lastFetchedCommitSha: null,
+				}));
+
+				const { changes } = await fit.getLocalChanges();
+
+				expect(changes).toEqual([]);
+				expect(fit.localShas['note.md']).toBeTruthy(); // canonical SHA adopted
+				expect(fit.localSha).toEqual({});              // entry fully promoted
+			});
+
+			it('changed file with legacy SHA — detected as ADDED, entry cleared', async () => {
+				// Legacy SHA was stored for 'old content'; file now has 'new content'
+				localVault.setFile('note.md', FileContent.fromPlainText('new content'));
+				const legacyShaForOldContent = await LocalVault.fileLegacySha1(
+					'note.md', FileContent.fromPlainText('old content')
+				);
+
+				const fit = createFit(makeLocalStore({
+					localShas: {},
+					localSha: { 'note.md': legacyShaForOldContent },
+					lastFetchedRemoteShas: {},
+					lastFetchedCommitSha: null,
+				}));
+
+				const { changes } = await fit.getLocalChanges();
+
+				expect(changes).toContainEqual(expect.objectContaining({ path: 'note.md', type: 'ADDED' }));
+				expect(fit.localSha).toEqual({});                 // entry cleared even on mismatch
+				expect(fit.localShas['note.md']).toBeUndefined(); // no canonical baseline set
+			});
+
+			it('downgrade scenario (both fields) — re-promoted on match', async () => {
+				// Both present: old code re-wrote localSha during downgrade
+				const content = FileContent.fromPlainText('stable content');
+				localVault.setFile('stable.md', content);
+				const legacySha = await LocalVault.fileLegacySha1('stable.md', content);
+				const oldCanonicalSha = 'old-canonical' as BlobSha;
+
+				const fit = createFit(makeLocalStore({
+					localShas: { 'stable.md': oldCanonicalSha },
+					localSha: { 'stable.md': legacySha },
+					lastFetchedRemoteShas: {},
+					lastFetchedCommitSha: null,
+				}));
+
+				const { changes } = await fit.getLocalChanges();
+
+				// File content matches legacy SHA → promoted, no change reported
+				expect(changes).toEqual([]);
+				expect(fit.localSha).toEqual({});              // legacy entry cleared
+				expect(fit.localShas['stable.md']).toBeTruthy(); // canonical baseline updated
+			});
+
+			it('last legacy entry promoted — localSha becomes empty', async () => {
+				const content = FileContent.fromPlainText('only file');
+				localVault.setFile('only.md', content);
+				const legacySha = await LocalVault.fileLegacySha1('only.md', content);
+
+				const fit = createFit(makeLocalStore({
+					localShas: {},
+					localSha: { 'only.md': legacySha },
+					lastFetchedRemoteShas: {},
+					lastFetchedCommitSha: null,
+				}));
+
+				await expect(fit.getLocalChanges()).resolves.not.toThrow();
+				expect(fit.localSha).toEqual({});
+			});
+
+			it('orphaned legacy entry for deleted file — cleaned up', async () => {
+				// File exists in localSha but not on disk → should be cleaned up
+				const fit = createFit(makeLocalStore({
+					localShas: {},
+					localSha: { 'deleted.md': 'some-legacy-sha' as BlobSha },
+					lastFetchedRemoteShas: {},
+					lastFetchedCommitSha: null,
+				}));
+
+				// No files on disk
+				const { changes } = await fit.getLocalChanges();
+
+				// Orphaned entry cleaned up, no spurious changes
+				expect(fit.localSha).toEqual({});
+				expect(changes).toEqual([]);
+			});
+		});
+
+		describe('re-upload safety', () => {
+			// After migration, a file whose legacy SHA mismatched appears as ADDED and gets re-uploaded.
+			// Re-uploading content that already matches remote is safe (GitHub deduplicates blobs).
+			it('file matching remote content re-uploaded without error', async () => {
+				const content = 'synced content';
+				localVault.setFile('note.md', content);
+				await remoteVault.setFile('note.md', content);
+
+				// lastFetchedRemoteShas still accurate from last v2 sync
+				const remoteState = await remoteVault.readFromSource();
+				const remoteFileSha = remoteState.state['note.md'];
+
+				localStoreState = makeLocalStore({
+					localShas: {},  // no baseline — file will appear as ADDED
+					lastFetchedRemoteShas: { 'note.md': remoteFileSha },
+					lastFetchedCommitSha: remoteState.commitSha,
+				});
+				const fitSync = createFitSync();
+
+				const result = await fitSync.sync(createMockNotice() as any);
+
+				// Re-upload of already-remote content succeeds — GitHub accepts duplicate blobs
+				expect(result).toEqual(expect.objectContaining({ success: true }));
+				expect(remoteVault.getAllFilesAsRaw()).toMatchObject({ 'note.md': content });
+			});
 		});
 	});
 });

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -9,22 +9,23 @@ import { Base64Content, FileContent } from "./util/contentEncoding";
 import { detectNormalizationMismatches } from "./util/filePath";
 import { BlobSha, CommitSha } from "./util/hashing";
 import { LocalVault } from "./localVault";
+import * as Encryption from "./encryption";
 
 // Helper to log SHA cache updates with provenance tracking
 function logCacheUpdate(
 	source: string,
-	oldLocalSha: FileStates,
-	newLocalSha: FileStates,
-	oldRemoteSha: FileStates,
-	newRemoteSha: FileStates,
+	oldLocalShas: FileStates,
+	newLocalShas: FileStates,
+	oldRemoteShas: FileStates,
+	newRemoteShas: FileStates,
 	oldCommitSha: CommitSha | null | undefined,
 	newCommitSha: CommitSha,
 	extraContext?: Record<string, unknown>
 ) {
-	const oldLocalCount = Object.keys(oldLocalSha).length;
-	const newLocalCount = Object.keys(newLocalSha).length;
-	const localShaAdded = Object.keys(newLocalSha).filter(k => !oldLocalSha[k]);
-	const localShaRemoved = Object.keys(oldLocalSha).filter(k => !newLocalSha[k]);
+	const oldLocalCount = Object.keys(oldLocalShas).length;
+	const newLocalCount = Object.keys(newLocalShas).length;
+	const localShasAdded = Object.keys(newLocalShas).filter(k => !oldLocalShas[k]);
+	const localShasRemoved = Object.keys(oldLocalShas).filter(k => !newLocalShas[k]);
 	const warnings: string[] = [];
 
 	// Warn if cache went from non-empty to empty (possible data loss)
@@ -37,14 +38,14 @@ function logCacheUpdate(
 		warnings.push(`Local SHA cache jumped from 0 to ${newLocalCount} files - possible recovery from empty cache or first sync`);
 	}
 
-	const totalChanges = localShaAdded.length + localShaRemoved.length +
-		Object.keys(newRemoteSha).filter(k => !oldRemoteSha[k]).length +
-		Object.keys(oldRemoteSha).filter(k => !newRemoteSha[k]).length;
+	const totalChanges = localShasAdded.length + localShasRemoved.length +
+		Object.keys(newRemoteShas).filter(k => !oldRemoteShas[k]).length +
+		Object.keys(oldRemoteShas).filter(k => !newRemoteShas[k]).length;
 
 	if (totalChanges > 0 || oldCommitSha !== newCommitSha || warnings.length > 0) {
 		fitLogger.log(`.. 📦 [Cache] Updating SHA cache after ${source}`, {
-			localChanges: localShaAdded.length + localShaRemoved.length,
-			remoteChanges: Object.keys(newRemoteSha).filter(k => !oldRemoteSha[k]).length + Object.keys(oldRemoteSha).filter(k => !newRemoteSha[k]).length,
+			localChanges: localShasAdded.length + localShasRemoved.length,
+			remoteChanges: Object.keys(newRemoteShas).filter(k => !oldRemoteShas[k]).length + Object.keys(oldRemoteShas).filter(k => !newRemoteShas[k]).length,
 			commitChanged: oldCommitSha !== newCommitSha,
 			...(warnings.length > 0 && { warnings }),
 			...extraContext
@@ -181,7 +182,7 @@ export class FitSync implements IFitSync {
 				continue; // Don't write to protected path
 			}
 
-			// SAFETY: Check filesystem for files not in localSha cache
+			// SAFETY: Check filesystem for files not in localShas cache
 			// This protects against:
 			// 1. Version migrations where tracking rules changed
 			// 2. Bugs where shouldTrackState returns wrong value
@@ -189,7 +190,7 @@ export class FitSync implements IFitSync {
 			//
 			// If file not in cache but exists on disk → treat as clash, save to _fit/
 			// If file not in cache and doesn't exist → safe to write directly
-			if (!this.fit.localSha.hasOwnProperty(change.path)) {
+			if (!this.fit.localShas.hasOwnProperty(change.path)) {
 				// Not in cache - check if file exists using statPaths result
 				const stat = existenceMap.get(change.path);
 				if (stat === undefined) {
@@ -225,7 +226,7 @@ export class FitSync implements IFitSync {
 
 			// SAFETY: Check if file is in cache before deleting
 			// If not in cache, we cannot verify it's safe to delete
-			if (!this.fit.localSha.hasOwnProperty(path)) {
+			if (!this.fit.localShas.hasOwnProperty(path)) {
 				// Not in cache - check if file actually exists to determine appropriate action
 				// Use the existenceMap we already computed above
 				const stat = existenceMap.get(path);
@@ -342,7 +343,7 @@ export class FitSync implements IFitSync {
 		// This allows baseline comparison to prevent unnecessary clashes
 		const pathsNeedingShaCheck = Array.from(pathsToStat).filter(path =>
 			filesystemState.get(path) === true &&
-			this.fit.localSha[path] !== undefined
+			this.fit.localShas[path] !== undefined
 		);
 
 		const currentShas = new Map<string, BlobSha>();
@@ -365,7 +366,7 @@ export class FitSync implements IFitSync {
 			remoteChanges,
 			localChangePaths,
 			filesystemState,
-			this.fit.localSha,
+			this.fit.localShas,
 			currentShas,
 			isProtectedPath
 		);
@@ -438,9 +439,34 @@ export class FitSync implements IFitSync {
 	): Promise<SyncExecutionResult> {
 		// Prepare safe remote changes for pulling
 		const deleteFromLocalNonClashed = safeRemote.filter(c => c.type === "REMOVED").map(c => c.path);
+
+		// SHA parity optimization: when a remote ADD/MODIFY has the same canonical blob SHA
+		// as our local file, the content is already identical — skip the download.
+		// Only safe when encryption is off (encrypted blobs have a different SHA than plaintext).
+		// Guard: isEnabled() requires Encryption.init(plugin) which isn't called in tests.
+		let encryptionEnabled = false;
+		try { encryptionEnabled = Encryption.isEnabled(); } catch { /* uninitialized — treat as disabled */ }
+		const shaParitySkipped = new Set<string>();
+		if (!encryptionEnabled) {
+			for (const change of safeRemote) {
+				if (change.type === "REMOVED") continue;
+				const localSha = currentLocalState[change.path];
+				const remoteSha = remoteUpdate.remoteTreeSha[change.path];
+				if (localSha && remoteSha && localSha === remoteSha) {
+					shaParitySkipped.add(change.path);
+				}
+			}
+			if (shaParitySkipped.size > 0) {
+				fitLogger.log('[FitSync] SHA parity: skipping redundant download for identical files', {
+					count: shaParitySkipped.size,
+					paths: [...shaParitySkipped]
+				});
+			}
+		}
+
 		const addToLocalNonClashed = await Promise.all(
 			safeRemote
-				.filter(c => c.type !== "REMOVED")
+				.filter(c => c.type !== "REMOVED" && !shaParitySkipped.has(c.path))
 				.map(async (change) => ({
 					path: change.path,
 					content: await this.fit.remoteVault.readFileContent(change.path)
@@ -471,7 +497,7 @@ export class FitSync implements IFitSync {
 		}
 
 		// Record any files skipped due to API size limit (422) into unpushedFiles.
-		// localSha is updated normally for these files (sync engine won't retry),
+		// localShas is updated normally for these files (sync engine won't retry),
 		// so unpushedFiles is the sole tracking mechanism for them.
 		// Capture which paths are freshly added (not already known) for the tiered warning.
 		const previousUnpushedKeys = new Set(Object.keys(this.fit.unpushedFiles));
@@ -489,7 +515,7 @@ export class FitSync implements IFitSync {
 		let pushedChanges: Array<FileChange>;
 
 		if (pushResult) {
-			latestRemoteTreeSha = pushResult.lastFetchedRemoteSha;
+			latestRemoteTreeSha = pushResult.lastFetchedRemoteShas;
 			latestCommitSha = pushResult.lastFetchedCommitSha;
 			pushedChanges = pushResult.pushedChanges;
 		} else {
@@ -546,9 +572,9 @@ export class FitSync implements IFitSync {
 
 		logCacheUpdate(
 			'sync',
-			this.fit.localSha || {},
+			this.fit.localShas || {},
 			newLocalState,
-			this.fit.lastFetchedRemoteSha || {},
+			this.fit.lastFetchedRemoteShas || {},
 			latestRemoteTreeSha,
 			this.fit.lastFetchedCommitSha,
 			latestCommitSha,
@@ -573,13 +599,15 @@ export class FitSync implements IFitSync {
 		const newlySkippedPaths = pushResult?.skippedPaths?.filter(p => !previousUnpushedKeys.has(p)) ?? [];
 
 		await this.saveLocalStoreCallback({
-			lastFetchedRemoteSha: latestRemoteTreeSha, // Unfiltered - must track ALL remote files to detect changes
+			lastFetchedRemoteShas: latestRemoteTreeSha,
 			lastFetchedCommitSha: latestCommitSha,
 			// TODO: Remove filterSyncedState after fixing bug where remote _fit/ files are passed to applyChanges
 			// Currently remote _fit/ paths bypass shouldSyncPath filtering and get SHAs computed.
 			// Once fixed, newBaselineStates will only contain syncable paths (no filtering needed).
-			localSha: this.fit.filterSyncedState(newLocalState),
+			localShas: this.fit.filterSyncedState(newLocalState),
 			unpushedFiles: this.fit.unpushedFiles,
+			// Only persist localSha if there are still legacy entries remaining (not yet promoted)
+			localSha: Object.keys(this.fit.localSha).length > 0 ? this.fit.localSha : undefined,
 		});
 
 		return {
@@ -764,7 +792,7 @@ export class FitSync implements IFitSync {
 			parentCommitSha: CommitSha
 		},
 		existenceMap: Map<string, 'file' | 'folder' | 'nonexistent'>
-	): Promise<{pushedChanges: FileChange[], lastFetchedRemoteSha: FileStates, lastFetchedCommitSha: CommitSha, skippedPaths?: string[], skippedWarning?: string}|null> {
+	): Promise<{pushedChanges: FileChange[], lastFetchedRemoteShas: FileStates, lastFetchedCommitSha: CommitSha, skippedPaths?: string[], skippedWarning?: string}|null> {
 		if (localUpdate.localChanges.length === 0) {
 			return null;
 		}
@@ -822,7 +850,7 @@ export class FitSync implements IFitSync {
 				// Return minimal push result so caller can update unpushedFiles
 				return {
 					pushedChanges: [],
-					lastFetchedRemoteSha: result.newState,
+					lastFetchedRemoteShas: result.newState,
 					lastFetchedCommitSha: result.commitSha,
 					skippedPaths: result.skippedPaths,
 					skippedWarning: result.skippedWarning,
@@ -838,7 +866,7 @@ export class FitSync implements IFitSync {
 
 		return {
 			pushedChanges,
-			lastFetchedRemoteSha: result.newState,
+			lastFetchedRemoteShas: result.newState,
 			lastFetchedCommitSha: result.commitSha,
 			skippedPaths: result.skippedPaths,
 			skippedWarning: result.skippedWarning,

--- a/src/localVault.test.ts
+++ b/src/localVault.test.ts
@@ -137,10 +137,9 @@ describe('LocalVault', () => {
 				'note1.md': expect.anything(),
 				'note2.txt': expect.anything()
 			});
-			// Frozen SHA behavior: Non-binary files use path + plaintext
-			// Binary files (png, jpg, jpeg, pdf) use path + base64
+			// Canonical git blob SHA: SHA1("blob " + byteLen + NUL + rawBytes) — path is not included
 			expect(state['note1.md']).toMatchInlineSnapshot(
-				`"b8b1b70958bbc0b6f0305f4bc57a8393ba333130"`);
+				`"5e1e15cb4d9afa9689ba28b99e3d17ed7384edca"`);
 		});
 
 		it('should exclude ignored paths from state', async () => {
@@ -186,13 +185,13 @@ describe('LocalVault', () => {
 				'image.png': expect.anything(),
 				'archive.zip': expect.anything()
 			});
-			// SHAs should be stable (uses base64 encoding for all three)
+			// SHAs should be stable (canonical git blob SHA, same for all three since they have identical content in the test)
 			expect(state['doc.pdf']).toMatchInlineSnapshot(
-				`"acf8daf266d952b03fb02280dc5c92d8e4e51ad7"`);
+				`"1b1cb4d44c57c2d7a5122870fa6ac3e62ff7e94e"`);
 			expect(state['image.png']).toMatchInlineSnapshot(
-				`"fe954d839c04f84471b6dd90c945e55a6035de80"`);
+				`"1b1cb4d44c57c2d7a5122870fa6ac3e62ff7e94e"`);
 			expect(state['archive.zip']).toMatchInlineSnapshot(
-				`"a93c48b470cca6e238405a1aad306434aa9618a2"`);
+				`"1b1cb4d44c57c2d7a5122870fa6ac3e62ff7e94e"`);
 		});
 
 		it('should handle empty vault', async () => {
@@ -661,40 +660,42 @@ describe('LocalVault', () => {
 		});
 	});
 
-	describe('Unicode normalization in fileSha1 (issue #51)', () => {
-		it('NFD and NFC forms now produce SAME SHA (bug fixed)', async () => {
+	describe('fileSha1 canonical git blob SHA (issue #51, #146)', () => {
+		it('NFD and NFC paths produce the same SHA (path not in hash)', async () => {
 			const content = FileContent.fromPlainText("test content");
-
-			// Turkish filename with İ (capital I with dot) and ı (lowercase i without dot)
-			const turkishName = "Merhaba dünya ıııııııİİİİ.md";
-
-			// macOS/iOS typically use NFD (decomposed)
+			const turkishName = "Merhaba dünya ıııınınİİİİ.md";
 			const nfdPath = turkishName.normalize('NFD');
-			// Windows/Linux/Android typically use NFC (composed)
 			const nfcPath = turkishName.normalize('NFC');
+			expect(nfdPath).not.toBe(nfcPath); // confirm inputs differ
 
-			// Verify input paths are different byte sequences but visually identical
-			expect(nfdPath).not.toBe(nfcPath);
-			expect(nfdPath.length).not.toBe(nfcPath.length); // NFD has more codepoints
-
-			// FIXED: Both normalize to NFC before hashing, producing identical SHAs
-			const nfdSha = await LocalVault.fileSha1(nfdPath, content);
-			const nfcSha = await LocalVault.fileSha1(nfcPath, content);
-
-			// These SHAs are now the same, preventing file duplication
-			expect(nfdSha).toBe(nfcSha);
+			// Path is not part of the canonical hash, so both are identical
+			expect(await LocalVault.fileSha1(nfdPath, content))
+				.toBe(await LocalVault.fileSha1(nfcPath, content));
 		});
 
-		it('fileSha1 concatenates path + content before hashing', async () => {
+		it('fileSha1 matches canonical git blob SHA format', async () => {
+			const content = FileContent.fromPlainText("test");
+			const sha = await LocalVault.fileSha1("any/path.md", content);
+
+			// git blob SHA: SHA1("blob " + byteLen + NUL + rawBytes)
+			const rawBytes = new TextEncoder().encode("test");
+			const header = new TextEncoder().encode(`blob ${rawBytes.length}\0`);
+			const data = new Uint8Array(header.length + rawBytes.length);
+			data.set(header);
+			data.set(rawBytes, header.length);
+			const hashBuf = await crypto.subtle.digest('SHA-1', data);
+			const expected = Array.from(new Uint8Array(hashBuf))
+				.map(b => b.toString(16).padStart(2, '0')).join('');
+
+			expect(sha).toBe(expected);
+		});
+
+		it('fileLegacySha1 reproduces the old path+content SHA', async () => {
 			const path = "dünya.md";
 			const content = FileContent.fromPlainText("test");
-
-			// LocalVault.fileSha1 does: computeSha1(path + content)
-			const sha = await LocalVault.fileSha1(path, content);
-
-			// Verify it's computing SHA of the concatenation
+			const legacySha = await LocalVault.fileLegacySha1(path, content);
 			const manualSha = await computeSha1(path + "test");
-			expect(sha).toBe(manualSha);
+			expect(legacySha).toBe(manualSha);
 		});
 	});
 

--- a/src/localVault.ts
+++ b/src/localVault.ts
@@ -10,7 +10,7 @@ import { FileChange } from "./util/changeTracking";
 import { fitLogger } from "./logger";
 import { Base64Content, FileContent } from "./util/contentEncoding";
 import { contentToArrayBuffer, readFileContent } from "./util/obsidianHelpers";
-import { BlobSha, computeSha1 } from "./util/hashing";
+import { BlobSha, computeGitBlobSha, computeSha1 } from "./util/hashing";
 import { FilePath, detectNormalizationIssues } from "./util/filePath";
 import { withSlowOperationMonitoring } from "./util/asyncMonitoring";
 import { findSuspiciousCorrespondences } from "./util/pathPattern";
@@ -34,39 +34,14 @@ function collectSettledFailures<T>(
 }
 
 /**
- * Frozen list of binary file extensions for SHA calculation consistency.
- *
- * IMPORTANT: This list is FROZEN to prevent spurious sync operations.
- *
- * Why this matters:
- * - Before PR #XXX: Non-listed binaries (.zip, .exe, etc.) had SHAs computed on
- *   CORRUPTED plaintext (with replacement characters �) because toPlainText()
- *   silently corrupted binary data
- * - After PR #XXX: toPlainText() throws on binary, fileSha1() catches and uses base64
- * - Problem: Existing .zip files will get DIFFERENT SHAs (corrupted vs correct)
- * - Result: Plugin detects "change" and tries to sync the same file again
- *
- * Solution:
- * - Keep list FROZEN to avoid batch SHA changes for existing users
- * - New fatal:true logic handles unlisted extensions gracefully via try/catch
- * - Users with .zip files will see ONE spurious sync after upgrading (acceptable)
- *
- * Future: Implement SHA migration strategy to expand this list safely
- * (e.g., version stores, detect and re-hash on upgrade, warn users)
- *
- * DO NOT modify this list unless you implement a SHA migration strategy.
+ * Extensions that used base64 (not plaintext) in the legacy v1 SHA algorithm.
+ * Preserved for fileLegacySha1 so the v1→v2 migration can reproduce old SHAs exactly.
  */
-const FROZEN_BINARY_EXT_FOR_SHA = new Set(["png", "jpg", "jpeg", "pdf"]);
+const LEGACY_BINARY_EXT_FOR_SHA = new Set(["png", "jpg", "jpeg", "pdf"]);
 
-/**
- * Check if a file extension is considered binary for SHA calculation purposes.
- * Uses FROZEN_BINARY_EXT_FOR_SHA to ensure SHA consistency.
- *
- * @param extension - File extension WITHOUT leading dot (e.g., "png", not ".png")
- */
-function isBinaryExtensionForSha(extension: string): boolean {
+function isBinaryExtensionForLegacySha(extension: string): boolean {
 	const normalized = extension.startsWith('.') ? extension.slice(1) : extension;
-	return FROZEN_BINARY_EXT_FOR_SHA.has(normalized.toLowerCase());
+	return LEGACY_BINARY_EXT_FOR_SHA.has(normalized.toLowerCase());
 }
 
 /**
@@ -236,35 +211,37 @@ export class LocalVault implements IVault<"local"> {
 	}
 
 	/**
-	 * Compute SHA-1 hash of file path + content
-	 * (Matches GitHub's blob SHA format)
+	 * Compute the canonical Git blob SHA-1 for a file.
 	 *
-	 * Path is normalized to NFC before hashing to prevent
-	 * duplication issues with Unicode normalization (issue #51)
+	 * Uses the same algorithm as GitHub (SHA1("blob " + byteLen + NUL + rawBytes)),
+	 * so local and remote SHAs are directly comparable when encryption is off.
+	 * The path is not included in the hash; it is accepted only for call-site
+	 * compatibility (tests and scan loop both pass it).
 	 */
 	// NOTE: Public visibility for tests.
-	static fileSha1(path: string, fileContent: FileContent): Promise<BlobSha> {
-		// Normalize path to NFC form for consistent hashing across platforms
+	static fileSha1(_path: string, fileContent: FileContent): Promise<BlobSha> {
+		const b64 = fileContent.toBase64(); // already normalized (no whitespace) by FileContent
+		const binStr = atob(b64);
+		const rawBytes = Uint8Array.from(binStr, c => c.charCodeAt(0));
+		return computeGitBlobSha(rawBytes);
+	}
+
+	/**
+	 * Compute the legacy v1 SHA (SHA1(normalizedPath + content)) for a file.
+	 * Used only during v1→v2 schema migration to check whether a file's content
+	 * has changed since it was last hashed with the old algorithm.
+	 */
+	// NOTE: Public visibility for migration use in fit.ts.
+	static fileLegacySha1(path: string, fileContent: FileContent): Promise<BlobSha> {
 		const normalizedPath = FilePath.create(path);
 		const extension = FilePath.getExtension(normalizedPath);
-
 		let contentToHash: string;
-		if (extension && isBinaryExtensionForSha(extension)) {
-			// Use base64 representation for consistent hashing
+		if (extension && isBinaryExtensionForLegacySha(extension)) {
 			contentToHash = fileContent.toBase64();
 		} else {
-			// Preserve plaintext SHA logic for non-binary case.
-			// NOTE: For non-FROZEN extensions like .zip, if content is binary,
-			// toPlainText() will now throw (due to fatal:true in decodeFromBase64).
-			// We intentionally fall back to base64 to avoid corruption.
-			// This may cause SHA changes for existing .zip files, but prevents
-			// silent replacement character corruption in SHA computation.
-			// TODO(future): Implement SHA migration strategy to expand FROZEN_BINARY_EXT_FOR_SHA
-			// to include all common binary extensions (.zip, .exe, .bin, etc.)
 			try {
 				contentToHash = fileContent.toPlainText();
 			} catch {
-				// Binary content detected (invalid UTF-8) - fall back to base64
 				contentToHash = fileContent.toBase64();
 			}
 		}

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -634,7 +634,8 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 				`  2. Sync via git (desktop):`,
 				`       cd <your-repo> && git checkout ${this.branch}`,
 				`       git add <file> && git commit -m "sync large file" && git push`,
-				'     Note: FIT may still be unable to download the file — option 1 is safer.',
+				'     FIT will detect the upload via SHA comparison and skip re-downloading if local content matches.',
+				'     Make sure any other devices syncing the same vault are up-to-date with this FIT plugin version for best results.',
 			].join('\n');
 		}
 

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -634,9 +634,6 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 				`  2. Sync via git (desktop):`,
 				`       cd <your-repo> && git checkout ${this.branch}`,
 				`       git add <file> && git commit -m "sync large file" && git push`,
-				// TODO(#116): once local SHA uses canonical git blob format, FIT can detect content
-				// parity on the next sync and auto-clear unpushedFiles without downloading.
-				// At that point, restore "run a sync to confirm" and remove the caveat below.
 				'     Note: FIT may still be unable to download the file — option 1 is safer.',
 			].join('\n');
 		}
@@ -707,9 +704,9 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		await this.updateRef(newCommit);
 
 		return {
-			localSha: {},
+			localShas: {},
 			lastFetchedCommitSha: newCommit,
-			lastFetchedRemoteSha: {},
+			lastFetchedRemoteShas: {},
 		};
 	}
 

--- a/src/util/hashing.ts
+++ b/src/util/hashing.ts
@@ -16,20 +16,32 @@ export type TreeSha = string & { readonly __brand: 'Tree' };
 export const EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904' as TreeSha;
 
 /**
- * Compute SHA-1 hash of content.
- * Generic SHA-1 helper used for FIT's local blob hashing.
+ * Compute canonical Git blob SHA-1 for file content.
  *
- * IMPORTANT: FIT uses a CUSTOM local SHA algorithm (path + content) that does NOT match
- * Git's blob SHA format. Local SHAs and remote SHAs use different algorithms and cannot
- * be compared. See docs/architecture.md "SHA Algorithms and Change Detection".
+ * Matches GitHub's blob SHA format: SHA1("blob " + byteLength + NUL + rawBytes).
+ * With canonical SHAs, local and remote SHAs are directly comparable.
  *
- * This function just computes SHA1 of the input string. The local SHA algorithm is
- * implemented in LocalVault.fileSha1() which calls this with (normalizedPath + content).
+ * @param rawBytes - Raw file bytes (not base64, not text-decoded)
+ * @returns Hex-encoded SHA-1 hash
+ */
+export async function computeGitBlobSha(rawBytes: Uint8Array): Promise<BlobSha> {
+	const header = new TextEncoder().encode(`blob ${rawBytes.length}\0`);
+	const data = new Uint8Array(header.length + rawBytes.length);
+	data.set(header);
+	data.set(rawBytes, header.length);
+	const hashBuf = await crypto.subtle.digest('SHA-1', data);
+	return Array.from(new Uint8Array(hashBuf))
+		.map(b => b.toString(16).padStart(2, '0'))
+		.join('') as BlobSha;
+}
+
+/**
+ * Compute SHA-1 hash of a string.
+ * Used internally for legacy local SHA (path + content) and commit/tree SHAs in tests.
  *
  * @param content - String content to hash
  * @returns Hex-encoded SHA-1 hash
  */
-
 export async function computeSha1(content: string): Promise<string> {
 	const enc = new TextEncoder();
 	const hashBuf = await crypto.subtle.digest('SHA-1', enc.encode(content));

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -154,7 +154,7 @@ export class VaultError extends Error {
  * // Update vault cache after sync (scan and update internal state atomically)
  * const newLocalState = await localVault.readFromSource();
  * // Save to persistent cache
- * await saveToCache({localSha: newLocalState});
+ * await saveToCache({localShas: newLocalState});
  * ```
  */
 export interface IVault<T extends VaultCategory> {


### PR DESCRIPTION
Automatically migrates from nonstandard legacy SHA calculations in `localSha` field to canonical SHA in `localShas` (plural) and uses only those canonical SHAs when there's no legacy `localSha` entry for a file. This provides two small advantages:
1. If a file already matches locally and remotely, that can be immediately detected by comparing SHAs without having to download or upload the file content, which allows the large file case in #146 to heal itself automatically if you upload a large file to remote manually.
2. The `FROZEN_BINARY_EXT_FOR_SHA` workaround is no longer significant for up-to-date caches/configs, because file extensions no longer alter the SHA behavior.

Also renames `lastFetchedRemoteSha` to `lastFetchedRemoteShas` for symmetry, but that one is just trivially renamed without changing any meaning because the values were already correct.

Fixes #116 and #146.

---

<!-- kody-pr-summary:start -->
This pull request updates the plugin's local file SHA calculation to use the canonical Git blob SHA format, aligning it with GitHub's remote SHA algorithm. This change enables direct comparison between local and remote file SHAs, leading to improved sync efficiency and consistency.

Key changes include:

*   **Unified SHA Algorithm**: The local SHA (`LocalVault.fileSha1`) now computes the canonical Git blob SHA (`SHA1("blob " + byteLength + "\\0" + rawBytes)`), making it directly comparable with remote SHAs from GitHub.
*   **SHA Parity Optimization**: When encryption is off, the plugin can now skip downloading remote files if their canonical Git blob SHA matches the local file's SHA, as it indicates identical content.
*   **Automatic Migration**: A migration strategy is implemented to seamlessly transition existing users from the old custom local SHA algorithm (`localSha`) to the new canonical Git blob SHA (`localShas`). On the first sync after upgrade, legacy SHAs are re-verified against local file content and promoted to the new canonical cache.
*   **Updated Data Structures**: The `LocalStores` interface and associated loading/saving logic are updated to manage both the new `localShas` and `lastFetchedRemoteShas` fields, as well as temporary legacy fields (`localSha`, `lastFetchedRemoteSha`) during the migration period.
*   **Enhanced Safety**: Existing data loss prevention mechanisms for file overwrites and deletions are updated to correctly utilize the new canonical SHA cache.
*   **Documentation Updates**: The `docs/architecture.md` and `docs/sync-logic.md` files have been revised to reflect the new SHA strategy, its benefits, and the migration process.
<!-- kody-pr-summary:end -->