### PR TITLE
fix transient upload failures to defer remainder to next sync

### DIFF
--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1950,6 +1950,52 @@ describe('FitSync', () => {
 		});
 	});
 
+	describe('rateLimitedPaths — transient upload failure retry', () => {
+		it('rate-limited file: localShas cleared so it is re-detected on next sync', async () => {
+			const fitSync = createFitSync();
+			localVault.setFile('normal.md', 'normal content');
+			localVault.setFile('blocked.md', 'blocked content');
+			remoteVault.setRateLimitedPaths(['blocked.md']);
+
+			const result = await fitSync.sync(createMockNotice() as any);
+
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+			expect(remoteVault.getAllFilesAsRaw()).toEqual({ 'normal.md': 'normal content' });
+			// Exact localShas shape: normal.md present, blocked.md absent (re-detected next sync)
+			expect(localStoreState.localShas).toEqual({ 'normal.md': expect.any(String) });
+			expect(localStoreState.unpushedFiles).toEqual({});
+		});
+
+		it.each([
+			{ desc: 'manual sync', isAutoSync: false },
+			{ desc: 'auto sync', isAutoSync: true },
+		])('shows "Sync incomplete" notice ($desc)', async ({ isAutoSync }) => {
+			const fitSync = createFitSync();
+			localVault.setFile('blocked.md', 'content');
+			remoteVault.setRateLimitedPaths(['blocked.md']);
+
+			const mockNotice = createMockNotice();
+			await fitSync.sync(mockNotice as any, { isAutoSync });
+
+			const finalMessage = mockNotice.setMessage.mock.calls.at(-1)?.[0] as string;
+			expect(finalMessage).toContain('Sync incomplete');
+			expect(finalMessage).toContain('blocked.md');
+		});
+
+		it('next sync retries rate-limited file after localShas cleared', async () => {
+			const fitSync = createFitSync();
+			localVault.setFile('blocked.md', 'content');
+			remoteVault.setRateLimitedPaths(['blocked.md']);
+			await fitSync.sync(createMockNotice() as any);
+
+			const result = await fitSync.sync(createMockNotice() as any);
+
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+			expect(remoteVault.getAllFilesAsRaw()).toEqual({ 'blocked.md': 'content' });
+			expect(localStoreState.localShas).toEqual({ 'blocked.md': expect.any(String) });
+		});
+	});
+
 	describe('SHA migration (localSha → localShas)', () => {
 		describe('loadLocalStore field mapping', () => {
 			it('localShas only (clean v2) — no migration, localSha empty', () => {

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1994,6 +1994,30 @@ describe('FitSync', () => {
 			expect(remoteVault.getAllFilesAsRaw()).toEqual({ 'blocked.md': 'content' });
 			expect(localStoreState.localShas).toEqual({ 'blocked.md': expect.any(String) });
 		});
+
+		it('rate-limited modified file: deleting locally before retry removes it from remote', async () => {
+			// Sync 1: push blocked.md to remote, establishing a baseline SHA
+			const fitSync = createFitSync();
+			localVault.setFile('blocked.md', 'original content');
+			await fitSync.sync(createMockNotice() as any);
+			expect(remoteVault.getAllFilesAsRaw()).toEqual({ 'blocked.md': 'original content' });
+
+			// Sync 2: user modifies the file, but upload is rate-limited
+			localVault.setFile('blocked.md', 'modified content');
+			remoteVault.setRateLimitedPaths(['blocked.md']);
+			await fitSync.sync(createMockNotice() as any);
+			// baseline SHA preserved (not deleted) so the file remains tracked
+			expect(localStoreState.localShas).toEqual({ 'blocked.md': expect.any(String) });
+
+			// User deletes the file locally before the next sync
+			localVault.deleteFile('blocked.md');
+
+			// Sync 3: deletion should be detected (baseline present) and removed from remote
+			const result = await fitSync.sync(createMockNotice() as any);
+
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+			expect(remoteVault.getAllFilesAsRaw()).toEqual({});
+		});
 	});
 
 	describe('SHA migration (localSha → localShas)', () => {

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -83,6 +83,8 @@ type SyncExecutionResult = {
 	newlySkippedPaths: string[];
 	/** Pre-built first-encounter notice for newly skipped files */
 	skippedWarning?: string;
+	/** Paths not uploaded due to a transient failure (localShas cleared so they retry next sync) */
+	rateLimitedPaths: string[];
 };
 
 export type ConflictResolutionResult = {
@@ -563,6 +565,18 @@ export class FitSync implements IFitSync {
 			delete newLocalState[path];
 		}
 
+		// Retriable paths: remove from localShas so they are re-detected as changed on the next sync.
+		// Do NOT add to unpushedFiles — these are expected to succeed on retry.
+		const rateLimitedPaths = pushResult?.rateLimitedPaths ?? [];
+		for (const path of rateLimitedPaths) {
+			delete newLocalState[path];
+		}
+		if (rateLimitedPaths.length > 0) {
+			fitLogger.log(`[FitSync] ${rateLimitedPaths.length} file(s) deferred — localShas cleared for retry`, {
+				paths: rateLimitedPaths
+			});
+		}
+
 		if (Object.keys(newBaselineShas).length > 0) {
 			fitLogger.log('[FitSync] Updated local state with SHAs from written files', {
 				filesProcessed: Object.keys(newBaselineShas).length,
@@ -616,6 +630,7 @@ export class FitSync implements IFitSync {
 			conflicts: clashes,
 			newlySkippedPaths,
 			skippedWarning: pushResult?.skippedWarning,
+			rateLimitedPaths,
 		};
 	}
 
@@ -695,7 +710,7 @@ export class FitSync implements IFitSync {
 			);
 
 			// Phase 3: Execute - push, pull, persist (atomic operation)
-			const { localOps, remoteOps, conflicts, newlySkippedPaths, skippedWarning } = await this.executeSync(
+			const { localOps, remoteOps, conflicts, newlySkippedPaths, skippedWarning, rateLimitedPaths } = await this.executeSync(
 				currentLocalState,
 				{
 					remoteChanges,
@@ -746,8 +761,20 @@ export class FitSync implements IFitSync {
 				fitLogger.log('[FitSync] Files still awaiting manual sync', { paths: remainingUnpushed });
 			}
 
-			// Set success message (only when not already replaced by the unpushed-files reminder)
-			if (remainingUnpushed.length === 0 || isAutoSync || newlySkippedPaths.length > 0) {
+			// Partial sync due to transient upload failure — show regardless of isAutoSync,
+			// overrides any earlier success/reminder message already set on syncNotice.
+			if (rateLimitedPaths.length > 0) {
+				const fileList = rateLimitedPaths.map(p => `• ${p}`).join('\n');
+				syncNotice.setMessage(
+					`Sync incomplete — ${rateLimitedPaths.length} file(s) not uploaded, ` +
+					`possibly due to rate limiting or a transient error. ` +
+					`They will be retried automatically on the next sync.\n${fileList}`
+				);
+			}
+
+			// Set success message (only when not already replaced by the unpushed-files reminder
+			// or the partial-sync notice above)
+			if (rateLimitedPaths.length === 0 && (remainingUnpushed.length === 0 || isAutoSync || newlySkippedPaths.length > 0)) {
 				if (conflicts.length === 0) {
 					syncNotice.setMessage(`Sync successful`);
 				} else if (conflicts.some(f => f.remoteOp !== "REMOVED")) {
@@ -792,7 +819,7 @@ export class FitSync implements IFitSync {
 			parentCommitSha: CommitSha
 		},
 		existenceMap: Map<string, 'file' | 'folder' | 'nonexistent'>
-	): Promise<{pushedChanges: FileChange[], lastFetchedRemoteShas: FileStates, lastFetchedCommitSha: CommitSha, skippedPaths?: string[], skippedWarning?: string}|null> {
+	): Promise<{pushedChanges: FileChange[], lastFetchedRemoteShas: FileStates, lastFetchedCommitSha: CommitSha, skippedPaths?: string[], skippedWarning?: string, rateLimitedPaths?: string[]}|null> {
 		if (localUpdate.localChanges.length === 0) {
 			return null;
 		}
@@ -846,14 +873,15 @@ export class FitSync implements IFitSync {
 					? 'All files skipped due to API size limit (422)'
 					: 'Local content matches remote despite SHA cache mismatch (likely SHA normalization or cache inconsistency)'
 			});
-			if (result.skippedPaths?.length) {
-				// Return minimal push result so caller can update unpushedFiles
+			if (result.skippedPaths?.length || result.rateLimitedPaths?.length) {
+				// Return minimal push result so caller can update unpushedFiles / clear retriable SHAs
 				return {
 					pushedChanges: [],
 					lastFetchedRemoteShas: result.newState,
 					lastFetchedCommitSha: result.commitSha,
 					skippedPaths: result.skippedPaths,
 					skippedWarning: result.skippedWarning,
+					rateLimitedPaths: result.rateLimitedPaths,
 				};
 			}
 			return null;
@@ -870,6 +898,7 @@ export class FitSync implements IFitSync {
 			lastFetchedCommitSha: result.commitSha,
 			skippedPaths: result.skippedPaths,
 			skippedWarning: result.skippedWarning,
+			rateLimitedPaths: result.rateLimitedPaths,
 		};
 	}
 

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -565,11 +565,19 @@ export class FitSync implements IFitSync {
 			delete newLocalState[path];
 		}
 
-		// Retriable paths: remove from localShas so they are re-detected as changed on the next sync.
+		// Retriable paths: revert to the pre-sync baseline SHA so the file is re-detected as changed
+		// on the next sync. Using the previous baseline (not delete) preserves tracking for the case
+		// where the user deletes the file before the retry — without a baseline, the deletion would
+		// be invisible to compareFileStates and leave an orphaned file on the remote.
 		// Do NOT add to unpushedFiles — these are expected to succeed on retry.
 		const rateLimitedPaths = pushResult?.rateLimitedPaths ?? [];
 		for (const path of rateLimitedPaths) {
-			delete newLocalState[path];
+			const previousSha = this.fit.localShas[path];
+			if (previousSha !== undefined) {
+				newLocalState[path] = previousSha;
+			} else {
+				delete newLocalState[path];
+			}
 		}
 		if (rateLimitedPaths.length > 0) {
 			fitLogger.log(`[FitSync] ${rateLimitedPaths.length} file(s) deferred — localShas cleared for retry`, {

--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -428,33 +428,47 @@ describe("RemoteGitHubVault", () => {
 				});
 			});
 
-			describe("422 size-limit partial skip", () => {
-				function make422Error(): Error {
+			describe("blob rejection bucketing", () => {
+				function makeStatusError(status: number, message: string): Error {
 					// Must include response: {} so wrapOctokitError treats it as an HTTP error
-					// and re-throws as-is, preserving status === 422.
-					const err: any = new Error("input file size too large to process");
-					err.status = 422;
+					// and re-throws as-is, preserving the status code.
+					const err: any = new Error(message);
+					err.status = status;
 					err.response = {};
 					return err;
 				}
+				const make422Error = () => makeStatusError(422, "input file size too large to process");
+				const make413Error = () => makeStatusError(413, "Request Entity Too Large");
+				const make403SizeError = () => makeStatusError(403, "This file is too large to process");
+				const make403RateLimitError = () => makeStatusError(403, "You have exceeded a secondary rate limit");
 
-				it("should skip a single file that returns 422, returning skippedPaths and skippedWarning", async () => {
+				it.each([
+					{ label: "422 (unprocessable entity)", makeError: make422Error, bucket: "skipped" as const, heuristic: false },
+					{ label: "413 (request entity too large)", makeError: make413Error, bucket: "skipped" as const, heuristic: false },
+					{ label: "403 with size keyword", makeError: make403SizeError, bucket: "skipped" as const, heuristic: true },
+					{ label: "403 without size keywords", makeError: make403RateLimitError, bucket: "retriable" as const, heuristic: false },
+				])("routes single-file $label rejection to $bucket bucket", async ({ makeError, bucket, heuristic }) => {
 					fakeOctokit.setupInitialState(PARENTCOMMIT123_SHA, TREE456_SHA, []);
-					fakeOctokit.simulateError("POST /repos/{owner}/{repo}/git/blobs", make422Error());
+					fakeOctokit.simulateError("POST /repos/{owner}/{repo}/git/blobs", makeError());
 
 					const result = await vault.applyChanges(
-						[{ path: "huge.mp4", content: FileContent.fromPlainText("x".repeat(100)) }],
+						[{ path: "file.bin", content: FileContent.fromPlainText("x".repeat(100)) }],
 						[]
 					);
 
-					expect(result.changes).toEqual([]);
-					expect(result.skippedPaths).toEqual(["huge.mp4"]);
-					expect(result.skippedWarning).toContain("huge.mp4");
-					expect(result.skippedWarning).toContain(".gitignore");
-					expect(result.skippedWarning).toContain("git push");
-					// Commit and tree should be unchanged (no-op)
-					expect(result.commitSha).toBe(PARENTCOMMIT123_SHA);
-					expect(result.treeSha).toBe(TREE456_SHA);
+					// No commit created when no files succeed
+					expect(result).toMatchObject({ changes: [], commitSha: PARENTCOMMIT123_SHA, treeSha: TREE456_SHA });
+
+					if (bucket === "skipped") {
+						expect(result).toMatchObject({ skippedPaths: ["file.bin"] });
+						expect(result.rateLimitedPaths).toBeUndefined();
+						expect(result.skippedWarning).toContain("file.bin");
+						expect(result.skippedWarning).toContain(".gitignore");
+						expect(result.skippedWarning?.includes("classified by error message keywords")).toBe(heuristic);
+					} else {
+						expect(result).toMatchObject({ rateLimitedPaths: ["file.bin"] });
+						expect(result.skippedPaths).toBeUndefined();
+					}
 				});
 
 				it("should skip only the 422 file and commit the rest when uploading multiple files", async () => {
@@ -500,7 +514,25 @@ describe("RemoteGitHubVault", () => {
 					expect(result.commitSha).not.toBe(PARENTCOMMIT123_SHA);
 				});
 
-				it("should throw VaultError for non-422 upload failures (unchanged behaviour)", async () => {
+				it("should commit successfully uploaded files when some are rate-limited", async () => {
+					fakeOctokit.setupInitialState(PARENTCOMMIT123_SHA, TREE456_SHA, []);
+					// Only the first blob call fails; second succeeds
+					fakeOctokit.simulateError("POST /repos/{owner}/{repo}/git/blobs", make403RateLimitError());
+
+					const result = await vault.applyChanges(
+						[
+							{ path: "rate-limited.md", content: FileContent.fromPlainText("blocked") },
+							{ path: "ok.md", content: FileContent.fromPlainText("fine") },
+						],
+						[]
+					);
+
+					expect(result.rateLimitedPaths).toEqual(["rate-limited.md"]);
+					expect(result.changes).toEqual([{ path: "ok.md", type: "ADDED" }]);
+					expect(result.commitSha).not.toBe(PARENTCOMMIT123_SHA);
+				});
+
+				it("should throw VaultError for non-blob-rejection upload failures (unchanged behaviour)", async () => {
 					fakeOctokit.setupInitialState(PARENTCOMMIT123_SHA, TREE456_SHA, []);
 					const serverError: any = new Error("Internal server error");
 					serverError.status = 500;

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -19,6 +19,12 @@ import { detectSuspiciousCorrespondence } from "./util/pathPattern";
 import * as Encryption from "./encryption";
 
 /**
+ * Keywords that suggest a 401/403 blob rejection is size-related rather than transient.
+ * Used heuristically — absence does not guarantee the file is small enough to push.
+ */
+const LARGE_FILE_ERROR_KEYWORDS = ['too large', 'exceeds', 'blob is over', 'size limit'];
+
+/**
  * Represents a node in GitHub's git tree structure
  * Maps to GitHub API tree object format
  */
@@ -171,16 +177,14 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 	}
 
 	/**
-	 * Returns true if the HTTP status code indicates a file-specific rejection that
-	 * should be skipped rather than treated as a sync-aborting error.
+	 * Returns true if the HTTP status code indicates a per-blob failure that applyChanges
+	 * should handle specially rather than propagating as a sync-aborting VaultError.
 	 *
-	 * 401/403: auth rejection — unlikely here since auth is pre-verified by readFromSource(),
-	 *          so more likely a size-based policy enforcement
-	 * 413: request entity too large
-	 * 422: unprocessable entity (GitHub's documented blob-too-large code)
+	 * 413/422: definitive size rejection — route to unpushedFiles.
+	 * 401/403: ambiguous — could be size-based policy or a transient failure (rate limit,
+	 *          secondary rate limit, etc.). applyChanges discriminates via keyword check.
 	 *
-	 * Excluded: 429 (rate limit — transient, not file-specific) and other 4xx codes
-	 * that indicate systemic API misuse or transient failures.
+	 * Excluded: 429 and 5xx codes — handled by the retry plugin before reaching here.
 	 */
 	private isBlobRejectionStatus(status: number): boolean {
 		return [401, 403, 413, 422].includes(status);
@@ -587,29 +591,64 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		// Wait for all tree nodes, collecting both successes and failures
 		const results = await Promise.allSettled(operations.map(op => op.promise));
 
-		// Extract successful nodes, collect per-file errors, and separate 422 skips
+		// Extract successful nodes, collect per-file errors, and bucket special rejections.
+		// Three rejection buckets:
+		//   skippedFiles    — definitive or likely size rejection (→ unpushedFiles, manual git)
+		//   retriableFiles  — ambiguous 401/403 without size keywords (→ retry next sync)
+		//   perFileErrors   — everything else (→ abort sync)
 		const treeNodes: TreeNode[] = [];
 		const perFileErrors: Array<{ path: string; error: unknown }> = [];
-		const skippedFiles: Array<{ path: string; sizeMB: string }> = [];
+		const skippedFiles: Array<{ path: string; sizeMB: string; heuristic: boolean }> = [];
+		const retriableFiles: Array<{ path: string }> = [];
 
 		results.forEach((result, index) => {
 			const { path, sizeBytes } = operations[index];
 			if (result.status === 'fulfilled' && result.value !== null) {
 				treeNodes.push(result.value);
-			} else if (result.status === 'rejected') {
-				const error = result.reason;
-				const errorObj = error as { status?: number };
-				const isFileRejection = typeof errorObj.status === 'number' && this.isBlobRejectionStatus(errorObj.status);
-				if (isFileRejection && sizeBytes !== null) {
-					const sizeMB = (sizeBytes / (1024 * 1024)).toFixed(1);
-					skippedFiles.push({ path, sizeMB });
-				} else {
-					perFileErrors.push({ path, error });
+				return;
+			}
+			if (result.status !== 'rejected') return;
+
+			const error = result.reason;
+			const errorObj = error as { status?: number; message?: string };
+			const status = errorObj.status;
+
+			if (typeof status !== 'number' || !this.isBlobRejectionStatus(status)) {
+				perFileErrors.push({ path, error });
+				return;
+			}
+
+			// 413/422: unambiguous size rejection codes — route directly to unpushedFiles
+			if (status === 413 || status === 422) {
+				if (sizeBytes !== null) {
+					skippedFiles.push({ path, sizeMB: (sizeBytes / (1024 * 1024)).toFixed(1), heuristic: false });
+				}
+				return;
+			}
+
+			// 401/403: ambiguous — check message for size keywords since GitHub reuses 403
+			// for both size-based policy enforcement and transient failures (rate limits)
+			const message = errorObj.message ?? '';
+			const looksLikeSize = LARGE_FILE_ERROR_KEYWORDS.some(kw => message.toLowerCase().includes(kw));
+			if (looksLikeSize && sizeBytes !== null) {
+				skippedFiles.push({ path, sizeMB: (sizeBytes / (1024 * 1024)).toFixed(1), heuristic: true });
+			} else {
+				retriableFiles.push({ path });
+				// Diagnostic: large file rejected with 401/403 but no matching keywords —
+				// may be a new size-limit message variant not yet in LARGE_FILE_ERROR_KEYWORDS.
+				if (sizeBytes !== null && sizeBytes > 15 * 1024 * 1024) {
+					fitLogger.log(
+						`[RemoteVault] Large file (~${(sizeBytes / (1024 * 1024)).toFixed(1)} MB) rejected with ${status} ` +
+						`but no known size-limit keywords found in the error response. ` +
+						`If this file consistently fails to sync, it may be too large for the GitHub API. ` +
+						`Share this log entry to help improve detection. Full error: "${message}"`,
+						{ path, status, sizeBytes }
+					);
 				}
 			}
 		});
 
-		// Non-422 errors abort the sync entirely (unchanged behaviour)
+		// Non-blob-rejection errors abort the sync entirely
 		if (perFileErrors.length > 0) {
 			const failedPaths = perFileErrors.map(e => e.path);
 			throw VaultError.network(
@@ -624,10 +663,18 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		let skippedWarning: string | undefined;
 		if (skippedFiles.length > 0) {
 			skippedPathsList = skippedFiles.map(f => f.path);
-			const fileLines = skippedFiles.map(f => `  • ${f.path} (~${f.sizeMB} MB)`).join('\n');
+			const heuristicCount = skippedFiles.filter(f => f.heuristic).length;
+			const fileLines = skippedFiles.map(f => {
+				const note = f.heuristic ? ' (size-related error inferred from response)' : '';
+				return `  • ${f.path} (~${f.sizeMB} MB)${note}`;
+			}).join('\n');
+			const heuristicNote = heuristicCount > 0
+				? `\n(${heuristicCount} file(s) above classified by error message keywords rather than a definitive rejection code — classification may be imprecise.)`
+				: '';
 			skippedWarning = [
-				`${skippedFiles.length} file(s) skipped — GitHub API rejected (possibly too large):`,
+				`${skippedFiles.length} file(s) skipped — GitHub API rejected, likely too large for the API:`,
 				fileLines,
+				heuristicNote,
 				'',
 				'To resolve, choose one:',
 				'  1. Exclude permanently: add path(s) to .gitignore',
@@ -639,7 +686,7 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			].join('\n');
 		}
 
-		// If no changes needed (all files skipped or no-ops), return without committing
+		// If no changes needed (all files skipped/retriable or no-ops), return without committing
 		if (treeNodes.length === 0) {
 			return {
 				changes: [],
@@ -647,6 +694,7 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 				treeSha: parentTreeSha,
 				newState: currentState,
 				...(skippedPathsList && { skippedPaths: skippedPathsList, skippedWarning }),
+				...(retriableFiles.length > 0 && { rateLimitedPaths: retriableFiles.map(f => f.path) }),
 			};
 		}
 
@@ -693,6 +741,7 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			newState,
 			userWarning,
 			...(skippedPathsList && { skippedPaths: skippedPathsList, skippedWarning }),
+			...(retriableFiles.length > 0 && { rateLimitedPaths: retriableFiles.map(f => f.path) }),
 		};
 	}
 

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -477,6 +477,10 @@ export class FakeLocalVault implements IVault<"local"> {
 		}
 	}
 
+	deleteFile(path: string): void {
+		this.files.delete(path);
+	}
+
 	/**
 	 * Get all files as raw PlainTextContent or Base64Content (for test assertions).
 	 */

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -761,6 +761,7 @@ export class FakeRemoteVault implements IVault<"remote"> {
 	private commitSha: CommitSha = 'initial-commit' as CommitSha;
 	private failureError: Error | null = null;
 	private _skippedPaths: Set<string> = new Set(); // Paths that return 422 on next applyChanges
+	private _rateLimitedPaths: Set<string> = new Set(); // Paths returned as rateLimitedPaths on next applyChanges
 	private owner: string;
 	private repo: string;
 	private branch: string;
@@ -791,6 +792,14 @@ export class FakeRemoteVault implements IVault<"remote"> {
 	 */
 	setSkippedPaths(paths: string[]): void {
 		this._skippedPaths = new Set(paths);
+	}
+
+	/**
+	 * Configure paths to be returned as rateLimitedPaths on the next applyChanges call.
+	 * Simulates a transient rejection (e.g. rate limit) where the file should be retried next sync.
+	 */
+	setRateLimitedPaths(paths: string[]): void {
+		this._rateLimitedPaths = new Set(paths);
 	}
 
 	/**
@@ -925,17 +934,23 @@ export class FakeRemoteVault implements IVault<"remote"> {
 
 		const changes: FileChange[] = [];
 		const skippedPaths: string[] = [];
+		const rateLimitedPaths: string[] = [];
 
 		for (const file of filesToWrite) {
 			if (this._skippedPaths.has(file.path)) {
 				skippedPaths.push(file.path);
 				continue; // Simulate 422 skip
 			}
+			if (this._rateLimitedPaths.has(file.path)) {
+				rateLimitedPaths.push(file.path);
+				continue; // Simulate transient rejection
+			}
 			const existed = this.files.has(file.path);
 			this.setFile(file.path, file.content);
 			changes.push({ path: file.path, type: existed ? 'MODIFIED' : 'ADDED' });
 		}
 		this._skippedPaths.clear(); // Consume after one applyChanges call
+		this._rateLimitedPaths.clear();
 
 		for (const path of filesToDelete) {
 			if (this.files.has(path)) {
@@ -972,6 +987,7 @@ export class FakeRemoteVault implements IVault<"remote"> {
 			treeSha,
 			newState,
 			...(skippedPaths.length > 0 && { skippedPaths, skippedWarning }),
+			...(rateLimitedPaths.length > 0 && { rateLimitedPaths }),
 		};
 	}
 

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -53,12 +53,16 @@ type ApplyChangesResultMap = {
 		treeSha: TreeSha;
 		/** FileStates computed from the new tree (for cache updates) */
 		newState: FileStates;
-		/** Paths skipped because GitHub returned 422 (file too large for API).
-		 * Caller must add these to unpushedFiles — they are NOT in newState. */
+		/** Paths skipped due to a definitive or likely size rejection (413/422, or 401/403
+		 * with size-related keywords). Caller must add to unpushedFiles — not in newState. */
 		skippedPaths?: string[];
 		/** Pre-built first-encounter notice for skipped files (includes git CLI instructions
 		 * with repo/branch substituted). Show only when path is newly added to unpushedFiles. */
 		skippedWarning?: string;
+		/** Paths not uploaded due to a transient failure (e.g. rate limit).
+		 * Caller must NOT update localShas for these — leave old SHA so they are
+		 * re-detected as changed and retried on the next sync. */
+		rateLimitedPaths?: string[];
 	};
 };
 


### PR DESCRIPTION
Fixes #179.

---

<!-- kody-pr-summary:start -->
This pull request introduces a robust retry mechanism for transient file upload failures to the GitHub API, such as those caused by rate limiting.

Key changes include:

*   **Granular Error Handling**: GitHub API blob rejection errors (401, 403, 413, 422) are now categorized more precisely. Errors definitively indicating a file is too large (413, 422) or 401/403 errors containing specific "size limit" keywords are classified as *skipped* (permanent failure). Ambiguous 401/403 errors *without* size-related keywords are now classified as *transient* failures.
*   **Automatic Retries for Transient Failures**: Files identified as having transient upload failures (e.g., due to rate limits) are automatically deferred. Their local SHA is reverted to its pre-sync baseline, ensuring they are re-detected as changed and retried on the subsequent sync without requiring manual intervention or being added to `unpushedFiles`.
*   **Improved User Feedback**: Users receive a "Sync incomplete" notice that lists files which encountered transient upload issues, informing them that these files will be retried automatically on the next sync.
*   **Partial Sync Success**: The system now commits successfully uploaded files even if other files encounter transient failures, ensuring that sync progress is not entirely blocked.
*   **Correct Deletion Handling**: If a file that previously failed transiently is deleted locally before the next sync, the deletion is correctly detected and propagated to the remote.

This enhancement significantly improves the reliability and user experience of syncing, particularly when encountering temporary API constraints.
<!-- kody-pr-summary:end -->