### PR TITLE
fix attempting 2nd sync during sync to not get stuck infinitely

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -226,9 +226,9 @@ export default class FitPlugin extends Plugin {
 
 			return { status: 'success', result: syncResult };
 		} else {
-			// Handle already-syncing case - this is expected for concurrent requests
+			// Handle already-syncing case - rare race between isActive check and sync() call
 			if (syncResult.error.type === 'already-syncing') {
-				fitLogger.log('[Plugin] Sync already in progress', { triggerType });
+				fitLogger.log('[Plugin] Sync already in progress (race)', { triggerType });
 				return { status: 'already-syncing' };
 			}
 
@@ -345,6 +345,11 @@ export default class FitPlugin extends Plugin {
 	private async executeSyncWithUICoordination(triggerType: 'manual' | 'auto'): Promise<void> {
 		fitLogger.log(`[Plugin] ${triggerType === 'manual' ? 'Manual' : 'Auto'} sync requested`);
 
+		if (this.fitSync.isActive) {
+			fitLogger.log('[Plugin] Sync already in progress - ignoring request', { triggerType });
+			return;
+		}
+
 		this.onSyncStart(triggerType);
 
 		let outcome: SyncOutcome;
@@ -391,8 +396,9 @@ export default class FitPlugin extends Plugin {
 				break;
 
 			case 'already-syncing':
-				// Don't modify the notice - it's being used by the active sync
-				// The concurrent request just logs and returns (no cleanup needed)
+				// Rare race: passed isActive check but sync() was claimed before we reached it.
+				// onSyncStart already ran, so undo its counter increment.
+				this.onSyncEnd(triggerType);
 				break;
 
 			case 'not-configured':

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -116,8 +116,9 @@ export type ConflictResolutionResult = {
 export class FitSync implements IFitSync {
 	fit: Fit;
 	saveLocalStoreCallback: (localStore: Partial<LocalStores>) => Promise<void>;
-	private isSyncing = false;
+	private syncPromise: Promise<SyncResult> | null = null;
 
+	get isActive(): boolean { return this.syncPromise !== null; }
 
 	constructor(fit: Fit, saveLocalStoreCallback: (localStore: Partial<LocalStores>) => Promise<void>) {
 		this.fit = fit;
@@ -620,14 +621,16 @@ export class FitSync implements IFitSync {
 	}
 
 	async sync(syncNotice: FitNotice, options?: { isAutoSync?: boolean }): Promise<SyncResult> {
-		const isAutoSync = options?.isAutoSync ?? false;
-		// Check if already syncing
-		if (this.isSyncing) {
+		if (this.syncPromise) {
 			fitLogger.log('[FitSync] Sync already in progress - aborting new sync request');
 			return { success: false, error: SyncErrors.alreadySyncing() };
 		}
+		this.syncPromise = this._doSync(syncNotice, options).finally(() => { this.syncPromise = null; });
+		return this.syncPromise;
+	}
 
-		this.isSyncing = true;
+	private async _doSync(syncNotice: FitNotice, options?: { isAutoSync?: boolean }): Promise<SyncResult> {
+		const isAutoSync = options?.isAutoSync ?? false;
 
 		try {
 			syncNotice.setMessage("Checking for changes...");
@@ -781,8 +784,6 @@ export class FitSync implements IFitSync {
 					? String(error.message)
 					: `Generic error: ${String(error)}`; // May result in '[object Object]' but it's the best we can do
 			return { success: false, error: SyncErrors.unknown(errorMessage, { originalError: error }) };
-		} finally {
-			this.isSyncing = false;
 		}
 	}
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request refactors the synchronization mechanism to prevent multiple sync operations from running concurrently and to handle race conditions more robustly.

Key changes include:

*   **Centralized Sync State Management:** The `FitSync` class now uses a `syncPromise` to track the active synchronization process instead of a simple `isSyncing` boolean flag. This ensures that only one sync can truly be active at any given time.
*   **Preventing Concurrent Syncs:**
    *   The `FitSync.sync()` method now immediately returns an `already-syncing` error if a sync is already in progress, preventing the initiation of a new sync.
    *   The `FitPlugin.executeSyncWithUICoordination()` method now performs an early check using `this.fitSync.isActive` to prevent starting UI coordination (like showing a sync notice) if a sync is already active.
*   **Graceful Race Condition Handling:** In the rare event that `onSyncStart` is called but the underlying `fitSync.sync()` then reports an `already-syncing` error (due to another sync claiming the slot just before), `onSyncEnd` is now explicitly called to correctly clean up any UI state or counters initiated by `onSyncStart`.
*   **Improved Logging:** Log messages have been updated to clearly distinguish between a sync request being ignored due to an active sync and a race condition where a sync attempt immediately finds another sync already running.

These changes prevent the plugin from getting stuck in an infinite loading state or exhibiting unexpected behavior when multiple sync requests are triggered simultaneously.
<!-- kody-pr-summary:end -->