### PR TITLE
fix(#283): data loss risks from considering only local files ignoring _fit/

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -25,6 +25,19 @@ FIT uses SHA-based change detection to maintain **baseline state** versions (`Lo
 
 **Critical**: Baseline updates only on successful sync. Failed syncs preserve baseline, so next sync detects all accumulated changes.
 
+### Why SHA Comparison?
+
+**Problem with timestamps:**
+- Clock skew between devices
+- Unreliable on mobile platforms
+- Lost when files are copied/restored
+
+**SHA advantages:**
+- Content-based comparison
+- Handles clock differences
+- Detects actual changes vs metadata changes
+- Enables three-way merge detection
+
 ### Cache Structure
 
 ```typescript
@@ -101,18 +114,30 @@ This enables future syncs to compare current local SHA vs baseline to determine 
 
 **Note:** Reading hidden files for baseline comparison requires using `vault.adapter` API instead of `vault.getAbstractFileByPath()`. See [docs/api-compatibility.md](./api-compatibility.md) "Reading Untracked Files".
 
-### Why SHA Comparison?
+## Concepts and Invariants
 
-**Problem with timestamps:**
-- Clock skew between devices
-- Unreliable on mobile platforms
-- Lost when files are copied/restored
+### Baseline
 
-**SHA advantages:**
-- Content-based comparison
-- Handles clock differences
-- Detects actual changes vs metadata changes
-- Enables three-way merge detection
+Each file path has a **baseline** SHA in `localShas` (local) and `lastFetchedRemoteShas` (remote). A baseline entry for `path` means: *this was the confirmed state of the file after the last successful sync.* Change detection works by comparing the current scanned state against the baseline.
+
+- Baselines are updated only on successful sync completion. A failed sync leaves them unchanged, so the next sync re-detects all accumulated changes.
+- A path **absent** from `localShas` has no confirmed local baseline — either it was never synced, or a clash removed the entry (see [Pending](#pending) below).
+
+### `_fit/` as scratchpad
+
+The `_fit/` directory is **never part of the synced vault.** It is out-of-band storage where FIT places copies of remote file versions during conflict resolution, so the user can inspect both sides before deciding.
+
+- `_fit/path` is always a copy of a *remote* version, never the local version.
+- The canonical local version of `path` is always at `path`, not at `_fit/path`.
+- `_fit/` contents are excluded from sync in both directions (`shouldSyncPath` returns false).
+
+### Pending
+
+A path is **pending** when it has an unresolved `_fit/` copy — the user has not yet confirmed which version to keep. FIT tracks pending paths in `pendingClashes` (persisted in `LocalStores`).
+
+- A pending path has no baseline: `localShas[path]` is absent. FIT makes no assumption about which version is canonical.
+- FIT **shields** pending paths: excluded from push (local version is unconfirmed) and protected from remote overwrites (new remote versions go to `_fit/` only).
+- A path leaves pending when the user resolves the discrepancy — deleting `_fit/path`, or editing either file until both copies match. See [Pending Clash State Machine](#pending-clash-state-machine).
 
 ## Change Detection
 
@@ -152,6 +177,8 @@ cachedLocalSha = {
 
 // Result: file2.md detected as REMOVED
 ```
+
+**Phase 0 note:** Before this detection runs, Phase 0 pre-processing excludes active pending clash paths (files with an unresolved `_fit/` copy tracked in `pendingClashes`). They re-enter this detection once resolved.
 
 ### ☁️ Remote Change Detection
 
@@ -415,8 +442,12 @@ FIT uses a **phased sync architecture** that maintains clear boundaries between 
 
 ```mermaid
 flowchart TD
-    Start[Start Sync] --> Phase1[Phase 1: Collect State]
-    Phase1 --> Gather1[💾 Scan local vault<br/>tracked files only]
+    Start[Start Sync] --> Phase0[Phase 0: Resolve Pending Clashes]
+    Phase0 --> PendingCheck{pendingClashes<br/>non-empty?}
+    PendingCheck -->|No| Phase1
+    PendingCheck -->|Yes| ResolvePending[Check _fit/ vs local for each pending path<br/>Resolved paths: re-enter normal detection<br/>Active paths: excluded from push/pull]
+    ResolvePending --> Phase1[Phase 1: Collect State]
+    Phase1 --> Gather1[💾 Scan local vault<br/>tracked + resolved-pending files]
     Gather1 --> Gather2[☁️ Read remote tree<br/>all files]
 
     Gather2 --> Phase2[Phase 2: Compare & Resolve]
@@ -427,11 +458,11 @@ flowchart TD
 
     Classify --> Resolve[Resolve ambiguities:<br/>Batch stat filesystem]
     Resolve --> Verify[Verify untracked files:<br/>protected? exists? baseline SHA?]
-    Verify --> Reclassify[Reclassify:<br/>❓ → ✓ Safe or 🔀 Clash]
+    Verify --> Reclassify[Reclassify:<br/>❓ → ✓ Safe or 🔀 Clash<br/>safeRemote + active pending → 🔀 Clash]
 
     Reclassify --> Phase3[Phase 3: Execute Sync]
-    Phase3 --> ResolveConflicts[Resolve clashes<br/>📁 Write to _fit/]
-    ResolveConflicts --> Push[⬆️ Push local changes]
+    Phase3 --> ResolveConflicts[Resolve clashes<br/>📁 Write to _fit/<br/>Remove from localShas, add to pendingClashes]
+    ResolveConflicts --> Push[⬆️ Push non-conflicted local changes]
     Push --> Pull[⬇️ Pull safe remote changes]
     Pull --> Persist[Persist state atomically]
 
@@ -441,24 +472,30 @@ flowchart TD
 
 **Architecture Principles:**
 
-1. **Phase 1 (Collect)**: Gather state from vaults in isolation
-   - Local: Only tracked files (efficient Obsidian API scan)
+1. **Phase 0 (Pending Clash Resolution)**: Pre-process files with unresolved `_fit/` copies
+   - Check each `pendingClashes` path: is `_fit/` still present? Does it match local?
+   - Resolved paths (no `_fit/`, or `_fit/` matches local) re-enter normal detection
+   - Active pending paths are excluded from push and shielded from remote overwrites
+
+2. **Phase 1 (Collect)**: Gather state from vaults in isolation
+   - Local: Only tracked files (efficient Obsidian API scan), excluding active-pending paths
    - Remote: All files (GitHub tree)
    - No filesystem checks yet
 
-2. **Phase 2 (Compare & Resolve)**: Determine outcomes and resolve ambiguities
+3. **Phase 2 (Compare & Resolve)**: Determine outcomes and resolve ambiguities
    - **Compare**: Classify changes based on vault state
      - Tracked files with changes on both sides → **Clash** (definite conflict)
      - Tracked files changed on one side → **Safe** (can apply directly)
      - Untracked remote changes → **Needs Verification** (insufficient info)
+     - safeRemote changes to active-pending paths → reclassified as **Clash** (new remote goes to `_fit/` only)
    - **Resolve**: Resolve ambiguity for untracked files
      - Batch collect filesystem state (one `stat` call for all paths)
      - Check: Is path protected? Does file exist locally? Baseline SHA match?
      - Reclassify: Needs Verification → Safe or Clash
 
-3. **Phase 3 (Execute)**: Apply changes and persist state
-   - Resolve real clashes (write to `_fit/`)
-   - Push and pull safe changes
+4. **Phase 3 (Execute)**: Apply changes and persist state
+   - Resolve real clashes (write to `_fit/`, remove from `localShas`, add to `pendingClashes`)
+   - Push non-conflicted local changes; pull safe remote changes
    - Atomically update SHA cache
 
 **Key Benefits:**
@@ -468,6 +505,45 @@ flowchart TD
 - **Testable**: Phases can be tested independently
 
 **Implementation:** [`FitSync.performSync()` in fitSync.ts](../src/fitSync.ts)
+
+### Pending Clash State Machine
+
+Once a clash is written, the file enters a **pending** state that persists across syncs until explicitly resolved. `pendingClashes` is persisted in `LocalStores`; `localShas[path]` is removed so the file has no stale baseline.
+
+```mermaid
+flowchart TD
+    Clash[🔀 Clash detected] --> WriteFit[Write remote → 📁 _fit/path]
+    WriteFit --> UpdateState[Remove localShas entry<br/>Add to pendingClashes]
+    UpdateState --> Pending
+
+    Pending([⏳ Pending]) --> NextSync[Next sync: Phase 0 check]
+
+    NextSync --> FitGone{_fit/path<br/>exists?}
+
+    FitGone -->|No, deleted| LocalGone{local file<br/>exists?}
+    FitGone -->|Yes| FitMatchesLocal{_fit/ content<br/>== local?}
+
+    LocalGone -->|Yes| PushLocal[local has no baseline<br/>→ ADDED → pushed ✓]
+    LocalGone -->|No| PushDelete[enqueue deletion<br/>→ remote file removed ✓]
+
+    FitMatchesLocal -->|Yes| PushResolved[re-enter normal detection<br/>push/no-op as appropriate ✓]
+    FitMatchesLocal -->|No| StillPending[Still pending:<br/>excluded from push/pull<br/>new remote → _fit/ only]
+
+    PushLocal --> Resolved([✅ Resolved])
+    PushDelete --> Resolved
+    PushResolved --> Resolved
+    StillPending --> Pending
+```
+
+**Resolution scenarios** (see `fitSync.realFit.test.ts` "clash lifecycle" describe block for tests):
+
+| Scenario | `_fit/` state | Local state | Outcome |
+|----------|--------------|-------------|---------|
+| A | Remote changes again | Unchanged | `_fit/` updated to latest remote, local preserved |
+| B | Deleted by user | Edited (merged) | Merged version pushed |
+| C | Deleted by user | Unchanged | Local pushed as-is |
+| D | Deleted by user | Also deleted | Deletion pushed to remote |
+| E | Edited to match local (or vice versa) | Matches `_fit/` | Resolved; canonical version pushed or no-op |
 
 ### Sync Operation Types
 
@@ -531,8 +607,8 @@ remoteChanges = [
 1. Identify clashed files
 2. For each clash, check if content actually differs
 3. If no actual difference, treat as compatible
-4. If real 🔀 conflict, save remote version to 📁 `_fit/`
-5. Push local changes (including conflicted files)
+4. If real 🔀 conflict, save remote version to 📁 `_fit/`, add path to `pendingClashes`, remove from `localShas`
+5. Push **non-conflicted** local changes only (conflicted files are withheld until resolved)
 6. Pull non-conflicted remote changes
 
 ## 🔀 Conflict Resolution
@@ -592,14 +668,14 @@ flowchart TD
 - User can manually restore from 📁 `_fit/` if needed
 
 **☁️ Remote deleted, 💾 local MODIFIED:**
-- Keep local version in original location
-- Push to remote (restores the file remotely)
-- Local version wins automatically
+- Keep local version in original location (not deleted)
+- ⚠️ Local MODIFIED is in `clashes`, not `safeLocal` — it is **not** pushed. The file ends up locally present but remotely absent with the divergence invisible to subsequent syncs. Tracked as a known bug.
 
 **Both sides MODIFIED (different content):**
 - Keep 💾 local version in original location
 - Save ☁️ remote version → 📁 `_fit/path/to/file.md`
-- User manually merges the two versions
+- Remove path from `localShas`, add to `pendingClashes`
+- Subsequent syncs hold the file in pending state until resolved — see [Pending Clash State Machine](#pending-clash-state-machine)
 - Binary files (`.png`, `.jpg`, `.pdf`) saved as-is to 📁 `_fit/`
 
 ## Initial Sync

--- a/main.ts
+++ b/main.ts
@@ -548,6 +548,11 @@ export default class FitPlugin extends Plugin {
 		this.settings = settingsObj;
 	}
 
+	// TODO: loadLocalStore and saveLocalStoreCallback are the persistence contract for all
+	// sync state. Adding any new field to LocalStores requires updating BOTH this function
+	// and saveLocalStoreCallback — they are not tested together (see follow-up PR for
+	// main.ts integration tests). When adding a field: add it here with a ?? default,
+	// add it to saveLocalStoreCallback, and add a round-trip test.
 	async loadLocalStore() {
 		const storedData = (await this.loadData()) ?? {};
 		this.localStore = {

--- a/main.ts
+++ b/main.ts
@@ -556,7 +556,8 @@ export default class FitPlugin extends Plugin {
 			lastFetchedCommitSha: storedData.lastFetchedCommitSha ?? null,
 			lastFetchedRemoteShas: storedData.lastFetchedRemoteSha ?? storedData.lastFetchedRemoteShas ?? {},
 			lastFetchedRemoteSha: undefined,                        // consume legacy field name → omitted by JSON.stringify, removing it from storage
-			unpushedFiles: storedData.unpushedFiles ?? {}
+			unpushedFiles: storedData.unpushedFiles ?? {},
+			pendingClashes: storedData.pendingClashes ?? [],
 		};
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -80,6 +80,11 @@ export interface LocalStores {
 	// on remote (and should be removed from this list).
 	// Note: transient failures like rate limits (#179) should be tracked separately when needed since they SHOULD retry on subsequent syncs.
 	unpushedFiles?: FileStates
+	// Paths with an unresolved _fit/ copy (pending clash state). localShas entry is absent
+	// for these paths. Resolved when _fit/ is deleted or matches local content.
+	// Downgrade-safe: absent field treated as empty array; missing localShas entry causes
+	// false-positive re-push on old clients (overhead only, not data loss).
+	pendingClashes?: string[]
 }
 
 /**
@@ -96,7 +101,8 @@ const DEFAULT_LOCAL_STORE: LocalStores = {
 	localShas: {},
 	lastFetchedCommitSha: null,
 	lastFetchedRemoteShas: {},
-	unpushedFiles: {}
+	unpushedFiles: {},
+	pendingClashes: []
 	// Note: no localSha — absent means no legacy data to migrate
 };
 

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -33,6 +33,7 @@ export class Fit {
 	lastFetchedCommitSha: CommitSha | null; // Last synced commit SHA
 	lastFetchedRemoteShas: FileStates;      // Canonical remote SHA cache
 	unpushedFiles: FileStates;              // Files skipped due to API size limit (422)
+	pendingClashes: string[];               // Paths with unresolved _fit/ copies
 	localVault: LocalVault;                 // Local vault (tracks local file state)
 	remoteVault: RemoteGitHubVault;
 
@@ -85,6 +86,7 @@ export class Fit {
 		this.lastFetchedCommitSha = localStore.lastFetchedCommitSha;
 		this.lastFetchedRemoteShas = localStore.lastFetchedRemoteShas;
 		this.unpushedFiles = localStore.unpushedFiles ?? {};
+		this.pendingClashes = localStore.pendingClashes ?? [];
 
 		const localCount = Object.keys(this.localShas).length;
 		const legacyCount = Object.keys(this.localSha).length;

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -99,6 +99,11 @@ describe('FitSync', () => {
 	 * Simulate main.ts sync result handling logic.
 	 * This covers error handling and user notification that currently lives outside FitSync.
 	 * TODO: Expand to handle success cases with conflict notifications (showUnappliedConflicts)
+	 *
+	 * Coverage gap: main.ts lifecycle (loadLocalStore deserialization, saveLocalStoreCallback
+	 * round-trip, settings-triggered saveLocalStore) is not exercised here. A dedicated
+	 * integration test file for main.ts would catch field-omission bugs like the
+	 * pendingClashes loadLocalStore regression — tracked in follow-up PR.
 	 */
 	async function syncAndHandleResult(fitSync: FitSync, notice: any) {
 		const result = await fitSync.sync(notice);
@@ -1198,6 +1203,49 @@ describe('FitSync', () => {
 					'doc.md': 'local edits\n',
 					'_fit/doc.md': 'remote edits\n',
 				});
+				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe('remote edits\n');
+			});
+
+			it('G: multiple pending syncs never re-include the path in localShas (prevents silent remote pull)', async () => {
+				// Regression guard: Phase 0 must keep the pending path out of localShas across
+				// consecutive syncs. If localShas re-includes the pending path with the LOCAL sha,
+				// the next sync sees remote-sha ≠ stored-sha → treats it as a safeRemote change
+				// → pulls and silently overwrites local edits.
+				const fitSync = createFitSync();
+				await setupClash(fitSync);
+
+				for (let i = 0; i < 3; i++) {
+					await syncAndHandleResult(fitSync, createMockNotice());
+					expect(localStoreState.localShas).not.toHaveProperty('doc.md');
+					expect(localStoreState.pendingClashes).toContain('doc.md');
+				}
+
+				// Remote must never have received the local edits
+				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe('remote edits\n');
+				expect(localVault.getAllFilesAsRaw()['doc.md']).toBe('local edits\n');
+			});
+
+			it('H: pendingClashes survive simulated plugin reload (re-init from saved state)', async () => {
+				// Regression guard: pendingClashes must be included in the state saved by
+				// saveLocalStoreCallback and correctly restored when FitSync is re-initialized
+				// (analogous to plugin unload/reload between syncs).
+				const fitSync = createFitSync();
+				await setupClash(fitSync);
+
+				expect(localStoreState.pendingClashes).toContain('doc.md');
+				expect(localStoreState.localShas).not.toHaveProperty('doc.md');
+
+				// Simulate plugin reload: new FitSync initialized from the saved localStoreState
+				const reloadedFitSync = createFitSync();
+
+				const result = await syncAndHandleResult(reloadedFitSync, createMockNotice());
+
+				// Phase 0 must run and surface the clash — not silently clear it
+				expect(result).toMatchObject({
+					success: true,
+					clash: expect.arrayContaining([expect.objectContaining({ path: 'doc.md', localState: 'pending' })]),
+				});
+				expect(localVault.getAllFilesAsRaw()['doc.md']).toBe('local edits\n');
 				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe('remote edits\n');
 			});
 		});

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1178,6 +1178,28 @@ describe('FitSync', () => {
 				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe(expectedRemote);
 				expect(localVault.getAllFilesAsRaw()).not.toHaveProperty('_fit/doc.md');
 			});
+
+			it('F: user ignores clash and syncs again — clash reported on every sync until resolved', async () => {
+				const fitSync = createFitSync();
+				await setupClash(fitSync);
+				// After clash: doc.md='local edits\n', _fit/doc.md='remote edits\n', no remote changes
+
+				// Sync without resolving anything
+				const result = await syncAndHandleResult(fitSync, createMockNotice());
+
+				// Must still report the pending clash so the user is reminded, even though
+				// remote hasn't changed and no local operations are performed.
+				expect(result).toMatchObject({
+					success: true,
+					clash: expect.arrayContaining([expect.objectContaining({ path: 'doc.md', localState: 'pending' })]),
+				});
+				// Local and remote must be unchanged
+				expect(localVault.getAllFilesAsRaw()).toMatchObject({
+					'doc.md': 'local edits\n',
+					'_fit/doc.md': 'remote edits\n',
+				});
+				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe('remote edits\n');
+			});
 		});
 
 		it('must NOT delete remote files when tracking capabilities removed (version migration safety)', async () => {

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1043,7 +1043,7 @@ describe('FitSync', () => {
 				clash: expect.arrayContaining([
 					expect.objectContaining({
 						path: 'document.md',
-						localState: 'MODIFIED',
+						localState: 'pending',
 						remoteOp: 'MODIFIED'
 					})
 				])
@@ -1056,6 +1056,119 @@ describe('FitSync', () => {
 				{method: 'setMessage', args: ['Change conflicts detected']},
 				{method: 'setMessage', args: ['Synced with remote, unresolved conflicts written to _fit']}
 			]);
+		});
+
+		describe('clash lifecycle: pending resolution across multiple syncs', () => {
+			// State machine for files written to _fit/ — the "pending clash" state.
+			// See docs/sync-logic.md "Conflict Resolution" for the full decision tree.
+			//
+			// When a clash is written to _fit/, the file enters a pending state:
+			//   - localShas entry is REMOVED (baseline invalidated; downgrade-safe since a
+			//     missing entry is a false-positive re-push, not a silent data loss)
+			//   - pendingClashes tracks the path until the user resolves it
+			//
+			// A pending clash is resolved when _fit/{path} is deleted OR its content
+			// matches local. Resolution scenarios:
+			//   A. Remote changes again while pending → _fit/ updated, local NOT overwritten
+			//   B. User edits to a merged version, deletes _fit/ → merged version pushed
+			//   C. User deletes _fit/ (keeps local unchanged) → local pushed to remote
+			//   D. User deletes both local and _fit/ → deletion pushed to remote
+			//   E. User edits either copy until they match → treated as resolved (parameterized)
+
+			async function setupClash(fitSync: FitSync) {
+				// Establish a clean baseline with 'doc.md' synced on both sides
+				localVault.setFile('doc.md', 'original\n');
+				remoteVault.setFile('doc.md', 'original\n');
+				await syncAndHandleResult(fitSync, createMockNotice());
+
+				// Both sides modify doc.md concurrently
+				localVault.setFile('doc.md', 'local edits\n');
+				remoteVault.setFile('doc.md', 'remote edits\n');
+
+				// Sync: clash detected, remote version written to _fit/doc.md, local kept
+				const result = await syncAndHandleResult(fitSync, createMockNotice());
+				expect(result).toMatchObject({ success: true, clash: expect.arrayContaining([expect.objectContaining({ path: 'doc.md' })]) });
+				expect(localVault.getAllFilesAsRaw()).toMatchObject({
+					'doc.md': 'local edits\n',
+					'_fit/doc.md': 'remote edits\n',
+				});
+			}
+
+			it('A: remote changes again while clash is pending — _fit/ updated, local NOT overwritten', async () => {
+				const fitSync = createFitSync();
+				await setupClash(fitSync);
+
+				remoteVault.setFile('doc.md', 'remote edits v2\n');
+
+				const result = await syncAndHandleResult(fitSync, createMockNotice());
+				expect(result).toMatchObject({ success: true });
+
+				const files = localVault.getAllFilesAsRaw();
+				expect(files['doc.md']).toBe('local edits\n');
+				expect(files['_fit/doc.md']).toBe('remote edits v2\n');
+				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe('remote edits v2\n');
+			});
+
+			it('B: user resolves by editing to merged version — merged version pushed', async () => {
+				const fitSync = createFitSync();
+				await setupClash(fitSync);
+
+				localVault.setFile('doc.md', 'merged content\n');
+				localVault.deleteFile('_fit/doc.md');
+
+				const result = await syncAndHandleResult(fitSync, createMockNotice());
+				expect(result).toMatchObject({ success: true, clash: [] });
+				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe('merged content\n');
+				expect(localVault.getAllFilesAsRaw()).not.toHaveProperty('_fit/doc.md');
+			});
+
+			it('C: user resolves by deleting _fit/ (keeping local unchanged) — local pushed to remote', async () => {
+				const fitSync = createFitSync();
+				await setupClash(fitSync);
+
+				localVault.deleteFile('_fit/doc.md');
+
+				const result = await syncAndHandleResult(fitSync, createMockNotice());
+				expect(result).toMatchObject({ success: true, clash: [] });
+				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe('local edits\n');
+			});
+
+			it('D: user deletes both local file and _fit/ — deletion pushed to remote', async () => {
+				const fitSync = createFitSync();
+				await setupClash(fitSync);
+
+				localVault.deleteFile('doc.md');
+				localVault.deleteFile('_fit/doc.md');
+
+				const result = await syncAndHandleResult(fitSync, createMockNotice());
+				expect(result).toMatchObject({ success: true, clash: [] });
+				expect(remoteVault.getAllFilesAsRaw()).not.toHaveProperty('doc.md');
+			});
+
+			it.each([
+				{
+					name: 'user edits _fit/ to match local (endorsing local version)',
+					setup: (lv: FakeLocalVault) => { lv.setFile('_fit/doc.md', 'local edits\n'); },
+					expectedRemote: 'local edits\n',
+				},
+				{
+					name: 'user edits local to match _fit/ (endorsing remote version)',
+					setup: (lv: FakeLocalVault) => { lv.setFile('doc.md', 'remote edits\n'); },
+					expectedRemote: 'remote edits\n',
+				},
+			])('E: $name — treated as resolved, correct version synced', async ({ setup, expectedRemote }) => {
+				const fitSync = createFitSync();
+				await setupClash(fitSync);
+				// After clash: local='local edits\n', _fit/='remote edits\n', remote='remote edits\n'
+
+				setup(localVault);
+
+				// Non-discrepant _fit/ = resolved. Push whichever version is now canonical.
+				const result = await syncAndHandleResult(fitSync, createMockNotice());
+				expect(result).toMatchObject({ success: true, clash: [] });
+				expect(remoteVault.getAllFilesAsRaw()['doc.md']).toBe(expectedRemote);
+				expect(localVault.getAllFilesAsRaw()).not.toHaveProperty('_fit/doc.md');
+			});
 		});
 
 		it('must NOT delete remote files when tracking capabilities removed (version migration safety)', async () => {

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1076,16 +1076,25 @@ describe('FitSync', () => {
 			//   E. User edits either copy until they match → treated as resolved (parameterized)
 
 			async function setupClash(fitSync: FitSync) {
-				// Establish a clean baseline with 'doc.md' synced on both sides
+				// Establish a clean baseline: pre-load localStoreState with the synced SHA
+				// values so the next sync sees 'doc.md' as already in sync (no changes).
+				// Without this, empty caches would detect ADDED+ADDED (a false-positive clash)
+				// instead of the intended MODIFIED+MODIFIED scenario.
 				localVault.setFile('doc.md', 'original\n');
 				remoteVault.setFile('doc.md', 'original\n');
-				await syncAndHandleResult(fitSync, createMockNotice());
+				const remoteResult = await remoteVault.readFromSource();
+				const localResult = await localVault.readFromSource();
+				fitSync.fit.loadLocalStore(makeLocalStore({
+					localShas: localResult.state,
+					lastFetchedRemoteShas: remoteResult.state,
+					lastFetchedCommitSha: remoteResult.commitSha,
+				}));
 
 				// Both sides modify doc.md concurrently
 				localVault.setFile('doc.md', 'local edits\n');
 				remoteVault.setFile('doc.md', 'remote edits\n');
 
-				// Sync: clash detected, remote version written to _fit/doc.md, local kept
+				// Sync: MODIFIED+MODIFIED clash detected, remote version written to _fit/doc.md
 				const result = await syncAndHandleResult(fitSync, createMockNotice());
 				expect(result).toMatchObject({ success: true, clash: expect.arrayContaining([expect.objectContaining({ path: 'doc.md' })]) });
 				expect(localVault.getAllFilesAsRaw()).toMatchObject({

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -762,7 +762,7 @@ export class FitSync implements IFitSync {
 								// readFileContent returns cached content from readFromSource (no extra network call).
 								try {
 									const remoteContent = await this.fit.remoteVault.readFileContent(path);
-									if (localContent.toBase64() === remoteContent.toBase64()) {
+									if (localContent.equals(remoteContent)) {
 										resolvedNoChangePaths.add(path);
 									}
 								} catch {

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -566,6 +566,21 @@ export class FitSync implements IFitSync {
 			delete newLocalState[path];
 		}
 
+		// Update pendingClashes: newly-clashed tracked files enter pending state.
+		// Remove their baseline so FIT makes no assumption about the canonical version.
+		// Untracked/protected clashes are excluded — they use the #169 baseline mechanism instead.
+		// Paths already in pendingClashes (localState === 'pending') stay there.
+		for (const clash of clashes) {
+			if (clash.remoteOp !== 'REMOVED' &&
+				clash.localState !== 'untracked' &&
+				clash.localState !== 'protected') {
+				if (!this.fit.pendingClashes.includes(clash.path)) {
+					this.fit.pendingClashes.push(clash.path);
+				}
+				delete newLocalState[clash.path];
+			}
+		}
+
 		// Retriable paths: revert to the pre-sync baseline SHA so the file is re-detected as changed
 		// on the next sync. Using the previous baseline (not delete) preserves tracking for the case
 		// where the user deletes the file before the retry — without a baseline, the deletion would
@@ -629,6 +644,7 @@ export class FitSync implements IFitSync {
 			// Once fixed, newBaselineStates will only contain syncable paths (no filtering needed).
 			localShas: this.fit.filterSyncedState(newLocalState),
 			unpushedFiles: this.fit.unpushedFiles,
+			pendingClashes: this.fit.pendingClashes,
 			// Only persist localSha if there are still legacy entries remaining (not yet promoted)
 			localSha: Object.keys(this.fit.localSha).length > 0 ? this.fit.localSha : undefined,
 		});
@@ -680,7 +696,113 @@ export class FitSync implements IFitSync {
 			const {changes: localChanges, state: currentLocalState} = localResult.value;
 			const {changes: remoteChanges, state: remoteTreeSha, commitSha: remoteCommitSha} = remoteResult.value;
 			fitLogger.log('.. ✅ [Sync] Change detection complete');
-			const filteredLocalChanges = localChanges.filter(c => this.fit.shouldSyncPath(c.path));
+
+			// Phase 0: Resolve pending clashes
+			// For each path with an unresolved _fit/ copy, check if the user has resolved it.
+			const activePendingPaths = new Set<string>();
+			const pendingDeletions: string[] = [];
+			// Paths resolved with content matching remote — already in sync, no push needed.
+			const resolvedNoChangePaths = new Set<string>();
+
+			if (this.fit.pendingClashes.length > 0) {
+				fitLogger.log('.. ⏳ [Phase0] Checking pending clashes', { count: this.fit.pendingClashes.length, paths: this.fit.pendingClashes });
+				const pathsToCheck = [
+					...this.fit.pendingClashes.map(p => `_fit/${p}`),
+					...this.fit.pendingClashes,
+				];
+				// All paths here are tracked (non-hidden, non-protected), so vault index would
+				// suffice for existence checks. collectFilesystemState uses adapter.stat, which
+				// is fine given the small count; if this becomes a bottleneck, check
+				// getAbstractFileByPath first and fall back to adapter.stat only on null.
+				const { existenceMap: pendingExistenceMap } = await this.collectFilesystemState(pathsToCheck);
+				const stillPending: string[] = [];
+				const fitCopiesToDelete: string[] = [];
+
+				for (const path of this.fit.pendingClashes) {
+					const fitState = pendingExistenceMap.get(`_fit/${path}`);
+					const localState = pendingExistenceMap.get(path);
+
+					if (fitState === undefined || localState === undefined) {
+						// Stat failed — keep pending conservatively
+						activePendingPaths.add(path);
+						stillPending.push(path);
+						continue;
+					}
+
+					const fitExists = fitState !== 'nonexistent';
+					const localExists = localState !== 'nonexistent';
+
+					if (!fitExists) {
+						// _fit/ deleted by user — clash is resolved
+						if (!localExists) {
+							// Both gone — push deletion to remote
+							pendingDeletions.push(path);
+						}
+						// If local exists: no baseline → ADDED → pushed in normal detection
+					} else if (!localExists) {
+						// Local deleted but _fit/ remains — treat as deletion, clean up _fit/
+						pendingDeletions.push(path);
+						fitCopiesToDelete.push(`_fit/${path}`);
+					} else {
+						// Both exist — resolved if content matches, still pending otherwise
+						try {
+							const [fitContent, localContent] = await Promise.all([
+								this.fit.localVault.readFileContent(`_fit/${path}`),
+								this.fit.localVault.readFileContent(path),
+							]);
+							const [fitSha, localSha] = await Promise.all([
+								LocalVault.fileSha1(path, fitContent),
+								LocalVault.fileSha1(path, localContent),
+							]);
+
+							if (fitSha === localSha) {
+								// Resolved — queue _fit/ copy for deletion; path re-enters normal detection
+								fitCopiesToDelete.push(`_fit/${path}`);
+								// Check if local content already matches remote — if so, no push needed.
+								// readFileContent returns cached content from readFromSource (no extra network call).
+								try {
+									const remoteContent = await this.fit.remoteVault.readFileContent(path);
+									if (localContent.toBase64() === remoteContent.toBase64()) {
+										resolvedNoChangePaths.add(path);
+									}
+								} catch {
+									// Can't read remote — safe to push (may cause harmless re-push)
+								}
+							} else {
+								activePendingPaths.add(path);
+								stillPending.push(path);
+							}
+						} catch {
+							// Can't read — keep pending conservatively
+							activePendingPaths.add(path);
+							stillPending.push(path);
+						}
+					}
+				}
+
+				if (fitCopiesToDelete.length > 0) {
+					await this.fit.localVault.applyChanges([], fitCopiesToDelete);
+				}
+
+				const originalCount = this.fit.pendingClashes.length;
+				this.fit.pendingClashes = stillPending;
+
+				fitLogger.log('.. ✅ [Phase0] Pending clash check complete', {
+					resolved: originalCount - stillPending.length,
+					stillPending: stillPending.length,
+					activePending: activePendingPaths.size,
+					pendingDeletions: pendingDeletions.length,
+					resolvedNoChange: resolvedNoChangePaths.size,
+				});
+			}
+
+			const filteredLocalChanges = [
+				...localChanges
+					.filter(c => this.fit.shouldSyncPath(c.path))
+					.filter(c => !activePendingPaths.has(c.path))
+					.filter(c => !resolvedNoChangePaths.has(c.path)),
+				...pendingDeletions.map(path => ({ path, type: 'REMOVED' as const })),
+			];
 
 			// Log detected changes for diagnostics
 			const localCount = filteredLocalChanges.length;
@@ -713,12 +835,22 @@ export class FitSync implements IFitSync {
 			// Phase 2: Compare & Resolve - determine safe vs clashed changes
 			const localScanPaths = new Set(Object.keys(currentLocalState));
 			const remoteScanPaths = new Set(Object.keys(remoteTreeSha));
-			const { safeLocal, safeRemote, clashes, existenceMap } = await this.compareAndResolveChanges(
+			const { safeLocal, safeRemote: initialSafeRemote, clashes: initialClashes, existenceMap } = await this.compareAndResolveChanges(
 				filteredLocalChanges,
 				remoteChanges,
 				localScanPaths,
 				remoteScanPaths
 			);
+
+			// Reclassify safeRemote items for active pending paths — new remote changes must
+			// go to _fit/ only, not overwrite the local file whose status is unresolved.
+			const safeRemote = initialSafeRemote.filter(c => !activePendingPaths.has(c.path));
+			const clashes = [
+				...initialClashes,
+				...initialSafeRemote
+					.filter(c => activePendingPaths.has(c.path))
+					.map(c => ({ path: c.path, localState: 'pending' as const, remoteOp: c.type })),
+			];
 
 			// Phase 3: Execute - push, pull, persist (atomic operation)
 			const { localOps, remoteOps, conflicts, newlySkippedPaths, skippedWarning, rateLimitedPaths } = await this.executeSync(

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -437,6 +437,7 @@ export class FitSync implements IFitSync {
 		safeLocal: FileChange[],
 		safeRemote: FileChange[],
 		clashes: FileClash[],
+		pendingReminderPaths: Set<string>,
 		existenceMap: Map<string, "file" | "folder" | "nonexistent">,
 		syncNotice: FitNotice
 	): Promise<SyncExecutionResult> {
@@ -477,10 +478,17 @@ export class FitSync implements IFitSync {
 		);
 
 		// Phase 3: Execute sync operations
-		// Prepare clash files for writing to _fit/ directory
+		// Prepare clash files for writing to _fit/ directory.
+		// readFileContent uses content cached by readFromSource() — no extra API calls.
+		// Reminder-only paths (pendingReminderPaths) are excluded: remote content is unchanged
+		// so there is nothing new to write. They remain in clashes for state-management purposes
+		// (the loop below still deletes them from newLocalState to prevent leaking into localShas).
+		// Deletion of a pending path arrives with remoteOp === 'REMOVED' via the reclassification
+		// path above, so the remoteOp !== 'REMOVED' filter here can never incorrectly skip it.
 		const clashFiles = await Promise.all(
 			clashes
-				.filter(c => c.remoteOp !== 'REMOVED') // Skip deletions
+				.filter(c => c.remoteOp !== 'REMOVED')
+				.filter(c => !pendingReminderPaths.has(c.path))
 				.map(async (clash) => {
 					const content = await this.fit.remoteVault.readFileContent(clash.path);
 					return this.prepareConflictFile(clash.path, content.toBase64());
@@ -848,21 +856,28 @@ export class FitSync implements IFitSync {
 				initialSafeRemote.filter(c => activePendingPaths.has(c.path)).map(c => c.path)
 			);
 			const safeRemote = initialSafeRemote.filter(c => !activePendingPaths.has(c.path));
+			// Reminder-only pending clashes: still unresolved from a prior sync, no new remote change
+			// this cycle. Included in clashes for state-management purposes (prevents the path from
+			// leaking back into localShas via currentLocalState), but passed separately so executeSync
+			// can skip the download+write step — remote content is unchanged, nothing new to write.
+			// Note: remote deletion of a pending path arrives via remoteChanges as REMOVED and is
+			// reclassified above with the real remoteOp, so it never ends up here as a reminder.
+			const pendingReminderPaths = new Set(
+				[...activePendingPaths]
+					.filter(p => !reclassifiedFromSafeRemote.has(p))
+					.filter(p => !initialClashes.some(c => c.path === p))
+			);
 			const clashes = [
 				...initialClashes,
 				...initialSafeRemote
 					.filter(c => activePendingPaths.has(c.path))
 					.map(c => ({ path: c.path, localState: 'pending' as const, remoteOp: c.type })),
-				// Surface still-pending paths with no current remote change so the user is
-				// reminded on every sync that these need resolution (not just the first sync).
-				...[...activePendingPaths]
-					.filter(p => !reclassifiedFromSafeRemote.has(p))
-					.filter(p => !initialClashes.some(c => c.path === p))
+				...[...pendingReminderPaths]
 					.map(p => ({ path: p, localState: 'pending' as const, remoteOp: 'MODIFIED' as const })),
 			];
 
 			// Phase 3: Execute - push, pull, persist (atomic operation)
-			const { localOps, remoteOps, conflicts, newlySkippedPaths, skippedWarning, rateLimitedPaths } = await this.executeSync(
+			const { localOps, remoteOps, conflicts: executedConflicts, newlySkippedPaths, skippedWarning, rateLimitedPaths } = await this.executeSync(
 				currentLocalState,
 				{
 					remoteChanges,
@@ -872,9 +887,12 @@ export class FitSync implements IFitSync {
 				safeLocal,
 				safeRemote,
 				clashes,
+				pendingReminderPaths,
 				existenceMap,
 				syncNotice
 			);
+
+			const conflicts = executedConflicts;
 
 			// Log conflicts if any (these are real unresolved conflicts, not temporary clashes)
 			if (conflicts.length > 0) {
@@ -927,9 +945,9 @@ export class FitSync implements IFitSync {
 			// Set success message (only when not already replaced by the unpushed-files reminder
 			// or the partial-sync notice above)
 			if (rateLimitedPaths.length === 0 && (remainingUnpushed.length === 0 || isAutoSync || newlySkippedPaths.length > 0)) {
-				if (conflicts.length === 0) {
+				if (executedConflicts.length === 0) {
 					syncNotice.setMessage(`Sync successful`);
-				} else if (conflicts.some(f => f.remoteOp !== "REMOVED")) {
+				} else if (executedConflicts.some(f => f.remoteOp !== "REMOVED")) {
 					syncNotice.setMessage(`Synced with remote, unresolved conflicts written to _fit`);
 				} else {
 					syncNotice.setMessage(`Synced with remote, ignored remote deletion of locally changed files`);

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -844,12 +844,21 @@ export class FitSync implements IFitSync {
 
 			// Reclassify safeRemote items for active pending paths — new remote changes must
 			// go to _fit/ only, not overwrite the local file whose status is unresolved.
+			const reclassifiedFromSafeRemote = new Set(
+				initialSafeRemote.filter(c => activePendingPaths.has(c.path)).map(c => c.path)
+			);
 			const safeRemote = initialSafeRemote.filter(c => !activePendingPaths.has(c.path));
 			const clashes = [
 				...initialClashes,
 				...initialSafeRemote
 					.filter(c => activePendingPaths.has(c.path))
 					.map(c => ({ path: c.path, localState: 'pending' as const, remoteOp: c.type })),
+				// Surface still-pending paths with no current remote change so the user is
+				// reminded on every sync that these need resolution (not just the first sync).
+				...[...activePendingPaths]
+					.filter(p => !reclassifiedFromSafeRemote.has(p))
+					.filter(p => !initialClashes.some(c => c.path === p))
+					.map(p => ({ path: p, localState: 'pending' as const, remoteOp: 'MODIFIED' as const })),
 			];
 
 			// Phase 3: Execute - push, pull, persist (atomic operation)

--- a/src/util/changeTracking.ts
+++ b/src/util/changeTracking.ts
@@ -34,8 +34,9 @@ export type FileStates = Record<string, BlobSha>;
  * - ChangeOperation: File has a tracked change (ADDED/MODIFIED/REMOVED)
  * - "untracked": File exists but state can't be determined (stat failed, hidden files)
  * - "protected": File is blocked by sync policy (shouldSyncPath returns false)
+ * - "pending": A previous clash for this file is unresolved (_fit/ copy still present)
  */
-export type LocalClashState = ChangeOperation | "untracked" | "protected";
+export type LocalClashState = ChangeOperation | "untracked" | "protected" | "pending";
 
 /** Represents a clash between local and remote changes to the same file */
 export type FileClash = {

--- a/src/util/contentEncoding.ts
+++ b/src/util/contentEncoding.ts
@@ -167,6 +167,13 @@ export class FileContent {
 		return Content.decodeFromBase64(content);
 	}
 
+	equals(other: FileContent): boolean {
+		if (this.content.encoding === other.content.encoding) {
+			return this.content.content === other.content.content;
+		}
+		return this.toBase64() === other.toBase64();
+	}
+
 	toRaw(): FileContentType {
 		return this.content;
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,17 +90,22 @@ export function showUnappliedConflicts(clashedFiles: Array<FileClash>): void {
 	footer.setText("Note:");
 	footer.style.fontWeight = "bold";
 	conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
-		.setText("Remote changes in _fit");
+		.setText("Remote version saved to _fit/ — file held pending until resolved");
 	conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
-		.setText("_fit folder is overwritten on conflict, copy needed changes outside _fit.");
+		.setText("Resolve: delete _fit/ copy (keep local), or edit either file until they match");
 
 	// Add explanatory notes for special local states
+	const hasPending = clashedFiles.some(c => c.localState === 'pending');
 	const hasProtected = clashedFiles.some(c => c.localState === 'protected');
 	const hasUntracked = clashedFiles.some(c => c.localState === 'untracked');
 
+	if (hasPending) {
+		conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
+			.setText("Pending: unresolved from a prior sync — will keep appearing and local changes won't sync until resolved");
+	}
 	if (hasProtected) {
 		conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
-			.setText("Protected: Paths excluded from sync by policy (.obsidian/, _fit/)");
+			.setText("Protected: path excluded from sync (.obsidian/, _fit/) — saved to _fit/ for transparency, not tracked as pending");
 	}
 	if (hasUntracked) {
 		conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,8 @@ export function showUnappliedConflicts(clashedFiles: Array<FileClash>): void {
 		MODIFIED: "change",
 		REMOVED: "delete",
 		untracked: "untracked",
-		protected: "protected"
+		protected: "protected",
+		pending: "pending"
 	};
 	const remoteStatusMap: Record<ChangeOperation, string> = {
 		ADDED:  "create",


### PR DESCRIPTION
Fixes #283.

---

<!-- kody-pr-summary:start -->
This pull request introduces a robust "pending clash" resolution mechanism to prevent data loss and improve conflict handling.

Key changes include:

1.  **Persistent Pending Clash State**: A new `pendingClashes` list is added to `LocalStores` to persistently track files that have an unresolved `_fit/` copy. This ensures that conflicts are remembered across syncs and plugin reloads.
2.  **New Sync Phase 0 (Pending Clash Resolution)**: A pre-processing phase is introduced at the beginning of each sync. For every path in `pendingClashes`:
    *   It checks if the user has resolved the conflict (e.g., by deleting the `_fit/` copy, or by editing either the local file or the `_fit/` copy until their content matches).
    *   If resolved, the path re-enters normal change detection, allowing local changes to be pushed or deletions to be synced.
    *   If still pending, the path is "shielded":
        *   It's excluded from local pushes (local changes are considered unconfirmed).
        *   It's protected from remote overwrites (any new remote versions are also written to `_fit/`, not the main local file).
        *   The file's baseline SHA is removed from `localShas` to prevent silent overwrites.
3.  **Enhanced Conflict Handling**:
    *   When a new clash occurs, the remote version is written to `_fit/`, the path is added to `pendingClashes`, and its `localShas` entry is removed.
    *   The `_fit/` directory is explicitly defined as out-of-band storage, never part of the synced vault.
    *   The `docs/sync-logic.md` is significantly updated to detail the "pending" concept, its state machine, and the rationale behind SHA-based comparison for conflict detection.
4.  **Improved User Guidance**: Conflict notifications (`showUnappliedConflicts`) are updated to reflect the "pending" state and provide clearer instructions on how to resolve conflicts.
5.  **Robustness**: Extensive new tests (`fitSync.realFit.test.ts`) cover various scenarios of the pending clash lifecycle, including remote changes while pending, user resolution, and persistence across multiple syncs and plugin reloads, ensuring data integrity.

This change addresses the risk of data loss by ensuring that files with unresolved conflicts are explicitly managed and protected until the user takes action, rather than being silently overwritten or pushed.
<!-- kody-pr-summary:end -->