### PR TITLE
fix: eliminate TOCTOU race in saveLocalStore/saveSettings

### DIFF
--- a/src/fitPlugin.test.ts
+++ b/src/fitPlugin.test.ts
@@ -79,17 +79,62 @@ describe('FitPlugin persistence lifecycle', () => {
 			);
 		});
 
-		it('merges partial update with existing persisted data', async () => {
+		it('merges partial update into existing in-memory store', async () => {
 			const plugin = makePlugin();
-			mockLoad(plugin, { localShas: { 'existing.md': sha('old') }, pendingClashes: [] });
+			plugin.localStore = { localShas: { 'existing.md': sha('old') }, pendingClashes: [], lastFetchedCommitSha: null, lastFetchedRemoteShas: {}, lastFetchedRemoteSha: undefined, unpushedFiles: {} };
 
 			await (plugin.fitSync as unknown as StubFitSync).simulateSyncSave({ pendingClashes: ['z.md'] });
 
 			expect(plugin.saveData).toHaveBeenCalledWith(
 				expect.objectContaining({
+					localShas: { 'existing.md': 'old' },
 					pendingClashes: ['z.md'],
 				})
 			);
+		});
+	});
+
+	describe('saveLocalStore / saveSettings write merged in-memory state', () => {
+		it('saveLocalStore includes settings fields so concurrent saveSettings cannot lose them', async () => {
+			const plugin = makePlugin();
+			plugin.settings = { pat: 'token', owner: 'alice', repo: 'r', branch: 'main' } as any;
+			plugin.localStore = { localShas: { 'a.md': sha('s1') }, pendingClashes: [], lastFetchedCommitSha: null, lastFetchedRemoteShas: {}, lastFetchedRemoteSha: undefined, unpushedFiles: {} };
+
+			await plugin.saveLocalStore();
+
+			expect(plugin.saveData).toHaveBeenCalledWith(
+				expect.objectContaining({ pat: 'token', localShas: { 'a.md': 's1' } })
+			);
+		});
+
+		it('saveSettings includes localStore fields so concurrent saveLocalStore cannot lose them', async () => {
+			const plugin = makePlugin();
+			plugin.fit = { loadLocalStore: vi.fn(), loadSettings: vi.fn() } as any;
+			plugin.settings = { pat: 'token', owner: 'alice', repo: 'r', branch: 'main', checkEveryXMinutes: 5 } as any;
+			plugin.localStore = { localShas: {}, pendingClashes: ['x.md'], lastFetchedCommitSha: null, lastFetchedRemoteShas: {}, lastFetchedRemoteSha: undefined, unpushedFiles: {} };
+			plugin.startOrUpdateAutoSyncInterval = vi.fn() as any;
+
+			await plugin.saveSettings();
+
+			expect(plugin.saveData).toHaveBeenCalledWith(
+				expect.objectContaining({ pat: 'token', pendingClashes: ['x.md'] })
+			);
+		});
+
+		it('concurrent saveLocalStore + saveSettings both land in the final persisted state', async () => {
+			const plugin = makePlugin();
+			plugin.fit = { loadLocalStore: vi.fn(), loadSettings: vi.fn() } as any;
+			plugin.settings = { pat: 'token' } as any;
+			plugin.localStore = { localShas: {}, pendingClashes: ['x.md'], lastFetchedCommitSha: null, lastFetchedRemoteShas: {}, lastFetchedRemoteSha: undefined, unpushedFiles: {} };
+			plugin.startOrUpdateAutoSyncInterval = vi.fn() as any;
+
+			// Fire both without awaiting — simulates concurrent execution
+			await Promise.all([plugin.saveLocalStore(), plugin.saveSettings()]);
+
+			// Both calls write full merged state, so both contain both sides
+			for (const call of (plugin.saveData as Mock).mock.calls) {
+				expect(call[0]).toMatchObject({ pat: 'token', pendingClashes: ['x.md'] });
+			}
 		});
 	});
 

--- a/src/fitPlugin.ts
+++ b/src/fitPlugin.ts
@@ -5,7 +5,7 @@ import FitSettingTab from '@/fitSettingTab';
 import { FitSync } from '@/fitSync';
 import { showFileChanges, showUnappliedConflicts } from '@/utils';
 import { fitLogger } from '@/logger';
-import { LocalStores, DEFAULT_LOCAL_STORE, parseLocalStore } from '@/localStores';
+import { LocalStores, parseLocalStore } from '@/localStores';
 import { handleCriticalError } from '@/util/errorHandling';
 import { GitHubConnection } from '@/remotes/githubConnection';
 import * as Encryption from "@/encryption";
@@ -102,7 +102,6 @@ export default class FitPlugin extends Plugin {
 
 	// use of arrow functions to ensure this refers to the FitPlugin class
 	saveLocalStoreCallback = async (localStore: Partial<LocalStores>): Promise<void> => {
-		await this.loadLocalStore();
 		this.localStore = {...this.localStore, ...localStore};
 		await this.saveLocalStore();
 	};
@@ -474,15 +473,13 @@ export default class FitPlugin extends Plugin {
 
 	// allow saving of local stores property, passed in properties will override existing stored value
 	async saveLocalStore() {
-		const data = Object.assign({}, DEFAULT_LOCAL_STORE, await this.loadData());
-		await this.saveData({...data, ...this.localStore});
+		await this.saveData({...this.settings, ...this.localStore});
 		// sync local store to Fit class as well upon saving
 		this.fit.loadLocalStore(this.localStore);
 	}
 
 	async saveSettings() {
-		const data = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-		await this.saveData({...data, ...this.settings});
+		await this.saveData({...this.settings, ...this.localStore});
 		// update auto sync interval with new setting
 		this.startOrUpdateAutoSyncInterval();
 		// sync settings to Fit class as well upon saving

--- a/src/localStores.ts
+++ b/src/localStores.ts
@@ -31,15 +31,6 @@ export interface LocalStores {
 	pendingClashes?: string[]
 }
 
-export const DEFAULT_LOCAL_STORE: LocalStores = {
-	localShas: {},
-	lastFetchedCommitSha: null,
-	lastFetchedRemoteShas: {},
-	unpushedFiles: {},
-	pendingClashes: []
-	// Note: no localSha — absent means no legacy data to migrate
-};
-
 /**
  * Deserialize raw stored data into a typed LocalStores object.
  * Pure function — no Obsidian dependency — so it can be unit-tested directly.


### PR DESCRIPTION
Simplifies round trip `loadData`/`saveData` calls in FitPlugin's saveLocalStore and saveSettings to use in-memory `this.settings` instead of the extra loadData. This is simpler and avoids reading stale data from disk in the case of multiple racing saves.

Suggested by Kody [in #286](https://github.com/joshuakto/fit/pull/286#discussion_r3329568576).

---

<!-- kody-pr-summary:start -->
This pull request addresses and eliminates a Time-of-Check-to-Time-of-Use (TOCTOU) race condition that could lead to data loss when `saveLocalStore` and `saveSettings` were called concurrently.

Previously, both `saveLocalStore` and `saveSettings` would first load the entire plugin data from disk, then merge their respective in-memory state (`this.localStore` or `this.settings`), and finally save the combined data back to disk. This approach created a race condition where concurrent calls could load the same initial state, apply their updates, and then the last one to write would overwrite the changes made by the other, leading to lost settings or local store data.

The fix implements the following changes:
- Both `saveLocalStore` and `saveSettings` now directly save a merged object containing the *current in-memory* `this.settings` and `this.localStore`. They no longer reload data from disk before saving.
- This ensures that any write operation always includes the most up-to-date values for both settings and local store, preventing one from clobbering the other's changes in concurrent scenarios.
- The `saveLocalStoreCallback` also no longer reloads the local store from disk, instead applying updates directly to the in-memory `this.localStore`.
- The `DEFAULT_LOCAL_STORE` constant is no longer used in the save process, as the in-memory state is now considered the authoritative source for persistence.

These changes improve the reliability of data persistence by ensuring that all plugin state is consistently saved, even when multiple parts of the plugin attempt to update and save data concurrently.
<!-- kody-pr-summary:end -->