### PR TITLE
include error stacks in logging

### DIFF
--- a/src/localVault.ts
+++ b/src/localVault.ts
@@ -191,7 +191,6 @@ export class LocalVault implements IVault<"local"> {
 				'filesystem',
 				`Failed to read ${failedPaths.length} file(s) from local vault: ${failedPaths.map(f => f.path).join(', ')}`,
 				{
-					originalError: failedPaths[0].error,
 					failedPaths: failedPaths.map(f => f.path),
 					errors: failedPaths.map(f => ({ path: f.path, error: f.error }))
 				}

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -432,6 +432,7 @@ describe('Logger', () => {
 			const content = adapter.content!;
 			expect(content).toContain('"name": "Error"');
 			expect(content).toContain('"message": "test error message"');
+			expect(content).toContain('"stack"');
 			expect(content).toContain('"status": 422');
 			expect(content).toContain('"method": "POST"');
 			expect(content).toContain('"response"');

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -79,6 +79,14 @@ function sanitizeForLogging(data: unknown, depth = 0): unknown {
 	if (data instanceof Error) {
 		result.name = data.name;
 		result.message = sanitizeForLogging(data.message, depth + 1);
+		if (data.stack) {
+			// Cap at 15 lines so Obsidian/Promise internals don't drown out app frames
+			const lines = data.stack.split('\n');
+			const MAX_STACK_LINES = 15;
+			result.stack = lines.length > MAX_STACK_LINES
+				? lines.slice(0, MAX_STACK_LINES).join('\n') + `\n    ... (${lines.length - MAX_STACK_LINES} more frames)`
+				: data.stack;
+		}
 	}
 
 	for (const [key, value] of Object.entries(data as Record<string, unknown>)) {


### PR DESCRIPTION
Includes error stack metadata in logging (truncated to first 15 lines if long), and removes `originalError` field in one error case that was redundant with `errors[0]` to avoid spamming stack/metadata twice.

sanitizeForLogging was already including enumerable fields using `Object.entries` but `stack` is not enumerable and is pretty important to include.

Why: helps make certain that debug.log from a repro of an issue like #281 will include stack information to actually troubleshoot.

---

<!-- kody-pr-summary:start -->
This pull request enhances error logging by including stack traces for `Error` objects.

Key changes include:
*   **Error Stack Trace Inclusion**: When an `Error` object is logged, its stack trace is now extracted and included in the log output.
*   **Stack Trace Truncation**: To prevent excessively long log entries and improve readability, stack traces are truncated to a maximum of 15 lines. If a stack trace exceeds this limit, a message indicating the presence of additional frames is appended.
*   **Test Coverage**: A new test assertion has been added to verify that error stack traces are correctly included in the log output.
*   **Log Context Refinement**: A redundant `originalError` property has been removed from the log context when multiple files fail to read in `LocalVault`, as the individual errors (including their details) are already provided in the `errors` array.
<!-- kody-pr-summary:end -->