### PR TITLE
ci: scripts for creating release + newline fix for version-bump.mjs

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,30 @@
+name: Attach Release Assets
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+
+      - run: npm ci --legacy-peer-deps
+
+      - run: npm run build
+
+      - name: Upload assets to release
+        run: gh release upload "${{ github.event.release.tag_name }}" main.js manifest.json styles.css --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -127,49 +127,36 @@ Please try to avoid breaking functionality (on desktop or mobile), and test majo
 - Version numbers never have a `v` prefix (`1.5.0`, not `v1.5.0`)
 - `manifest.json` and `package.json` versions must always match
 - Version bumps must be in **dedicated commits**, never mixed with feature or bug-fix changes
-- The `main` branch manifest always shows the current **stable** version; beta versions never appear there
+- The `main` branch manifest always shows the current **stable** version; pre-release versions never appear there
 
-### Stable Release
+### Using the release script (maintainers)
 
-Beta testing is recommended before a stable release. When ready:
+`scripts/release.sh` automates the full release flow for all channels:
 
-1. **Build artifacts**: `npm run build` produces `main.js`
+```shell
+./scripts/release.sh alpha    # e.g. 1.5.0 → 1.6.0-alpha.1
+./scripts/release.sh beta     # e.g. 1.6.0-alpha.3 → 1.6.0-beta.1
+./scripts/release.sh stable   # e.g. 1.6.0-beta.2 → 1.6.0
 
-2. **Create the GitHub Release** via the GitHub UI:
-   - Tag: `X.Y.Z` — no `v` prefix; mark as a full release (not pre-release)
-   - Upload `manifest.json`, `main.js`, `styles.css` as release assets
-   - The GitHub Release must exist **before** the version bump PR is merged (automated PR checks enforce this)
+./scripts/release.sh alpha 1.6.0-alpha.5   # explicit version override
+```
 
-3. **Open a PR to `main`** containing only these changes:
-   - `manifest.json`: bump `version` to `X.Y.Z`
-   - `package.json`: bump `version` to `X.Y.Z`
-   - `versions.json`: add `"X.Y.Z": "<minAppVersion>"`
-   - Commit message: `Bump version to X.Y.Z`
+The script runs pre-flight checks, bumps version files, commits and tags, pushes, and creates a draft GitHub release. The CI workflow `release-assets.yml` then builds and attaches `main.js`, `styles.css`, and `manifest.json` automatically.
 
-4. **Merge the PR** — automated checks verify the GitHub Release exists
+After the script completes:
+1. **Stable only:** apply the pending README changes listed in [Pending README changes for next stable release](#pending-readme-changes-for-next-stable-release) below, then commit
+2. Review and curate the auto-generated release notes on GitHub (comms step)
+3. Publish the draft release
+4. For stable: ask the head maintainer to post in [Announcements](https://github.com/joshuakto/fit/discussions/categories/announcements)
+5. For alpha/beta: post in [Beta Testing](https://github.com/joshuakto/fit/discussions/categories/beta-testing)
 
-### Beta Release
+### Version scheme
 
-Beta releases are for early testing via [BRAT](https://github.com/TfTHacker/obsidian42-brat). They live only on the `beta` branch and are invisible to regular plugin users (never reflected in `main`'s manifest).
+Pre-releases use `MAJOR.MINOR.PATCH-CHANNEL.N` (e.g. `1.6.0-alpha.1`, `1.6.0-beta.2`). The channel label (`alpha`/`beta`) appears in the version string but BRAT does not distinguish between them — both are delivered to anyone who enabled pre-release updates. Use `alpha` for incomplete milestone work and `beta` for feature-complete pre-releases approaching stable.
 
-1. **Merge `main` into `beta`** (using jj):
-   ```shell
-   jj new beta main -m "Merge branch 'main' into beta"
-   ```
+### How pre-releases reach BRAT users
 
-2. **Bump the beta version** directly on the `beta` branch (not via PR to main):
-   - `manifest.json`: set `version` to `X.Y.Z-beta.N`, update `minAppVersion` if needed
-   - `package.json`: set `version` to `X.Y.Z-beta.N`
-   - `versions.json`: add `"X.Y.Z-beta.N": "<minAppVersion>"`
-   - Commit message: `Bump version to X.Y.Z-beta.N (minAppVersion: A.B.C)`
-
-3. **Push `beta`** to GitHub
-
-4. **Create a GitHub Pre-release** via the GitHub UI:
-   - Tag: `X.Y.Z-beta.N` — no `v` prefix (created here via the GH UI); mark as pre-release
-   - Build and upload the same three artifacts as a stable release
-
-BRAT users who point to `joshuakto/fit` receive the latest pre-release automatically.
+BRAT detects pre-releases by the `prerelease` flag on GitHub Releases (not by the version string). Pre-release version bumps are **not pushed to `main`** — the version bump commit lives only in the release tag's ancestry, so `main`'s manifest always reflects the last stable version.
 
 ### Anti-Patterns
 
@@ -182,6 +169,18 @@ BRAT users who point to `joshuakto/fit` receive the latest pre-release automatic
 | `manifest.json` and `package.json` versions out of sync | Confuses tooling and reviewers; automated checks will reject it |
 
 See [Obsidian Hub release guide](https://publish.obsidian.md/hub/04+-+Guides%2C+Workflows%2C+%26+Courses/Guides/How+to+release+a+new+version+of+your+plugin) for general Obsidian plugin release context.
+
+---
+
+## Pending README changes for next stable release
+
+Apply these manually when cutting stable, then clear the list. Add to this list as you ship features that change what README says.
+
+- **Remove "still in beta" note** (line ~20): delete the `**Note:** This plugin is still in beta...` line.
+- **Remove "Coming soon" section**: the "Explain Sync Status" command shipped in 1.6 — delete the entire `## Coming soon` block (the heading, description, and preview image).
+- **Update `.obsidian/` bullet** (under "NOT synced"): remove the `(selective opt-in coming in 1.6)` qualifier — it shipped.
+- **Convert "Coming in the 1.6 release" callout** to present tense: the hidden-files and selective `.obsidian/` sync features are both live. Rewrite as "New in 1.6:" rather than "Coming in the 1.6 release:".
+- **Retake the settings screenshot** (line ~39): the current screenshot predates 1.5 UI changes. Capture a fresh screenshot of the FIT settings panel and replace the image at that line.
 
 ---
 

--- a/scripts/next-version.mjs
+++ b/scripts/next-version.mjs
@@ -1,0 +1,55 @@
+// Computes the next version for a given release channel.
+// Usage: node scripts/next-version.mjs <alpha|beta|stable> [explicit-version]
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+
+const [channel, explicit, baseVersion] = process.argv.slice(2);
+
+if (explicit) {
+    process.stdout.write(explicit);
+    process.exit(0);
+}
+
+const v = baseVersion || JSON.parse(readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json'), 'utf8'
+)).version;
+const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d+))?$/);
+if (!m) {
+    process.stderr.write(`Cannot parse version: ${v}\n`);
+    process.exit(1);
+}
+
+const [, maj, min, pat, pre, preN] = m;
+const major = +maj, minor = +min, patch = +pat;
+
+if (channel === 'stable') {
+    if (!pre) {
+        process.stderr.write(`Already stable (${v}). Pass an explicit version for a patch release.\n`);
+        process.exit(1);
+    }
+    process.stdout.write(`${major}.${minor}.${patch}`);
+} else if (channel === 'alpha') {
+    if (!pre) {
+        process.stdout.write(`${major}.${minor + 1}.0-alpha.1`);
+    } else if (pre === 'alpha') {
+        process.stdout.write(`${major}.${minor}.${patch}-alpha.${+preN + 1}`);
+    } else {
+        process.stderr.write(`Cannot regress from ${pre} to alpha. Pass an explicit version.\n`);
+        process.exit(1);
+    }
+} else if (channel === 'beta') {
+    if (!pre) {
+        process.stdout.write(`${major}.${minor + 1}.0-beta.1`);
+    } else if (pre === 'alpha') {
+        process.stdout.write(`${major}.${minor}.${patch}-beta.1`);
+    } else if (pre === 'beta') {
+        process.stdout.write(`${major}.${minor}.${patch}-beta.${+preN + 1}`);
+    } else {
+        process.stderr.write(`Cannot regress from ${pre} to beta. Pass an explicit version.\n`);
+        process.exit(1);
+    }
+} else {
+    process.stderr.write(`Unknown channel: ${channel}\n`);
+    process.exit(1);
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+# Release script for FIT plugin.
+#
+# Usage:
+#   ./scripts/release.sh <alpha|beta|stable> [VERSION] [REF]
+#
+# Channels:
+#   alpha   pre-release for early testing      (e.g. 1.6.0-alpha.1)
+#   beta    pre-release for broader testing     (e.g. 1.6.0-beta.1)
+#   stable  full release                        (e.g. 1.6.0)
+#
+# VERSION: semver string, or '-' to auto-compute (default: auto-compute)
+# REF: git ref to promote — branch, tag, or commit (default: origin/main)
+#   Use '-' for VERSION to pass REF without pinning the version:
+#   ./scripts/release.sh alpha - my-feature-branch
+#
+# Patch releases (e.g. 1.5.1):
+#   TODO: auto-version does not handle patch releases — it always targets the
+#         next minor. Pass VERSION explicitly: ./scripts/release.sh stable 1.5.1
+#
+# What this script does:
+#   1. Pre-flight: typecheck, lint, unit tests
+#   2. Compute or validate VERSION
+#   3. Fetch REF; apply version bump to its files in a temp dir (no working copy changes)
+#   4. Create a git commit object from that tree; tag it
+#   5. For stable: also push the commit to main
+#   6. Create draft GitHub release (prerelease flag for alpha/beta)
+#   7. CI (release-assets.yml) builds from the tag and attaches main.js, styles.css, manifest.json
+#   8. Print comms next steps
+
+set -e
+
+CHANNEL="$1"
+VERSION_ARG="$2"
+REF_ARG="$3"
+
+case "$CHANNEL" in
+    alpha|beta|stable) ;;
+    *)
+        printf 'Usage: %s <alpha|beta|stable> [VERSION] [REF]\n' "$0" >&2
+        exit 1
+        ;;
+esac
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+printf '==> Pre-flight: typecheck + lint + tests\n'
+npm run typecheck
+npm run lint
+npm test
+
+# ── Resolve base ref ──────────────────────────────────────────────────────────
+# Strip '-' placeholder; default to origin/main.
+if [ -z "$REF_ARG" ] || [ "$REF_ARG" = "-" ]; then
+    BASE_REF="origin/main"
+elif printf '%s' "$REF_ARG" | grep -qv '/'; then
+    # Bare branch name — qualify with origin/ to avoid local/remote ambiguity
+    BASE_REF="origin/$REF_ARG"
+else
+    BASE_REF="$REF_ARG"
+fi
+
+# Strip '-' placeholder from VERSION_ARG so next-version.mjs sees empty string.
+if [ "$VERSION_ARG" = "-" ]; then
+    VERSION_ARG=""
+fi
+
+# ── Version ───────────────────────────────────────────────────────────────────
+# Fetch now so BASE_REF resolves and we can read its current version.
+git fetch origin main
+BASE_VERSION=$(git show "$BASE_REF":package.json | node -p \
+    "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+VERSION=$(node scripts/next-version.mjs "$CHANNEL" "$VERSION_ARG" "$BASE_VERSION")
+case "$VERSION" in
+    [0-9]*.[0-9]*.[0-9]*) ;;
+    *) printf 'Error: computed version %s does not look like semver.\n' "$VERSION" >&2; exit 1 ;;
+esac
+printf '==> Channel: %s  Version: %s\n' "$CHANNEL" "$VERSION"
+
+if gh release view "$VERSION" > /dev/null 2>&1; then
+    printf 'Error: release %s already exists.\n' "$VERSION" >&2
+    exit 1
+fi
+
+# ── Build release commit from REF ─────────────────────────────────────────────
+# Apply version bump to files extracted from BASE_REF in a temp dir.
+# The working copy is never touched; the script can run from any branch.
+printf '==> Applying version bump to %s...\n' "$BASE_REF"
+PARENT=$(git rev-parse "$BASE_REF")
+REPOROOT=$(git rev-parse --show-toplevel)
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git show "$PARENT":manifest.json  > "$TMPDIR/manifest.json"
+git show "$PARENT":versions.json  > "$TMPDIR/versions.json"
+git show "$PARENT":package.json   > "$TMPDIR/package.json"
+
+# version-bump.mjs reads/writes manifest.json and versions.json relative to CWD
+(cd "$TMPDIR" && npm_package_version="$VERSION" node "$REPOROOT/version-bump.mjs")
+
+# Update package.json version field
+node -e "
+const fs = require('fs'), f = '$TMPDIR/package.json';
+const p = JSON.parse(fs.readFileSync(f, 'utf8'));
+p.version = '$VERSION';
+fs.writeFileSync(f, JSON.stringify(p, null, '\t') + '\n');
+"
+
+# Build git blobs for the three changed files
+MANIFEST_BLOB=$(git hash-object -w "$TMPDIR/manifest.json")
+VERSIONS_BLOB=$(git hash-object -w "$TMPDIR/versions.json")
+PKG_BLOB=$(git hash-object -w "$TMPDIR/package.json")
+
+# Build the release tree by taking BASE_REF's root tree entries and swapping
+# in the updated blobs. Uses no index — avoids conflicts with jj's index lock.
+TREE=$(git ls-tree "$PARENT" | while IFS='	' read -r meta path; do
+    mode=$(printf '%s' "$meta" | cut -d' ' -f1)
+    type=$(printf '%s' "$meta" | cut -d' ' -f2)
+    sha=$(printf '%s' "$meta" | cut -d' ' -f3)
+    case "$path" in
+        manifest.json) sha="$MANIFEST_BLOB" ;;
+        versions.json) sha="$VERSIONS_BLOB" ;;
+        package.json)  sha="$PKG_BLOB" ;;
+    esac
+    printf '%s %s %s\t%s\n' "$mode" "$type" "$sha" "$path"
+done | git mktree)
+
+if [ "$CHANNEL" = "stable" ]; then
+    COMMIT=$(git commit-tree "$TREE" -p "$PARENT" -m "release: $VERSION")
+else
+    COMMIT=$(git commit-tree "$TREE" -p "$PARENT" -m "chore: release $VERSION")
+fi
+git tag "$VERSION" "$COMMIT"
+
+# ── Push ──────────────────────────────────────────────────────────────────────
+if [ "$CHANNEL" = "stable" ]; then
+    printf '==> Pushing to main...\n'
+    git push origin "$COMMIT":refs/heads/main
+fi
+printf '==> Pushing tag %s\n' "$VERSION"
+git push origin "$VERSION"
+
+# ── GitHub release ────────────────────────────────────────────────────────────
+printf '==> Creating draft GitHub release...\n'
+
+if [ "$CHANNEL" = "stable" ]; then
+    gh release create "$VERSION" \
+        --draft \
+        --latest \
+        --generate-notes \
+        --title "$VERSION"
+else
+    gh release create "$VERSION" \
+        --draft \
+        --prerelease \
+        --latest=false \
+        --generate-notes \
+        --title "$VERSION"
+fi
+
+RELEASE_URL=$(gh release view "$VERSION" --json url -q .url)
+
+printf '
+==> Draft release created. CI is attaching build artifacts now.
+    Edit release notes and publish when ready:
+    %s
+' "$RELEASE_URL"
+
+# ── Comms next steps ──────────────────────────────────────────────────────────
+if [ "$CHANNEL" = "stable" ]; then
+    printf '
+==> README: Apply pending changes listed in docs/CONTRIBUTING.md
+    (search for "Pending README changes for next stable release")
+    then commit and push before publishing the release.
+
+==> Comms: Ask the head maintainer to post a release announcement:
+    https://github.com/joshuakto/fit/discussions/categories/announcements
+'
+else
+    printf '
+==> Comms: Post an alpha/beta announcement in Beta Testing:
+    https://github.com/joshuakto/fit/discussions/categories/beta-testing
+'
+fi

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -6,9 +6,9 @@ const targetVersion = process.env.npm_package_version;
 let manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
 const { minAppVersion } = manifest;
 manifest.version = targetVersion;
-writeFileSync("manifest.json", JSON.stringify(manifest, null, "\t"));
+writeFileSync("manifest.json", JSON.stringify(manifest, null, "\t") + "\n");
 
 // update versions.json with target version and minAppVersion from manifest.json
 let versions = JSON.parse(readFileSync("versions.json", "utf8"));
 versions[targetVersion] = minAppVersion;
-writeFileSync("versions.json", JSON.stringify(versions, null, "\t"));
+writeFileSync("versions.json", JSON.stringify(versions, null, "\t") + "\n");


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a comprehensive, automated release process for the plugin, significantly streamlining the workflow for maintainers.

Key changes include:
-   **Automated Release Script (`scripts/release.sh`):** A new shell script that orchestrates the entire release flow for `alpha`, `beta`, and `stable` channels. This script performs pre-flight checks (typecheck, lint, tests), calculates the next version, applies version bumps to `manifest.json`, `package.json`, and `versions.json` in a temporary environment, creates a Git commit and tag, pushes changes (to `main` for stable releases), and generates a draft GitHub release.
-   **Next Version Calculation (`scripts/next-version.mjs`):** A new Node.js script to intelligently compute the next semantic version string based on the specified release channel (alpha, beta, stable) and the current version.
-   **Automated Release Asset Attachment (`.github/workflows/release-assets.yml`):** A new GitHub Actions workflow that automatically builds the plugin (`main.js`, `styles.css`, `manifest.json`) and attaches these artifacts to a newly created GitHub release.
-   **Updated Contributing Documentation (`docs/CONTRIBUTING.md`):** The documentation has been updated to reflect the new automated release process, replacing the previous manual steps with instructions on using the `release.sh` script and outlining post-script communication steps. It also clarifies the versioning scheme and how pre-releases reach BRAT users, and adds a checklist for manual README updates required for stable releases.
-   **Newline Fix (`version-bump.mjs`):** Ensures that `manifest.json` and `versions.json` files always end with a newline character when updated.

This change aims to reduce manual effort, minimize errors, and standardize the release procedure across different channels.
<!-- kody-pr-summary:end -->