### PR TITLE
ci: add workflow_dispatch to release-assets for manual re-trigger

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -3,6 +3,11 @@ name: Attach Release Assets
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build and attach assets to'
+        required: true
 
 permissions:
   contents: write
@@ -11,9 +16,18 @@ jobs:
   build-and-attach:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ steps.tag.outputs.value }}
 
       - uses: actions/setup-node@v4
         with:
@@ -25,6 +39,6 @@ jobs:
       - run: npm run build
 
       - name: Upload assets to release
-        run: gh release upload "${{ github.event.release.tag_name }}" main.js manifest.json styles.css --clobber
+        run: gh release upload "${{ steps.tag.outputs.value }}" main.js manifest.json styles.css --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allows manually attaching build artifacts to a release when the published event doesn't fire (GitHub webhook delivery is occasionally unreliable).

---

<!-- kody-pr-summary:start -->
This pull request enhances the `Attach Release Assets` GitHub Actions workflow by enabling manual re-triggering.

Key changes include:
*   **Manual Trigger Support**: The workflow can now be manually dispatched via `workflow_dispatch`, allowing users to trigger it on demand from the GitHub Actions UI.
*   **Release Tag Input**: When manually triggered, the workflow requires a `tag` input, specifying which existing release to build and attach assets to.
*   **Dynamic Tag Resolution**: The workflow now dynamically resolves the target release tag, using either the tag from a `release` event or the manually provided input tag, ensuring the correct code reference is checked out and assets are uploaded to the specified release.

This update provides flexibility to re-upload or rebuild release assets for a specific release without requiring a new release publication.
<!-- kody-pr-summary:end -->