### PR TITLE
fix: silent protected path handling for .obsidian/ files (#67)

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -125,7 +125,9 @@ Each file path has a **baseline** SHA in `localShas` (local) and `lastFetchedRem
 
 ### `_fit/` as scratchpad
 
-The `_fit/` directory is **never part of the synced vault.** It is out-of-band storage where FIT places copies of remote file versions during conflict resolution, so the user can inspect both sides before deciding.
+The `_fit/` directory is **never part of the synced vault.** It is out-of-band storage where FIT places copies of remote file versions for conflict resolution:
+
+1. **Conflict copies:** When both local and remote changed the same tracked file, the remote version is written to `_fit/path` for the user to inspect. The path enters `pendingClashes`.
 
 - `_fit/path` is always a copy of a *remote* version, never the local version.
 - The canonical local version of `path` is always at `path`, not at `_fit/path`.
@@ -264,30 +266,22 @@ Paths not in `obsidianSyncRules` (or in the always-excluded set) remain blocked.
 
 **Behavior for blocked paths:**
 - **⬆️ Local→Remote:** Never pushed
-- **⬇️ Remote→Local:** Saved to 📁 `_fit/` for transparency (e.g., `_fit/.obsidian/app.json`)
-- **📦 SHA Caches:** Excluded from both `localShas` and `lastFetchedRemoteShas`
+- **⬇️ Remote→Local:** Silently tracked — no write, no notice. Remote SHA recorded in `protectedPathShas[path]` for use during opt-in transition (see below).
+- **📦 SHA Caches:** Excluded from `localShas`. Tracked in `protectedPathShas`.
 
-**Why save remote protected paths to `_fit/`?**
-- User can see what exists on remote without risk
-- Prevents silent data loss
-- Consistent behavior: all `!shouldSyncPath` files go to `_fit/`, even `_fit/` files themselves (→ `_fit/_fit/`)
+**Why not treat as a clash?**
+A "conflict" requires two parties with competing claims to the same file. A protected path has no local ownership — remote is authoritative by definition. Showing a conflict notice for every sync where remote has a protected file the current client doesn't track is misleading and noisy.
 
-**Example:**
-```typescript
-// Remote has .obsidian/app.json (not opted in)
-remoteChanges = [
-  { path: ".obsidian/app.json", content: "{\"theme\":\"dark\"}" }
-]
+**protectedPathShas:**
+`LocalStores.protectedPathShas` maps `path → last-seen remote SHA`. Enables the opt-in transition without a junk clash (see below). Entries are cleared when the path becomes opted in.
 
-// Filtering applied in FitSync.applyRemoteChanges():
-if (!this.fit.shouldSyncPath(".obsidian/app.json")) {
-  // Save to _fit/.obsidian/app.json instead of .obsidian/app.json
-  resolvedChanges.push({
-    path: "_fit/.obsidian/app.json",
-    content: "{\"theme\":\"dark\"}"
-  });
-}
-```
+**Opt-in transition:**
+When `obsidianSyncRules` gains a new entry, at the start of the next sync FIT reconciles `protectedPathShas` entries for newly-tracked paths:
+- If local file exists and matches cached remote SHA: set baseline in `localShas` and `lastFetchedRemoteShas` — sync is a no-op.
+- If local file exists but differs: set baseline in `localShas` (local will be pushed); `lastFetchedRemoteShas` not set so remote appears ADDED → remote applied (overwrite).
+- If local file absent: clear `lastFetchedRemoteShas[path]` so remote appears ADDED → downloaded and written to the live path.
+
+In all cases the `protectedPathShas` entry is deleted (path is now tracked normally).
 
 ### 2. Hidden Files (`shouldTrackState`) - Configurable
 
@@ -623,11 +617,12 @@ remoteChanges = [
 
 **Phase 2b**: Batch collects filesystem state for all paths needing verification
 
-**Phase 2c**: Resolves all changes to final safe/clash outcomes:
+**Phase 2c**: Resolves all changes to final safe/clash/protectedRemote outcomes:
 - **Tracked files**: Both sides changed → clash
-- **Untracked files**: Checks filesystem existence, protection rules, and (future: baseline SHA)
-  - Exists locally or protected → clash
-  - Doesn't exist and not protected → safe
+- **Protected paths** (`!shouldSyncPath`): → `protectedRemote` (separate category, not a clash; SHA recorded in `protectedPathShas`, no write)
+- **Untracked files**: Checks filesystem existence and baseline SHA (#169)
+  - Exists locally (and changed from baseline, or no baseline) → clash
+  - Doesn't exist locally → safe
   - Stat failed → conservative clash
 
 **Implementation:**

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -7,7 +7,7 @@
 
 import { LocalStores } from "@/localStores";
 import { FitSettings, ObsidianSyncRules } from "@/fitSettings";
-import { FileChange, FileClash, FileStates, LocalClashState, compareFileStates } from "./util/changeTracking";
+import { FileChange, FileStates, compareFileStates } from "./util/changeTracking";
 import { Vault } from "obsidian";
 import { LocalVault } from "./localVault";
 import { RemoteGitHubVault } from "./remoteGitHubVault";
@@ -51,6 +51,7 @@ export class Fit {
 	lastFetchedRemoteShas: FileStates;      // Canonical remote SHA cache
 	unpushedFiles: FileStates;              // Files skipped due to API size limit (422)
 	pendingClashes: string[];               // Paths with unresolved _fit/ copies
+	protectedPathShas: FileStates;          // Remote SHAs for paths excluded by shouldSyncPath (dedup cache)
 	obsidianSyncRules: ObsidianSyncRules;
 	localVault: LocalVault;                 // Local vault (tracks local file state)
 	remoteVault: RemoteGitHubVault;
@@ -114,6 +115,7 @@ export class Fit {
 		this.lastFetchedRemoteShas = localStore.lastFetchedRemoteShas;
 		this.unpushedFiles = localStore.unpushedFiles ?? {};
 		this.pendingClashes = localStore.pendingClashes ?? [];
+		this.protectedPathShas = localStore.protectedPathShas ?? {};
 
 		const localCount = Object.keys(this.localShas).length;
 		const legacyCount = Object.keys(this.localSha).length;
@@ -290,45 +292,5 @@ export class Fit {
 		}
 
 		return { changes, state, commitSha };
-	}
-
-	getClashedChanges(localChanges: FileChange[], remoteChanges:FileChange[]): Array<FileClash> {
-		const clashes: Array<FileClash> = [];
-
-		// Step 1: Filter out remote changes to untracked/unsynced paths and treat as clashes.
-		const trackedRemoteChanges: FileChange[] = [];
-
-		for (const remoteChange of remoteChanges) {
-			if (this.shouldSyncPath(remoteChange.path) && this.localVault.shouldTrackState(remoteChange.path)) {
-				trackedRemoteChanges.push(remoteChange);
-			} else {
-				// Determine if blocked by sync policy or untracked
-				const localState: LocalClashState = !this.shouldSyncPath(remoteChange.path)
-					? 'protected'
-					: 'untracked';
-				clashes.push({
-					path: remoteChange.path,
-					localState,
-					remoteOp: remoteChange.type
-				});
-			}
-		}
-
-		// Step 2: Find tracked paths that changed on both sides
-		const localChangesByPath = new Map(localChanges.map(lc => [lc.path, lc.type]));
-
-		for (const remoteChange of trackedRemoteChanges) {
-			const localState = localChangesByPath.get(remoteChange.path);
-			if (localState !== undefined) {
-				// Both sides changed this tracked path
-				clashes.push({
-					path: remoteChange.path,
-					localState,
-					remoteOp: remoteChange.type
-				});
-			}
-		}
-
-		return clashes;
 	}
 }

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -304,7 +304,7 @@ describe('FitSync', () => {
 	});
 
 	describe('Protected path handling (📁 shouldSyncPath filtering)', () => {
-		it('should save remote 📁 .obsidian/ files to _fit/ (both protected and hidden)', async () => {
+		it('should silently track remote 📁 .obsidian/ SHA without writing to _fit/', async () => {
 			// === SETUP: Initial synced state ===
 			const fitSync = createFitSync();
 
@@ -320,31 +320,31 @@ describe('FitSync', () => {
 			const mockNotice = createMockNotice();
 			const result = await syncAndHandleResult(fitSync, mockNotice);
 
-			// Verify: Sync succeeded with protected files treated as clashes
-			expect(result).toEqual(expect.objectContaining({ success: true }));
-			// Protected/hidden files are now treated as clashes and get appropriate messaging
-			expect(mockNotice._calls).toContainEqual({
+			// Verify: Sync succeeded, protected files silently ignored (not treated as conflicts)
+			expect(result).toEqual(expect.objectContaining({ success: true, clash: [] }));
+			// Protected paths do not trigger conflict notice
+			expect(mockNotice._calls).not.toContainEqual({
 				method: 'setMessage',
 				args: ['Synced with remote, unresolved conflicts written to _fit']
 			});
 
-			// Verify: .obsidian/ files saved to _fit/ for safety, normal file pulled directly
+			// Verify: Only normal file written locally — no _fit/ writes for protected paths
 			expect(localVault.getAllFilesAsRaw()).toEqual({
-				// .obsidian/ files saved to _fit/ (protected path - never write directly to .obsidian/)
-				'_fit/.obsidian/app.json': '{"theme":"dark"}',
-				'_fit/.obsidian/plugins/plugin1/main.js': 'Plugin code',
-				// Normal file pulled directly
 				'normal.md': 'Normal file'
 			});
 
-			// Verify: LocalStores - .obsidian/ files NOT tracked (filtered by shouldSyncPath)
-			// Protected paths (.obsidian/, _fit/) are excluded from both local and remote caches
+			// Verify: LocalStores - .obsidian/ files NOT tracked in localShas (filtered by shouldSyncPath)
+			// Remote SHAs for protected paths stored in protectedPathShas for opt-in reconciliation
 			expect(localStoreState).toMatchObject({
 				localShas: {
 					'normal.md': expect.any(String)  // Only normal file
 				},
 				lastFetchedRemoteShas: {
 					'normal.md': expect.any(String)  // Only normal file (protected paths filtered)
+				},
+				protectedPathShas: {
+					'.obsidian/app.json': expect.any(String),
+					'.obsidian/plugins/plugin1/main.js': expect.any(String)
 				}
 			});
 		});
@@ -383,39 +383,31 @@ describe('FitSync', () => {
 				{ path: 'remote-normal.md', content: FileContent.fromPlainText('Normal remote file') }
 			], []);
 
-			// === STEP 4: Attempt sync - should pull both files, but save _fit/ to _fit/_fit/ ===
+			// === STEP 4: Attempt sync - should pull remote-normal.md, silently ignore remote _fit/ ===
 			const mockNotice2 = createMockNotice();
 			const result2 = await syncAndHandleResult(fitSync, mockNotice2);
 
-			// Verify: Both files pulled, but _fit/ file saved to _fit/_fit/ (protected path treated as clash)
+			// Verify: Normal file pulled, remote _fit/ file silently ignored (SHA tracked, not written)
 			expect(result2).toEqual({
 				success: true,
 				changeGroups: expect.arrayContaining([
 					{
 						heading: expect.stringContaining('Local file updates'),
 						changes: expect.arrayContaining([
-							expect.objectContaining({ path: '_fit/_fit/remote-conflict.md', type: 'ADDED' }),
 							expect.objectContaining({ path: 'remote-normal.md', type: 'ADDED' })
 						])
 					}
 				]),
-				clash: [{
-					path: '_fit/remote-conflict.md',
-					localState: 'protected',
-					remoteOp: 'ADDED'
-				}]
+				clash: []
 			});
 
-			// Verify: Final local vault state
+			// Verify: Final local vault state — no _fit/_fit/ write for remote _fit/ files
 			expect(localVault.getAllFilesAsRaw()).toEqual({
 				'_fit/conflict.md': 'Remote version saved locally', // Local-only (created in step 1)
 				'_fit/nested/file.md': 'Another conflict',          // Local-only (created in step 1)
-				// Remote _fit/ saved to _fit/_fit/ (protected path)
-				'_fit/_fit/remote-conflict.md': 'Remote _fit file content',
 				'normal.md': 'Normal file content',                 // Synced (created in step 1)
 				'remote-normal.md': 'Normal remote file'            // Pulled from remote (step 4)
 			});
-			// NOT present: '_fit/remote-conflict.md' (would conflict with our conflict resolution area)
 
 			// Verify: LocalStores track different files:
 			// - localShas: Only synced files (excludes _fit/ and other protected paths)
@@ -440,6 +432,34 @@ describe('FitSync', () => {
 			const uniquePaths = new Set(statLog);
 			expect(statLog.length).toBe(uniquePaths.size);
 		});
+		it('should not trigger junk clash when user opts in a previously-protected path', async () => {
+			// Simulate: remote has .obsidian/graph.json, client A synced without opt-in
+			// then user enables sync for that path
+			const fitSync = createFitSync();
+
+			await remoteVault.applyChanges([
+				{ path: '.obsidian/graph.json', content: FileContent.fromPlainText('{"colorGroups":[]}') }
+			], []);
+
+			// First sync without opt-in: caches SHA in protectedPathShas (no _fit/ write)
+			await syncAndHandleResult(fitSync, createMockNotice());
+			expect(localStoreState.protectedPathShas?.['.obsidian/graph.json']).toBeTruthy();
+
+			// User opts in the path
+			fitSync.fit.obsidianSyncRules = { '.obsidian/graph.json': {} };
+
+			// First sync with opt-in: reconciliation should set baseline from protectedPathShas,
+			// no junk clash even though local doesn't have the file yet
+			const result = await syncAndHandleResult(fitSync, createMockNotice());
+
+			// Should succeed with no conflicts — reconciliation handled it
+			expect(result).toMatchObject({ success: true, clash: [] });
+			// protectedPathShas entry should be cleared (path is now tracked)
+			expect(localStoreState.protectedPathShas?.['.obsidian/graph.json']).toBeUndefined();
+			// File should now be in localShas (tracked)
+			expect(localStoreState.localShas?.['.obsidian/graph.json']).toBeTruthy();
+		});
+
 		it('should sync opted-in .obsidian/ file directly (not to _fit/)', async () => {
 			const fitSync = createFitSync();
 			fitSync.fit.obsidianSyncRules = { '.obsidian/appearance.json': {} };
@@ -474,8 +494,8 @@ describe('FitSync', () => {
 			const mockNotice = createMockNotice();
 			await syncAndHandleResult(fitSync, mockNotice);
 
-			// workspace.json saved to _fit/, not synced directly
-			expect(localVault.getAllFilesAsRaw()['_fit/.obsidian/workspace.json']).toBeDefined();
+			// workspace.json silently ignored — no _fit/ write, no direct sync
+			expect(localVault.getAllFilesAsRaw()['_fit/.obsidian/workspace.json']).toBeUndefined();
 			expect(localVault.getAllFilesAsRaw()['.obsidian/workspace.json']).toBeUndefined();
 		});
 

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -460,6 +460,38 @@ describe('FitSync', () => {
 			expect(localStoreState.localShas?.['.obsidian/graph.json']).toBeTruthy();
 		});
 
+		it('should restore pre-reconciliation state when sync fails after opt-in mutation', async () => {
+			// Kody bug: reconciliation mutates protectedPathShas/localShas/lastFetchedRemoteShas before
+			// sync succeeds. If sync then fails, mutations leak into next attempt → missed reconciliation.
+			const fitSync = createFitSync();
+
+			// Remote has a .obsidian/ file that we'll opt in to
+			await remoteVault.applyChanges([
+				{ path: '.obsidian/graph.json', content: FileContent.fromPlainText('{"colorGroups":[]}') }
+			], []);
+
+			// First sync without opt-in: caches SHA in protectedPathShas
+			await syncAndHandleResult(fitSync, createMockNotice());
+			const cachedSha = localStoreState.protectedPathShas?.['.obsidian/graph.json'];
+			expect(cachedSha).toBeTruthy();
+
+			// User opts in the path
+			fitSync.fit.obsidianSyncRules = { '.obsidian/graph.json': {} };
+
+			// Second sync fails after reconciliation mutates state
+			remoteVault.setFailure(VaultError.network("Couldn't reach GitHub API"));
+			await syncAndHandleResult(fitSync, createMockNotice());
+
+			// In-memory protectedPathShas must be restored to pre-reconciliation state
+			// so next sync attempt can re-run reconciliation from the correct baseline.
+			expect(fitSync.fit.protectedPathShas['.obsidian/graph.json']).toBe(cachedSha);
+
+			// Third sync (succeeds): reconciliation re-runs, no junk clash
+			const result = await syncAndHandleResult(fitSync, createMockNotice());
+			expect(result).toMatchObject({ success: true, clash: [] });
+			expect(localStoreState.protectedPathShas?.['.obsidian/graph.json']).toBeUndefined();
+		});
+
 		it('should sync opted-in .obsidian/ file directly (not to _fit/)', async () => {
 			const fitSync = createFitSync();
 			fitSync.fit.obsidianSyncRules = { '.obsidian/appearance.json': {} };

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -673,11 +673,24 @@ export class FitSync implements IFitSync {
 	private async _doSync(syncNotice: FitNotice, options?: { isAutoSync?: boolean }): Promise<SyncResult> {
 		const isAutoSync = options?.isAutoSync ?? false;
 
+		// Snapshots for pre-sync reconciliation rollback (see comment below).
+		// Initialized to empty so catch block can always restore safely, even if try throws before mutation.
+		let preReconcileProtectedPathShas = {...this.fit.protectedPathShas};
+		let preReconcileLocalShas = {...this.fit.localShas};
+		let preReconcileLastFetchedRemoteShas = {...this.fit.lastFetchedRemoteShas};
+
 		try {
 			syncNotice.setMessage("Checking for changes...");
 
 			// Pre-sync: reconcile paths that became tracked since last sync (e.g. user opted in via obsidianSyncRules).
 			// Without this, a path with no localShas entry but an existing local file → untrackedPaths → junk clash.
+			// Snapshot the three stores mutated here so we can restore them if the sync subsequently fails.
+			// saveLocalStoreCallback only runs on success, so in-memory mutations would otherwise leak
+			// into the next sync attempt and cause junk clashes or missed reconciliation.
+			preReconcileProtectedPathShas = {...this.fit.protectedPathShas};
+			preReconcileLocalShas = {...this.fit.localShas};
+			preReconcileLastFetchedRemoteShas = {...this.fit.lastFetchedRemoteShas};
+
 			const reconcilePaths = Object.keys(this.fit.protectedPathShas)
 				.filter(p => this.fit.shouldSyncPath(p));
 			if (reconcilePaths.length > 0) {
@@ -982,6 +995,12 @@ export class FitSync implements IFitSync {
 		} catch (error) {
 			// Handle unexpected errors that escape from individual sync operations.
 
+			// Restore pre-reconciliation in-memory state so next sync attempt can re-run reconciliation.
+			// saveLocalStoreCallback only fires on success, so without this restore the mutations leak.
+			this.fit.protectedPathShas = preReconcileProtectedPathShas;
+			this.fit.localShas = preReconcileLocalShas;
+			this.fit.lastFetchedRemoteShas = preReconcileLastFetchedRemoteShas;
+
 			// VaultError from vault operations (both LocalVault and RemoteGitHubVault)
 			if (error instanceof VaultError) {
 				return { success: false, error };
@@ -990,8 +1009,8 @@ export class FitSync implements IFitSync {
 			// All other errors - sync orchestration failures
 			const errorMessage = error instanceof Error
 				? String(error) // Gets "ErrorType: message" which includes both type and message
-				: (error && typeof error === 'object' && error.message)
-					? String(error.message)
+				: (error && typeof error === 'object' && 'message' in error)
+					? String((error as { message: unknown }).message)
 					: `Generic error: ${String(error)}`; // May result in '[object Object]' but it's the best we can do
 			return { success: false, error: SyncErrors.unknown(errorMessage, { originalError: error }) };
 		}

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -172,21 +172,6 @@ export class FitSync implements IFitSync {
 		}
 
 		for (const change of addToLocalNonClashed) {
-			// SAFETY: Save protected paths to _fit/ (e.g., .obsidian/, _fit/)
-			// These paths should never be written directly to the vault to avoid:
-			// - Overwriting critical Obsidian settings/plugins (.obsidian/)
-			// - Conflicting with our conflict resolution area (_fit/)
-			// - User confusion from inconsistent behavior (_fit/_fit/ for remote _fit/ files)
-			if (!this.fit.shouldSyncPath(change.path)) {
-				fitLogger.log('[FitSync] Protected path - saving to _fit/ for safety', {
-					path: change.path,
-					reason: 'path excluded by shouldSyncPath (e.g., .obsidian/, _fit/)'
-				});
-				clashPaths.add(change.path);
-				resolvedChanges.push(change);
-				continue; // Don't write to protected path
-			}
-
 			// SAFETY: Check filesystem for files not in localShas cache
 			// This protects against:
 			// 1. Version migrations where tracking rules changed
@@ -217,18 +202,9 @@ export class FitSync implements IFitSync {
 			resolvedChanges.push({path: change.path, content: change.content});
 		}
 
-		// SAFETY: Never delete protected or untracked files from local
+		// SAFETY: Never delete untracked files from local
 		const safeDeleteFromLocal = [];
 		for (const path of deleteFromLocalNonClashed) {
-			// Skip deletion of protected paths (shouldn't exist locally, but be safe)
-			if (!this.fit.shouldSyncPath(path)) {
-				fitLogger.log('[FitSync] Skipping deletion of protected path', {
-					path,
-					reason: 'path excluded by shouldSyncPath (e.g., .obsidian/, _fit/)'
-				});
-				continue; // Skip deletion
-			}
-
 			// SAFETY: Check if file is in cache before deleting
 			// If not in cache, we cannot verify it's safe to delete
 			if (!this.fit.localShas.hasOwnProperty(path)) {
@@ -253,7 +229,7 @@ export class FitSync implements IFitSync {
 		const addToLocal = resolvedChanges;
 		const deleteFromLocal = safeDeleteFromLocal;
 
-		// Apply changes with clashPaths to write protected/unsafe paths to _fit/
+		// Apply changes with clashPaths to write unsafe/clash paths to _fit/
 		const result = await this.fit.localVault.applyChanges(addToLocal, deleteFromLocal, { clashPaths });
 
 		// Show user warning if encoding issues detected
@@ -377,7 +353,7 @@ export class FitSync implements IFitSync {
 		);
 
 		// Phase 2c: Simple clash detection
-		const { safeLocal, safeRemote, clashes } = resolveAllChanges(
+		const { safeLocal, safeRemote, clashes, protectedRemote } = resolveAllChanges(
 			localChanges,
 			remoteChanges,
 			protectedPaths,
@@ -414,11 +390,12 @@ export class FitSync implements IFitSync {
 		fitLogger.log('[FitSync] Conflict detection complete', {
 			safeLocal: safeLocal.length,
 			safeRemote: safeRemote.length,
-			clashes: clashes.length
+			clashes: clashes.length,
+			protectedRemote: protectedRemote.length
 		});
 
 		return {
-			safeLocal, safeRemote, clashes, statError, filesMovedToFitDueToStatFailure, deletionsSkippedDueToStatFailure, existenceMap
+			safeLocal, safeRemote, clashes, protectedRemote, statError, filesMovedToFitDueToStatFailure, deletionsSkippedDueToStatFailure, existenceMap
 		};
 	}
 
@@ -439,6 +416,7 @@ export class FitSync implements IFitSync {
 		safeLocal: FileChange[],
 		safeRemote: FileChange[],
 		clashes: FileClash[],
+		protectedRemote: FileChange[],
 		pendingReminderPaths: Set<string>,
 		existenceMap: Map<string, "file" | "folder" | "nonexistent">,
 		syncNotice: FitNotice
@@ -558,6 +536,20 @@ export class FitSync implements IFitSync {
 			});
 		}
 
+		// 3b'. Track protected path SHA arrivals for opt-in reconciliation.
+		// Remote changes to paths excluded by shouldSyncPath (e.g. .obsidian/ not opted in).
+		// Only the remote SHA is recorded — no content download, no _fit/ write.
+		// When the user later opts in a path, the reconciliation pre-sync step reads
+		// protectedPathShas to establish a baseline and avoid junk clashes.
+		for (const change of protectedRemote) {
+			if (change.type === 'REMOVED') {
+				delete this.fit.protectedPathShas[change.path];
+				continue;
+			}
+			const remoteSha = remoteUpdate.remoteTreeSha[change.path];
+			if (remoteSha) this.fit.protectedPathShas[change.path] = remoteSha;
+		}
+
 		// 3c. Update local state using SHAs computed by LocalVault (performance optimization)
 		// LocalVault computed SHAs from in-memory content during file writes (see docs/sync-logic.md).
 		// Benefits: avoids redundant I/O, prevents race conditions, no normalization in Obsidian.
@@ -578,12 +570,11 @@ export class FitSync implements IFitSync {
 
 		// Update pendingClashes: newly-clashed tracked files enter pending state.
 		// Remove their baseline so FIT makes no assumption about the canonical version.
-		// Untracked/protected clashes are excluded — they use the #169 baseline mechanism instead.
+		// Untracked clashes are excluded — they use the #169 baseline mechanism instead.
 		// Paths already in pendingClashes (localState === 'pending') stay there.
 		for (const clash of clashes) {
 			if (clash.remoteOp !== 'REMOVED' &&
-				clash.localState !== 'untracked' &&
-				clash.localState !== 'protected') {
+				clash.localState !== 'untracked') {
 				if (!this.fit.pendingClashes.includes(clash.path)) {
 					this.fit.pendingClashes.push(clash.path);
 				}
@@ -655,6 +646,7 @@ export class FitSync implements IFitSync {
 			localShas: this.fit.filterSyncedState(newLocalState),
 			unpushedFiles: this.fit.unpushedFiles,
 			pendingClashes: this.fit.pendingClashes,
+			protectedPathShas: this.fit.protectedPathShas,
 			// Only persist localSha if there are still legacy entries remaining (not yet promoted)
 			localSha: Object.keys(this.fit.localSha).length > 0 ? this.fit.localSha : undefined,
 		});
@@ -683,6 +675,34 @@ export class FitSync implements IFitSync {
 
 		try {
 			syncNotice.setMessage("Checking for changes...");
+
+			// Pre-sync: reconcile paths that became tracked since last sync (e.g. user opted in via obsidianSyncRules).
+			// Without this, a path with no localShas entry but an existing local file → untrackedPaths → junk clash.
+			const reconcilePaths = Object.keys(this.fit.protectedPathShas)
+				.filter(p => this.fit.shouldSyncPath(p));
+			if (reconcilePaths.length > 0) {
+				fitLogger.log('[FitSync] Reconciling newly-tracked paths from protectedPathShas', { paths: reconcilePaths });
+				for (const path of reconcilePaths) {
+					const cachedRemoteSha = this.fit.protectedPathShas[path];
+					delete this.fit.protectedPathShas[path];
+					try {
+						const content = await this.fit.localVault.readFileContent(path);
+						const currentSha = await LocalVault.fileSha1(path, content);
+						// Establish baseline from current local content so detection sees no spurious change.
+						// If local == remote: also update lastFetchedRemoteShas → full no-op (no download).
+						// If local != remote: remote shows as ADDED → applied (remote wins on first opt-in sync).
+						this.fit.localShas[path] = currentSha;
+						if (currentSha === cachedRemoteSha) {
+							this.fit.lastFetchedRemoteShas[path] = cachedRemoteSha;
+						}
+					} catch {
+						// File absent locally. lastFetchedRemoteShas may already have this path from prior
+						// syncs (it stores the full remote tree including protected paths). Clear it so
+						// remote appears as ADDED and gets applied this sync.
+						delete this.fit.lastFetchedRemoteShas[path];
+					}
+				}
+			}
 
 			// Get local and remote changes in parallel
 			// Use allSettled to ensure both operations complete (or fail) before processing
@@ -846,7 +866,7 @@ export class FitSync implements IFitSync {
 			// Phase 2: Compare & Resolve - determine safe vs clashed changes
 			const localScanPaths = new Set(Object.keys(currentLocalState));
 			const remoteScanPaths = new Set(Object.keys(remoteTreeSha));
-			const { safeLocal, safeRemote: initialSafeRemote, clashes: initialClashes, existenceMap } = await this.compareAndResolveChanges(
+			const { safeLocal, safeRemote: initialSafeRemote, clashes: initialClashes, protectedRemote, existenceMap } = await this.compareAndResolveChanges(
 				filteredLocalChanges,
 				remoteChanges,
 				localScanPaths,
@@ -890,6 +910,7 @@ export class FitSync implements IFitSync {
 				safeLocal,
 				safeRemote,
 				clashes,
+				protectedRemote,
 				pendingReminderPaths,
 				existenceMap,
 				syncNotice
@@ -899,8 +920,6 @@ export class FitSync implements IFitSync {
 
 			// Log conflicts if any (these are real unresolved conflicts, not temporary clashes)
 			if (conflicts.length > 0) {
-				const protectedConflicts = conflicts.filter(c => c.localState === 'protected');
-
 				fitLogger.log('[FitSync] Sync completed with conflicts', {
 					conflictCount: conflicts.length,
 					conflicts: conflicts.map(c => ({
@@ -909,12 +928,6 @@ export class FitSync implements IFitSync {
 						remote: c.remoteOp
 					}))
 				});
-
-				if (protectedConflicts.length > 0) {
-					fitLogger.log(`[FitSync] ${protectedConflicts.length} path(s) blocked by sync policy`, {
-						protectedPaths: protectedConflicts.map(c => c.path)
-					});
-				}
 			}
 
 			// Show tiered warning for files still awaiting manual sync

--- a/src/localStores.ts
+++ b/src/localStores.ts
@@ -30,6 +30,12 @@ export interface LocalStores {
 	// false-positive re-push on old clients (overhead only, not data loss).
 	pendingClashes?: string[]
 	lastSyncedAt?: number  // Unix ms timestamp of last successful sync completion
+	// Remote SHA cache for paths excluded by shouldSyncPath (e.g. .obsidian/ not opted in).
+	// Enables junk-clash-free opt-in: when the user adds a path to obsidianSyncRules, the
+	// reconciliation pre-sync step uses this SHA to establish a baseline without re-downloading.
+	// Entries are cleared when a path becomes opted in (baseline reconciliation takes over).
+	// Downgrade-safe: absent field treated as empty object.
+	protectedPathShas?: FileStates
 }
 
 /**
@@ -53,5 +59,6 @@ export function parseLocalStore(data: Record<string, unknown> | null | undefined
 		unpushedFiles: (d.unpushedFiles ?? {}) as unknown as FileStates,
 		pendingClashes: (d.pendingClashes ?? []) as unknown as string[],
 		lastSyncedAt: (d.lastSyncedAt as number | undefined) ?? undefined,
+		protectedPathShas: (d.protectedPathShas ?? {}) as unknown as FileStates,
 	};
 }

--- a/src/util/changeTracking.ts
+++ b/src/util/changeTracking.ts
@@ -33,10 +33,12 @@ export type FileStates = Record<string, BlobSha>;
  * When detecting clashes, we need to know the local state:
  * - ChangeOperation: File has a tracked change (ADDED/MODIFIED/REMOVED)
  * - "untracked": File exists but state can't be determined (stat failed, hidden files)
- * - "protected": File is blocked by sync policy (shouldSyncPath returns false)
  * - "pending": A previous clash for this file is unresolved (_fit/ copy still present)
+ *
+ * Note: protected paths (shouldSyncPath=false) are returned separately as
+ * protectedRemote from resolveAllChanges — they are not clashes and never appear here.
  */
-export type LocalClashState = ChangeOperation | "untracked" | "protected" | "pending";
+export type LocalClashState = ChangeOperation | "untracked" | "pending";
 
 /** Represents a clash between local and remote changes to the same file */
 export type FileClash = {
@@ -172,7 +174,7 @@ export function resolveUntrackedState(
  * @param remoteChanges - Changes detected in remote vault
  * @param protectedPaths - Paths blocked by sync policy (shouldSyncPath)
  * @param untrackedPaths - Paths with unknown state (stat failed or untracked changes)
- * @returns Final categorization into safe changes and clashes
+ * @returns Final categorization into safe changes, clashes, and protected remote arrivals
  */
 export function resolveAllChanges(
 	localChanges: FileChange[],
@@ -183,12 +185,15 @@ export function resolveAllChanges(
 	safeLocal: FileChange[];
 	safeRemote: FileChange[];
 	clashes: FileClash[];
+	/** Remote changes to paths excluded by shouldSyncPath — not clashes, handled separately */
+	protectedRemote: FileChange[];
 } {
 	const localChangePaths = new Set(localChanges.map(c => c.path));
 
 	const safeLocal: FileChange[] = [];
 	const safeRemote: FileChange[] = [];
 	const clashes: FileClash[] = [];
+	const protectedRemote: FileChange[] = [];
 
 	// Process all local changes
 	for (const localChange of localChanges) {
@@ -214,19 +219,14 @@ export function resolveAllChanges(
 			continue;
 		}
 
-		// Determine local state based on block reason
-		let localState: LocalClashState | null = null;
 		if (protectedPaths.has(remoteChange.path)) {
-			localState = 'protected';
+			// Protected path arrival — not a clash, handled separately
+			protectedRemote.push(remoteChange);
 		} else if (untrackedPaths.has(remoteChange.path)) {
-			localState = 'untracked';
-		}
-
-		if (localState !== null) {
-			// Blocked - treat as clash
+			// Untracked: can't verify local state — block conservatively
 			clashes.push({
 				path: remoteChange.path,
-				localState,
+				localState: 'untracked',
 				remoteOp: remoteChange.type
 			});
 		} else {
@@ -235,7 +235,7 @@ export function resolveAllChanges(
 		}
 	}
 
-	return { safeLocal, safeRemote, clashes };
+	return { safeLocal, safeRemote, clashes, protectedRemote };
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,7 +67,6 @@ export function showUnappliedConflicts(clashedFiles: Array<FileClash>): void {
 		MODIFIED: "change",
 		REMOVED: "delete",
 		untracked: "untracked",
-		protected: "protected",
 		pending: "pending"
 	};
 	const remoteStatusMap: Record<ChangeOperation, string> = {
@@ -109,17 +108,12 @@ export function showUnappliedConflicts(clashedFiles: Array<FileClash>): void {
 
 	// Add explanatory notes for special local states
 	const hasPending = clashedFiles.some(c => c.localState === 'pending');
-	const hasProtected = clashedFiles.some(c => c.localState === 'protected');
 	const hasUntracked = clashedFiles.some(c => c.localState === 'untracked');
 	const hasHidden = clashedFiles.some(c => c.path.split('/').some(p => p.startsWith('.')));
 
 	if (hasPending) {
 		conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
 			.setText("Pending: unresolved from a prior sync — will keep appearing and local changes won't sync until resolved");
-	}
-	if (hasProtected) {
-		conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})
-			.setText("Protected: path excluded from sync (.obsidian/, _fit/) — saved to _fit/ for transparency, not tracked as pending");
 	}
 	if (hasUntracked) {
 		conflictNotice.noticeEl.createEl("li", {cls: "file-conflict-note"})


### PR DESCRIPTION
Protected paths (e.g. .obsidian/ files not opted in via obsidianSyncRules) were incorrectly classified as clashes, triggering an alarming 'Change conflicts' notice on every sync. The notice repeated forever because localShas never stored entries for !shouldSyncPath paths, so the same remote SHA looked new each sync.

Root cause: resolveAllChanges() mixed protected paths into the clashes array. A 'conflict' requires two parties with competing claims — a protected path has no local ownership; remote is authoritative by definition.

Changes:
- changeTracking.ts: resolveAllChanges() now returns protectedRemote: FileChange[] separately from clashes. LocalClashState drops 'protected' (never generated).
- localStores.ts / fit.ts: add protectedPathShas: FileStates — persisted map of path → last-seen remote SHA for protected paths.
- fitSync.ts executeSync(): handle protectedRemote in a separate loop. Just records the remote SHA in protectedPathShas — no content download, no _fit/ write, no notice. On REMOVED: clears protectedPathShas entry.
- fitSync.ts _doSync(): pre-sync reconciliation for newly opted-in paths. Finds protectedPathShas entries where shouldSyncPath now returns true (user opted in), clears the entry, sets localShas baseline from current local content, clears lastFetchedRemoteShas if file absent (so remote ADDED is applied this sync, no junk clash).
- fit.ts: delete dead getClashedChanges() method.
- applyRemoteChanges(): remove !shouldSyncPath redirect to _fit/ (protected paths no longer reach this path — they go to protectedRemote instead).
- utils.ts showUnappliedConflicts(): remove 'protected' case (never reached).
- docs/sync-logic.md: update _fit/ scratchpad section (one purpose: conflict copies), protected path behavior, Phase 2c description, opt-in transition docs.