### PR TITLE
Replace existing rotated log backups

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -2,7 +2,7 @@
  * Tests for Logger
  */
 
-import { LogFileAdapter, Logger } from "@/logger";
+import { FitLogger, LogFileAdapter, Logger } from "@/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const UTF8_BOM = '\uFEFF';
@@ -532,5 +532,55 @@ describe('Logger', () => {
 			// Should have depth limit message somewhere
 			expect(content).toContain('[nested too deep]');
 		});
+	});
+});
+
+describe('FitLogger', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should replace an existing rotated log backup', async () => {
+		const pluginDir = '.obsidian/plugins/fit';
+		const logPath = `${pluginDir}/debug.log`;
+		const rotatedPath = `${logPath}.0`;
+		const currentLog = UTF8_BOM + 'current log content';
+		const files = new Map<string, string>([
+			[logPath, currentLog],
+			[rotatedPath, 'previous rotated content']
+		]);
+		const adapter = {
+			exists: vi.fn(async (path: string) => files.has(path)),
+			read: vi.fn(async (path: string) => files.get(path) ?? ''),
+			append: vi.fn(async (path: string, data: string) => {
+				files.set(path, (files.get(path) ?? '') + data);
+			}),
+			remove: vi.fn(async (path: string) => {
+				files.delete(path);
+			}),
+			rename: vi.fn(async (oldPath: string, newPath: string) => {
+				if (files.has(newPath)) {
+					throw new Error('Destination file already exists!');
+				}
+				files.set(newPath, files.get(oldPath) ?? '');
+				files.delete(oldPath);
+			})
+		};
+		const logger = new FitLogger({ adapter: null, maxLogSize: 1 });
+
+		logger.configure({ adapter } as any, pluginDir);
+		logger.setEnabled(true);
+		logger.log('New entry');
+		await logger.flush();
+
+		expect(adapter.remove).toHaveBeenCalledWith(rotatedPath);
+		expect(adapter.rename).toHaveBeenCalledWith(logPath, rotatedPath);
+		expect(files.get(rotatedPath)).toBe(currentLog);
+		expect(files.get(logPath)).toContain('New entry');
 	});
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -285,6 +285,9 @@ export class FitLogger extends Logger {
 			async renameTo(newName: string): Promise<void> {
 				const dirPath = logPath.substring(0, logPath.lastIndexOf('/'));
 				const newPath = `${dirPath}/${newName}`;
+				if (await vault.adapter.exists(newPath)) {
+					await vault.adapter.remove(newPath);
+				}
 				await vault.adapter.rename(logPath, newPath);
 			}
 		};


### PR DESCRIPTION
## Summary

- remove an existing `debug.log.0` before rotating the current log
- keep the existing single-backup rotation behavior
- use the cross-platform Obsidian DataAdapter APIs for desktop and mobile
- add a regression test whose adapter rejects an existing rename destination

Fixes #314.

## Testing

- `npm test -- src/logger.test.ts` — 22 tests passed
- `npm run typecheck`
- `npx eslint src/logger.ts src/logger.test.ts`
- full unit suite, production build, and Node 18/20/26 coverage passed during validation
- `git diff --check`
