### PR TITLE
fix: skip clash when local and remote content is identical

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -603,11 +603,13 @@ remoteChanges = [
 
 **Actions:**
 1. Identify clashed files
-2. For each clash, check if content actually differs
-3. If no actual difference, treat as compatible
+2. For each clash, compare canonical git blob SHAs (local vs. incoming remote) — this is a content check, not a heuristic, since matching SHA-1 over `"blob " + len + NUL + bytes` means byte-identical content
+3. If SHAs match (e.g. two devices/sync plugins independently producing the same edit), skip entirely — no `_fit/` write, no push, no pull; local state already matches remote
 4. If real 🔀 conflict, save remote version to 📁 `_fit/`, add path to `pendingClashes`, remove from `localShas`
 5. Push **non-conflicted** local changes only (conflicted files are withheld until resolved)
 6. Pull non-conflicted remote changes
+
+Skipped when encryption is enabled — encrypted blob SHAs aren't comparable to plaintext content SHAs, so the fast path is disabled and clashes fall through to normal resolution.
 
 ## 🔀 Conflict Resolution
 
@@ -618,9 +620,10 @@ remoteChanges = [
 **Phase 2b**: Batch collects filesystem state for all paths needing verification
 
 **Phase 2c**: Resolves all changes to final safe/clash/protectedRemote outcomes:
-- **Tracked files**: Both sides changed → clash
+- **Tracked files**: Both sides changed → clash, *unless* local and remote blob SHAs are equal (identical content) → skipped entirely, no reconciliation needed
 - **Protected paths** (`!shouldSyncPath`): → `protectedRemote` (separate category, not a clash; SHA recorded in `protectedPathShas`, no write)
-- **Untracked files**: Checks filesystem existence and baseline SHA (#169)
+- **Untracked files**: Checks filesystem existence, remote-content SHA, and baseline SHA (#169)
+  - Local content SHA matches incoming remote SHA → safe, no clash (regardless of baseline)
   - Exists locally (and changed from baseline, or no baseline) → clash
   - Doesn't exist locally → safe
   - Stat failed → conservative clash
@@ -656,8 +659,8 @@ flowchart TD
 - **Resolution:** ✓ Automatically resolved - both sides agree
 
 **Both sides modified, but content is identical:**
-- **Example:** Line ending differences, whitespace changes
-- **Resolution:** ✓ Automatically resolved - SHA differs but content effectively the same
+- **Example:** Two devices (or a third-party sync plugin racing on the same note) independently produce the same resulting edit
+- **Resolution:** ✓ Automatically resolved - local and remote blob SHAs match, so nothing is written to `_fit/`, pushed, or pulled
 
 #### Manual Resolution Required
 

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -303,6 +303,41 @@ describe('FitSync', () => {
 		expect(consoleLogSpy).toHaveBeenCalled();
 	});
 
+	it('should not write to _fit/ when local and remote clash to identical content', async () => {
+		// Reproduces two devices independently producing the same edit (e.g. a third-party
+		// sync plugin like TickTickSync applying the same task-completion metadata on both
+		// devices within the same window) — both sides differ from baseline, but agree with
+		// each other, so there's nothing to reconcile.
+		localVault.setFile('note.md', 'Original content');
+		await remoteVault.setFile('note.md', 'Original content');
+
+		const remoteResult = await remoteVault.readFromSource();
+		localStoreState = makeLocalStore({
+			localShas: await localVault.readFromSource().then(r => r.state),
+			lastFetchedRemoteShas: remoteResult.state,
+			lastFetchedCommitSha: remoteResult.commitSha
+		});
+		const fitSync = createFitSync();
+
+		// Both sides edit independently but converge on the same resulting text.
+		localVault.setFile('note.md', 'Original content ✅ done');
+		await remoteVault.setFile('note.md', 'Original content ✅ done');
+
+		const mockNotice = createMockNotice();
+		const result = await syncAndHandleResult(fitSync, mockNotice);
+
+		expect(result).toEqual(expect.objectContaining({ success: true, clash: [] }));
+
+		// No _fit/ copy written, local content untouched.
+		expect(localVault.getAllFilesAsRaw()).toEqual({
+			'note.md': 'Original content ✅ done'
+		});
+
+		// Baseline converges on the shared content SHA so future syncs don't re-flag it.
+		const localSha = await LocalVault.fileSha1('note.md', FileContent.fromPlainText('Original content ✅ done'));
+		expect(localStoreState.localShas['note.md']).toBe(localSha);
+	});
+
 	describe('Protected path handling (📁 shouldSyncPath filtering)', () => {
 		it('should silently track remote 📁 .obsidian/ SHA without writing to _fit/', async () => {
 			// === SETUP: Initial synced state ===

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -283,7 +283,9 @@ export class FitSync implements IFitSync {
 		localChanges: FileChange[],
 		remoteChanges: FileChange[],
 		localScanPaths: Set<string>,
-		remoteScanPaths: Set<string>
+		remoteScanPaths: Set<string>,
+		currentLocalState: FileStates,
+		remoteTreeSha: FileStates
 	) {
 		// Diagnostic: Check if any clashes are due to Unicode normalization mismatches
 		detectNormalizationMismatches(Array.from(localScanPaths), Array.from(remoteScanPaths));
@@ -323,8 +325,7 @@ export class FitSync implements IFitSync {
 		// For files that exist locally AND have a baseline SHA, read and compute current SHA
 		// This allows baseline comparison to prevent unnecessary clashes
 		const pathsNeedingShaCheck = Array.from(pathsToStat).filter(path =>
-			filesystemState.get(path) === true &&
-			this.fit.localShas[path] !== undefined
+			filesystemState.get(path) === true
 		);
 
 		const currentShas = new Map<string, BlobSha>();
@@ -341,6 +342,15 @@ export class FitSync implements IFitSync {
 			}
 		}
 
+		// Content-identity fast path: when local and remote independently produced
+		// byte-identical content (same canonical git blob SHA), there's nothing to reconcile —
+		// skip the clash entirely instead of writing a redundant copy to _fit/. Guarded off
+		// under encryption: encrypted blob SHAs aren't comparable to plaintext content SHAs.
+		let encryptionEnabled = false;
+		try { encryptionEnabled = Encryption.isEnabled(); } catch { /* uninitialized — treat as disabled */ }
+		const identityRemoteShas = encryptionEnabled ? {} : remoteTreeSha;
+		const identityLocalShas = encryptionEnabled ? {} : currentLocalState;
+
 		// Phase 2b (part 2): Resolve untracked state from filesystem checks
 		const localChangePaths = new Set(localChanges.map(c => c.path));
 		const { protectedPaths, untrackedPaths } = resolveUntrackedState(
@@ -349,7 +359,8 @@ export class FitSync implements IFitSync {
 			filesystemState,
 			this.fit.localShas,
 			currentShas,
-			isProtectedPath
+			isProtectedPath,
+			identityRemoteShas
 		);
 
 		// Phase 2c: Simple clash detection
@@ -357,7 +368,9 @@ export class FitSync implements IFitSync {
 			localChanges,
 			remoteChanges,
 			protectedPaths,
-			untrackedPaths
+			untrackedPaths,
+			identityLocalShas,
+			identityRemoteShas
 		);
 
 		// Track stat failures for logging
@@ -883,7 +896,9 @@ export class FitSync implements IFitSync {
 				filteredLocalChanges,
 				remoteChanges,
 				localScanPaths,
-				remoteScanPaths
+				remoteScanPaths,
+				currentLocalState,
+				remoteTreeSha
 			);
 
 			// Reclassify safeRemote items for active pending paths — new remote changes must

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -8,7 +8,7 @@ import { ApplyChangesResult, IVault, VaultError, VaultReadResult } from './vault
 import { FileChange, FileStates } from "./util/changeTracking";
 import { FileContent, Base64Content, PlainTextContent } from './util/contentEncoding';
 import { FilePath } from './util/filePath';
-import { BlobSha, CommitSha, computeSha1, TreeSha } from "./util/hashing";
+import { BlobSha, CommitSha, computeGitBlobSha, computeSha1, TreeSha } from "./util/hashing";
 import { LocalVault } from './localVault';
 import { fitLogger } from './logger';
 
@@ -826,8 +826,10 @@ export class FakeRemoteVault implements IVault<"remote"> {
 			fileContent = FileContent.fromPlainText(content);
 		}
 		this.files.set(path, fileContent);
-		// Store blob SHA -> content mapping for readFileContent
-		const sha = await computeSha1(path + fileContent.toBase64()) as BlobSha;
+		// Store blob SHA -> content mapping for readFileContent.
+		// Canonical git blob SHA (matches GitHub's actual blob SHAs) so tests exercise the same
+		// local/remote SHA comparability that production relies on (e.g. SHA parity fast paths).
+		const sha = await computeGitBlobSha(fileContent.toBytes());
 		this.blobShas.set(sha, fileContent.toBase64());
 	}
 
@@ -886,7 +888,7 @@ export class FakeRemoteVault implements IVault<"remote"> {
 		for (const [path, content] of this.files.entries()) {
 			if (this.shouldTrackState(path)) {
 				const base64Content = content.toBase64();
-				const sha = await computeSha1(path + base64Content) as BlobSha;
+				const sha = await computeGitBlobSha(content.toBytes());
 				state[path] = sha;
 				// Store blob SHA -> content mapping for readFileContent if requested
 				if (storeBlobShaMapping) {

--- a/src/util/changeTracking.ts
+++ b/src/util/changeTracking.ts
@@ -99,6 +99,8 @@ export function determineLocalChecksNeeded(
  * @param baselineShas - Baseline SHA cache for detecting unchanged files (#169)
  * @param currentShas - Current SHAs for files that exist locally
  * @param isProtectedPath - Function to check if path is protected
+ * @param remoteShas - Incoming remote blob SHAs, keyed by path — used to detect that a local
+ *   untracked file already has the same content as the remote arrival (no real clash)
  * @returns Sets of paths categorized by block reason
  */
 export function resolveUntrackedState(
@@ -107,7 +109,8 @@ export function resolveUntrackedState(
 	filesystemState: Map<string, boolean | null>,
 	baselineShas: FileStates,
 	currentShas: Map<string, BlobSha>,
-	isProtectedPath: (path: string) => boolean
+	isProtectedPath: (path: string) => boolean,
+	remoteShas: FileStates = {}
 ): {
 	protectedPaths: Set<string>;
 	untrackedPaths: Set<string>;
@@ -148,10 +151,18 @@ export function resolveUntrackedState(
 		}
 
 		// Case 4: File exists locally but wasn't in scan (untracked)
-		// Check if it's unchanged from baseline (#169)
-		const baselineSha = baselineShas[remoteChange.path];
 		const currentSha = currentShas.get(remoteChange.path);
 
+		// Local content already matches the incoming remote content - nothing to reconcile,
+		// regardless of whether a baseline exists (e.g. two devices independently producing
+		// the same edit, such as two sync plugins racing on the same note).
+		const remoteSha = remoteShas[remoteChange.path];
+		if (currentSha !== undefined && remoteSha !== undefined && currentSha === remoteSha) {
+			continue;
+		}
+
+		// Check if it's unchanged from baseline (#169)
+		const baselineSha = baselineShas[remoteChange.path];
 		if (baselineSha !== undefined && currentSha !== undefined && currentSha === baselineSha) {
 			// Unchanged from baseline - clear for remote (no action needed)
 			continue;
@@ -174,13 +185,18 @@ export function resolveUntrackedState(
  * @param remoteChanges - Changes detected in remote vault
  * @param protectedPaths - Paths blocked by sync policy (shouldSyncPath)
  * @param untrackedPaths - Paths with unknown state (stat failed or untracked changes)
+ * @param localShas - Current local blob SHAs, keyed by path — used to detect that a local change
+ *   and a remote change independently produced identical content (no real clash)
+ * @param remoteShas - Incoming remote blob SHAs, keyed by path
  * @returns Final categorization into safe changes, clashes, and protected remote arrivals
  */
 export function resolveAllChanges(
 	localChanges: FileChange[],
 	remoteChanges: FileChange[],
 	protectedPaths: Set<string>,
-	untrackedPaths: Set<string>
+	untrackedPaths: Set<string>,
+	localShas: FileStates = {},
+	remoteShas: FileStates = {}
 ): {
 	safeLocal: FileChange[];
 	safeRemote: FileChange[];
@@ -200,6 +216,18 @@ export function resolveAllChanges(
 		const remoteChange = remoteChanges.find(c => c.path === localChange.path);
 
 		if (remoteChange) {
+			// Both sides changed content independently - but if the resulting content is
+			// byte-identical (e.g. two devices/sync plugins converging on the same edit),
+			// there is nothing to reconcile: skip entirely (no push, no pull, no _fit/ write).
+			const localSha = localShas[localChange.path];
+			const remoteSha = remoteShas[remoteChange.path];
+			if (
+				localChange.type !== "REMOVED" && remoteChange.type !== "REMOVED" &&
+				localSha !== undefined && remoteSha !== undefined && localSha === remoteSha
+			) {
+				continue;
+			}
+
 			// Both sides changed - definite clash
 			clashes.push({
 				path: localChange.path,


### PR DESCRIPTION
## Summary
- Two devices (or a third-party sync plugin racing on the same note) independently producing the same resulting edit was flagged as a clash and written to `_fit/`, even though there was nothing to reconcile.
- `resolveAllChanges`/`resolveUntrackedState` now compare canonical git blob SHAs between local and remote before treating a same-path change on both sides as a clash — if the content is byte-identical, the path is skipped entirely (no `_fit/` write, no push, no pull). Disabled under encryption, where ciphertext SHAs aren't comparable to plaintext.
- Fixed `FakeRemoteVault` in `testUtils.ts`, which hashed content with a legacy non-canonical scheme, so no test could previously exercise local/remote SHA equality.

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
This PR fixes false-positive sync clashes when local and remote content is byte-identical.

### What changed
- Added a content-identity fast path during conflict detection: if the local file's canonical git blob SHA matches the incoming remote blob SHA, the change is skipped entirely—no `_fit/` copy is written, nothing is pushed, and nothing is pulled.
- Applied this skip to both tracked-file clashes (both sides modified) and untracked local files that happen to already match incoming remote content.
- Disabled the fast path when encryption is enabled, because encrypted blob SHAs cannot be compared to plaintext content SHAs.
- Updated `FakeRemoteVault` to compute canonical git blob SHAs so tests exercise the same SHA comparability as production.
- Added a regression test covering the case where two devices independently produce the exact same edit.

### Functional impact
Two devices or sync plugins that race to make the same edit no longer trigger an unnecessary clash/reconciliation; sync succeeds cleanly and leaves local content untouched. Real conflicts (different content) continue to be saved to `_fit/` as before.
<!-- kody-pr-summary:end -->