### PR TITLE
fix(ci): fix E2E flakes causing post-merge CI failures

### DIFF
--- a/test/e2e/basic.e2e.ts
+++ b/test/e2e/basic.e2e.ts
@@ -115,6 +115,28 @@ describe('FIT Plugin E2E Tests', function() {
 			// Test PAT authentication flow with stubbed GitHub API
 			// Verifies: PAT input → Authenticate → Owner populated → Repos fetched and displayed
 
+			// Obsidian 1.13+ defaults to opening Settings in a separate OS window
+			// on desktop (app.vault.getConfig('settingsPopoutWindow')), and on
+			// Android too — both stopped rendering settings in this test's
+			// same-window DOM. Force it off so Settings renders in-page, matching
+			// pre-1.13 behavior. Neither this config key nor app.setting.close()
+			// can be assumed to exist/behave safely on every platform, so this
+			// must not throw and block the actual open-settings command below.
+			try {
+				await browser.executeObsidian(({ app }) => {
+					try {
+						(app.vault as any).setConfig?.('settingsPopoutWindow', false);
+						if ((app as any).setting?.popout) {
+							(app as any).setting.close();
+						}
+					} catch (e) {
+						console.warn('settingsPopoutWindow workaround failed in-page:', String(e));
+					}
+				});
+			} catch (e) {
+				console.warn('settingsPopoutWindow workaround call itself failed:', String(e));
+			}
+
 			// 1. Open Obsidian settings
 			await browser.executeObsidianCommand('app:open-settings');
 			await browser.pause(500);

--- a/test/e2e/basic.e2e.ts
+++ b/test/e2e/basic.e2e.ts
@@ -144,8 +144,15 @@ describe('FIT Plugin E2E Tests', function() {
 			// Take screenshot of settings page before trying to find FIT tab
 			await takeScreenshot('settings-opened');
 
-			// 2. Navigate to FIT plugin settings
+			// 2. Navigate to FIT plugin settings.
+			// Screenshot-confirmed: on Android, Settings can open directly onto
+			// the last-active tab's content (no .vertical-tab-nav-item list
+			// visible at all in that case), so check whether we're already
+			// looking at FIT's pane before assuming there's a tab left to click.
 			const fitTabFound = await browser.executeObsidian(() => {
+				if (document.querySelector('input[placeholder*="personal access token"]')) {
+					return true;
+				}
 				// Find FIT tab in settings sidebar (case-insensitive search)
 				const fitTab = Array.from(document.querySelectorAll('.vertical-tab-nav-item'))
 					.find(el => el.textContent?.toLowerCase().includes('fit'));


### PR DESCRIPTION
## Why
Since #322, `test-desktop` and `test-android` E2E checks passed on the PR but failed on the post-merge push to `main` for the exact same commit, blocking merges.

Root cause: Obsidian 1.13+ defaults `settingsPopoutWindow` to `true`, opening the Settings modal in a separate window/context this test's same-page DOM queries can't see, on both desktop and Android.

## What
`test/e2e/basic.e2e.ts`: disable `settingsPopoutWindow` before opening Settings, and only close an already-open instance when it's actually popped out.

<!-- kody-pr-summary:start -->
This PR fixes flaky end-to-end tests that were causing post-merge CI failures.

The E2E suite now handles two Obsidian UI behaviors that previously caused intermittent failures when navigating to plugin settings:

- **Obsidian 1.13+ settings popout window:** Newer Obsidian versions default to opening Settings in a separate OS window on desktop and Android, which prevented the test from finding Settings elements in the same-window DOM. The test now disables the `settingsPopoutWindow` setting and closes any existing popout before opening Settings, with defensive error handling for platforms where these APIs may not be available.

- **Android reopening on last-active tab:** On Android, Settings can reopen directly on the last-active tab's content, hiding the settings tab navigation. The test now first checks whether the FIT plugin settings pane is already displayed (by looking for the personal access token input) before attempting to click the FIT tab.
<!-- kody-pr-summary:end -->