### PR TITLE
ci: publish Allure reports for E2E runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,6 +72,14 @@ jobs:
         path: test-results/
         retention-days: 30
 
+    - name: Upload Allure results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: allure-results-desktop
+        path: allure-results/
+        retention-days: 30
+
   test-android:
     env:
       AVD_ARGS: "-no-metrics -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none"
@@ -164,6 +172,47 @@ jobs:
           path: |
             test-results/
             appium-server.log
+          retention-days: 30
+
+      - name: Upload Allure results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-results-android-${{ matrix.obsidian-version }}
+          path: allure-results/
+          retention-days: 30
+
+  allure-report:
+    if: always()
+    needs: [test-desktop, test-android]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all Allure result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: allure-results-*
+          path: allure-results-raw
+          merge-multiple: false
+
+      - name: Merge Allure results into one tree
+        run: |
+          mkdir -p allure-results-raw allure-results
+          # each artifact unpacks to allure-results-raw/<artifact-name>/<original-outputDir-suffix>/*
+          find allure-results-raw -mindepth 1 -type f -exec cp -t allure-results {} +
+
+      # No gh-pages publish (yet) — just generate the static HTML report and
+      # upload it as a normal build artifact. Download + unzip it, then run
+      # `npx allure-commandline open <unzipped-dir>` locally (Allure's data
+      # files are loaded via fetch(), which browsers block over file://, so
+      # it needs a local server rather than opening index.html directly).
+      - name: Generate Allure report
+        run: npx --yes allure-commandline@2 generate allure-results --clean -o allure-report
+
+      - name: Upload Allure report
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-report
+          path: allure-report/
           retention-days: 30
 
   check:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ coverage/
 
 # Test results and screenshots
 /test-results/
+/allure-results/
+/allure-history/
+/allure-results-raw/
 
 # Local agent instructions (personal workflow details, overrides AGENTS.md)
 AGENTS.local.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"@typescript-eslint/parser": "^8.53.0",
 				"@vitest/coverage-istanbul": "^4.0.8",
 				"@vitest/ui": "^4.0.8",
+				"@wdio/allure-reporter": "^9.30.0",
 				"@wdio/cli": "^9.23.0",
 				"@wdio/globals": "^9.23.0",
 				"@wdio/local-runner": "^9.23.0",
@@ -3889,6 +3890,95 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@wdio/allure-reporter": {
+			"version": "9.30.0",
+			"resolved": "https://registry.npmjs.org/@wdio/allure-reporter/-/allure-reporter-9.30.0.tgz",
+			"integrity": "sha512-hV/TNy7x1ENkX5cfWLN4CyVczfqBQYWqGdNhRdtX6+8nZFwRBtMRcC770MABFJyeVZzwAvyliZNgJMphxtEPMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0",
+				"@wdio/reporter": "9.29.1",
+				"@wdio/types": "9.29.1",
+				"allure-js-commons": "^3.3.2",
+				"csv-stringify": "^6.0.4",
+				"html-entities": "^2.6.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/@types/node": {
+			"version": "20.19.43",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+			"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/@wdio/logger": {
+			"version": "9.29.1",
+			"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+			"integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.1.2",
+				"loglevel": "^1.6.0",
+				"loglevel-plugin-prefix": "^0.8.4",
+				"safe-regex2": "^5.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/@wdio/reporter": {
+			"version": "9.29.1",
+			"resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.29.1.tgz",
+			"integrity": "sha512-CKAcVy9BGwvufokMcl3H+yNcvD11Klku/1BPz8bKSRv7/KzueXR06s1cPbJH3tv9r9zxPErxgdVMpulN8I0qAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0",
+				"@wdio/logger": "9.29.1",
+				"@wdio/types": "9.29.1",
+				"diff": "^8.0.2",
+				"object-inspect": "^1.12.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/@wdio/types": {
+			"version": "9.29.1",
+			"resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.29.1.tgz",
+			"integrity": "sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/@wdio/appium-service": {
 			"version": "9.23.0",
 			"resolved": "https://registry.npmjs.org/@wdio/appium-service/-/appium-service-9.23.0.tgz",
@@ -4822,6 +4912,24 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/allure-js-commons": {
+			"version": "3.10.2",
+			"resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.10.2.tgz",
+			"integrity": "sha512-5nAjUF1iNPSQMwKtEsadclSta8C3L705/k/pIzGb9M6P9krgfRaCyaEHt8pkLlCP9NFj5xk3grjtnAhiLeT+Kg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"md5": "^2.3.0"
+			},
+			"peerDependencies": {
+				"allure-playwright": "3.10.2"
+			},
+			"peerDependenciesMeta": {
+				"allure-playwright": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -5175,6 +5283,16 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/@img/colour": {
@@ -10102,6 +10220,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/cheerio": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -10648,6 +10776,16 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/css-select": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -10690,6 +10828,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
 			}
+		},
+		"node_modules/csv-stringify": {
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.2.tgz",
+			"integrity": "sha512-V0md5rBGlZb5WOfUmBWM8tr1+vvbe00EC2+ZhIYPKypA1GLvGuh0NzWEK0L+yRplocH7r37YGoT9uK0r1TtqBQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "6.0.2",
@@ -12754,6 +12899,23 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"node_modules/html-entities": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/mdevils"
+				},
+				{
+					"type": "patreon",
+					"url": "https://patreon.com/mdevils"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -14017,6 +14179,25 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
+		"node_modules/md5/node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/media-typer": {
 			"version": "1.1.1",
@@ -20735,6 +20916,73 @@
 				"tinyrainbow": "^3.0.3"
 			}
 		},
+		"@wdio/allure-reporter": {
+			"version": "9.30.0",
+			"resolved": "https://registry.npmjs.org/@wdio/allure-reporter/-/allure-reporter-9.30.0.tgz",
+			"integrity": "sha512-hV/TNy7x1ENkX5cfWLN4CyVczfqBQYWqGdNhRdtX6+8nZFwRBtMRcC770MABFJyeVZzwAvyliZNgJMphxtEPMQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "^20.1.0",
+				"@wdio/reporter": "9.29.1",
+				"@wdio/types": "9.29.1",
+				"allure-js-commons": "^3.3.2",
+				"csv-stringify": "^6.0.4",
+				"html-entities": "^2.6.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "20.19.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+					"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+					"dev": true,
+					"requires": {
+						"undici-types": "~6.21.0"
+					}
+				},
+				"@wdio/logger": {
+					"version": "9.29.1",
+					"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+					"integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^5.1.2",
+						"loglevel": "^1.6.0",
+						"loglevel-plugin-prefix": "^0.8.4",
+						"safe-regex2": "^5.0.0",
+						"strip-ansi": "^7.1.0"
+					}
+				},
+				"@wdio/reporter": {
+					"version": "9.29.1",
+					"resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.29.1.tgz",
+					"integrity": "sha512-CKAcVy9BGwvufokMcl3H+yNcvD11Klku/1BPz8bKSRv7/KzueXR06s1cPbJH3tv9r9zxPErxgdVMpulN8I0qAg==",
+					"dev": true,
+					"requires": {
+						"@types/node": "^20.1.0",
+						"@wdio/logger": "9.29.1",
+						"@wdio/types": "9.29.1",
+						"diff": "^8.0.2",
+						"object-inspect": "^1.12.0"
+					}
+				},
+				"@wdio/types": {
+					"version": "9.29.1",
+					"resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.29.1.tgz",
+					"integrity": "sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==",
+					"dev": true,
+					"requires": {
+						"@types/node": "^20.1.0"
+					}
+				},
+				"chalk": {
+					"version": "5.6.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+					"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+					"dev": true
+				}
+			}
+		},
 		"@wdio/appium-service": {
 			"version": "9.23.0",
 			"resolved": "https://registry.npmjs.org/@wdio/appium-service/-/appium-service-9.23.0.tgz",
@@ -21410,6 +21658,15 @@
 					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 					"optional": true
 				}
+			}
+		},
+		"allure-js-commons": {
+			"version": "3.10.2",
+			"resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.10.2.tgz",
+			"integrity": "sha512-5nAjUF1iNPSQMwKtEsadclSta8C3L705/k/pIzGb9M6P9krgfRaCyaEHt8pkLlCP9NFj5xk3grjtnAhiLeT+Kg==",
+			"dev": true,
+			"requires": {
+				"md5": "^2.3.0"
 			}
 		},
 		"ansi-colors": {
@@ -24977,6 +25234,12 @@
 			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
 			"dev": true
 		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"dev": true
+		},
 		"cheerio": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -25343,6 +25606,12 @@
 				"which": "^2.0.1"
 			}
 		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"dev": true
+		},
 		"css-select": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -25373,6 +25642,12 @@
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
 			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
 			"devOptional": true
+		},
+		"csv-stringify": {
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.2.tgz",
+			"integrity": "sha512-V0md5rBGlZb5WOfUmBWM8tr1+vvbe00EC2+ZhIYPKypA1GLvGuh0NzWEK0L+yRplocH7r37YGoT9uK0r1TtqBQ==",
+			"dev": true
 		},
 		"data-uri-to-buffer": {
 			"version": "6.0.2",
@@ -26793,6 +27068,12 @@
 				}
 			}
 		},
+		"html-entities": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+			"dev": true
+		},
 		"html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -27675,6 +27956,25 @@
 			"resolved": "https://registry.npmjs.org/maybe-combine-errors/-/maybe-combine-errors-1.0.0.tgz",
 			"integrity": "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A==",
 			"dev": true
+		},
+		"md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"requires": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+					"dev": true
+				}
+			}
 		},
 		"media-typer": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"@typescript-eslint/parser": "^8.53.0",
 		"@vitest/coverage-istanbul": "^4.0.8",
 		"@vitest/ui": "^4.0.8",
+		"@wdio/allure-reporter": "^9.30.0",
 		"@wdio/cli": "^9.23.0",
 		"@wdio/globals": "^9.23.0",
 		"@wdio/local-runner": "^9.23.0",
@@ -48,8 +49,8 @@
 		"obsidian": "^1.8.7",
 		"tslib": "^2.8.1",
 		"typescript": "^5.9.2",
-		"vitest": "^4.0.8",
 		"unicorn-magic": "^0.4.0",
+		"vitest": "^4.0.8",
 		"wdio-obsidian-reporter": "^2.4.0",
 		"wdio-obsidian-service": "^2.4.0"
 	},

--- a/test/README.md
+++ b/test/README.md
@@ -61,6 +61,33 @@ npm run test:android
 - **Access**: Downloadable from "Actions" tab → click on workflow run → "Artifacts" section
 - **Note**: GitHub Actions always zips artifacts, even single files
 
+#### Allure Report (step timeline, timing)
+Every E2E job also emits raw Allure results (`allure-results-desktop`,
+`allure-results-android-latest`, `allure-results-android-earliest` artifacts). A combined
+HTML report — with a per-test step timeline and durations — is built by the
+`allure-report` job in `e2e.yml` and uploaded as the `allure-report` build artifact.
+(Not published anywhere yet — download and view locally for now; see below.)
+
+- **Human debugging**: download the `allure-report` artifact from the run's Actions
+  page, unzip it, then serve it locally — Allure's report loads its data via `fetch()`,
+  which browsers block over `file://`, so opening `index.html` directly won't work:
+  ```shell
+  gh run download <run-id> -n allure-report -D /tmp/allure-report
+  npx allure-commandline open /tmp/allure-report
+  ```
+  Each test shows its steps (command execution, DOM queries, screenshots) with timing,
+  so you can see exactly which step stalled or failed without re-reading raw CI logs.
+- **Debugging without the HTML report** (e.g. scripted/agent investigation): download
+  the raw `allure-results-*` artifact instead and read the `*-result.json` files
+  directly — each one has `name`, `status`, `statusDetails.message`/`trace`,
+  `start`/`stop` timestamps, and a `steps[]` array with per-step timing. That's usually
+  faster than navigating the rendered report when you already know what you're looking
+  for:
+  ```shell
+  gh run download <run-id> -n allure-results-desktop -D /tmp/allure
+  jq '{name, status, start, stop, steps: [.steps[] | {name, status}]}' /tmp/allure/*-result.json
+  ```
+
 ### Troubleshooting
 When E2E tests fail:
 1. Check console output for error messages

--- a/test/e2e/wdio.conf.mts
+++ b/test/e2e/wdio.conf.mts
@@ -25,7 +25,16 @@ export const config: WebdriverIO.Config = {
 	})),
 
 	services: ['obsidian'],
-	reporters: ['obsidian'],
+	reporters: [
+		'obsidian',
+		['allure', {
+			// Relative to process.cwd() (repo root when run via `npm run test:e2e`),
+			// not relative to this config file.
+			outputDir: 'allure-results/desktop',
+			disableWebdriverStepsReporting: false,
+			disableWebdriverScreenshotsReporting: false,
+		}],
+	],
 	cacheDir: cacheDir,
 
 	mochaOpts: {

--- a/test/e2e/wdio.mobile.conf.mjs
+++ b/test/e2e/wdio.mobile.conf.mjs
@@ -51,7 +51,16 @@ export const config = {
 		...appiumService,
 	],
 
-	reporters: ['obsidian'],
+	reporters: [
+		'obsidian',
+		['allure', {
+			// Relative to process.cwd() (repo root when run via `npm run test:android`),
+			// not relative to this config file.
+			outputDir: `allure-results/android-${obsidianVersion}`,
+			disableWebdriverStepsReporting: false,
+			disableWebdriverScreenshotsReporting: false,
+		}],
+	],
 	cacheDir: cacheDir,
 
 	mochaOpts: {


### PR DESCRIPTION
## Summary
Stacked on #327 and #331 (base branch will show a clean allure-only diff once those merge).

- Wire `@wdio/allure-reporter` (added in #331) into both wdio configs (desktop `wdio.conf.mts`, android `wdio.mobile.conf.mjs`) — per-test step timeline, DOM queries, screenshots, with timing.
- Upload raw `allure-results-*` as CI artifacts per job/matrix leg.
- New `allure-report` job: merges all `allure-results-*` artifacts, generates a combined HTML report via `allure-commandline`, uploads it as a plain build artifact.
- Deliberately **not** publishing to `gh-pages`/GitHub Pages yet — that needs a repo-settings change and adds real complexity (history checkout, `contents: write`, one-time manual Pages enable). Kept this PR to the simplest thing that works: download the `allure-report` artifact and `npx allure-commandline open <dir>` locally. Can revisit `gh-pages` publishing later if the artifact-download workflow turns out to be too much friction.
- `test/README.md`: documents both the local-view HTML report workflow and reading raw `*-result.json` directly (for scripted/agent debugging — usually faster than the rendered report when you already know what to look for).

## Test plan
- [ ] `allure-report` job runs successfully and produces a downloadable `allure-report` artifact
- [ ] `gh run download <run-id> -n allure-report && npx allure-commandline open <dir>` renders the report with per-test step timing
- [ ] Raw `allure-results-*` artifact contains readable `*-result.json` files

<!-- kody-pr-summary:start -->
This PR enables Allure test reporting for our E2E test suite and publishes the generated report as a CI artifact.

**What's changed:**

- **Allure reporter added to WebdriverIO configurations** (desktop and Android). Each E2E run now collects rich step-level data, timing, and screenshots into `allure-results/`.
- **CI workflow updates**:
  - Raw Allure results from the desktop and Android matrix jobs are uploaded as artifacts.
  - A new `allure-report` job aggregates all raw results from every E2E job into a single tree, generates a combined HTML report, and uploads it as the `allure-report` artifact.
- **Documentation** in `test/README.md` explains how to download the report artifact and serve it locally (Allure requires a local server, not `file://`), plus a faster JSON-level debugging approach using the raw results.
- **Dependencies**: `@wdio/allure-reporter` added; `.gitignore` updated to ignore local `allure-results/` and related directories.

The report is not published to any hosted location yet—it's available as a downloadable artifact from each workflow run. This gives us per-test step timelines and timings, making it easier to pinpoint slow or failing steps without digging through raw CI logs.
<!-- kody-pr-summary:end -->