### PR TITLE
build(deps-dev): add @wdio/allure-reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"@typescript-eslint/parser": "^8.53.0",
 				"@vitest/coverage-istanbul": "^4.0.8",
 				"@vitest/ui": "^4.0.8",
+				"@wdio/allure-reporter": "^9.30.0",
 				"@wdio/cli": "^9.23.0",
 				"@wdio/globals": "^9.23.0",
 				"@wdio/local-runner": "^9.23.0",
@@ -3889,6 +3890,95 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@wdio/allure-reporter": {
+			"version": "9.30.0",
+			"resolved": "https://registry.npmjs.org/@wdio/allure-reporter/-/allure-reporter-9.30.0.tgz",
+			"integrity": "sha512-hV/TNy7x1ENkX5cfWLN4CyVczfqBQYWqGdNhRdtX6+8nZFwRBtMRcC770MABFJyeVZzwAvyliZNgJMphxtEPMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0",
+				"@wdio/reporter": "9.29.1",
+				"@wdio/types": "9.29.1",
+				"allure-js-commons": "^3.3.2",
+				"csv-stringify": "^6.0.4",
+				"html-entities": "^2.6.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/@types/node": {
+			"version": "20.19.43",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+			"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/@wdio/logger": {
+			"version": "9.29.1",
+			"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+			"integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.1.2",
+				"loglevel": "^1.6.0",
+				"loglevel-plugin-prefix": "^0.8.4",
+				"safe-regex2": "^5.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/@wdio/reporter": {
+			"version": "9.29.1",
+			"resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.29.1.tgz",
+			"integrity": "sha512-CKAcVy9BGwvufokMcl3H+yNcvD11Klku/1BPz8bKSRv7/KzueXR06s1cPbJH3tv9r9zxPErxgdVMpulN8I0qAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0",
+				"@wdio/logger": "9.29.1",
+				"@wdio/types": "9.29.1",
+				"diff": "^8.0.2",
+				"object-inspect": "^1.12.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/@wdio/types": {
+			"version": "9.29.1",
+			"resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.29.1.tgz",
+			"integrity": "sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^20.1.0"
+			},
+			"engines": {
+				"node": ">=18.20.0"
+			}
+		},
+		"node_modules/@wdio/allure-reporter/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/@wdio/appium-service": {
 			"version": "9.23.0",
 			"resolved": "https://registry.npmjs.org/@wdio/appium-service/-/appium-service-9.23.0.tgz",
@@ -4822,6 +4912,24 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/allure-js-commons": {
+			"version": "3.10.2",
+			"resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.10.2.tgz",
+			"integrity": "sha512-5nAjUF1iNPSQMwKtEsadclSta8C3L705/k/pIzGb9M6P9krgfRaCyaEHt8pkLlCP9NFj5xk3grjtnAhiLeT+Kg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"md5": "^2.3.0"
+			},
+			"peerDependencies": {
+				"allure-playwright": "3.10.2"
+			},
+			"peerDependenciesMeta": {
+				"allure-playwright": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -5175,6 +5283,16 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/@img/colour": {
@@ -10102,6 +10220,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/cheerio": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -10648,6 +10776,16 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/css-select": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -10690,6 +10828,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
 			}
+		},
+		"node_modules/csv-stringify": {
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.2.tgz",
+			"integrity": "sha512-V0md5rBGlZb5WOfUmBWM8tr1+vvbe00EC2+ZhIYPKypA1GLvGuh0NzWEK0L+yRplocH7r37YGoT9uK0r1TtqBQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/data-uri-to-buffer": {
 			"version": "6.0.2",
@@ -12754,6 +12899,23 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"node_modules/html-entities": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/mdevils"
+				},
+				{
+					"type": "patreon",
+					"url": "https://patreon.com/mdevils"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -14017,6 +14179,25 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
+		"node_modules/md5/node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/media-typer": {
 			"version": "1.1.1",
@@ -20735,6 +20916,73 @@
 				"tinyrainbow": "^3.0.3"
 			}
 		},
+		"@wdio/allure-reporter": {
+			"version": "9.30.0",
+			"resolved": "https://registry.npmjs.org/@wdio/allure-reporter/-/allure-reporter-9.30.0.tgz",
+			"integrity": "sha512-hV/TNy7x1ENkX5cfWLN4CyVczfqBQYWqGdNhRdtX6+8nZFwRBtMRcC770MABFJyeVZzwAvyliZNgJMphxtEPMQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "^20.1.0",
+				"@wdio/reporter": "9.29.1",
+				"@wdio/types": "9.29.1",
+				"allure-js-commons": "^3.3.2",
+				"csv-stringify": "^6.0.4",
+				"html-entities": "^2.6.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "20.19.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+					"integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+					"dev": true,
+					"requires": {
+						"undici-types": "~6.21.0"
+					}
+				},
+				"@wdio/logger": {
+					"version": "9.29.1",
+					"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+					"integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^5.1.2",
+						"loglevel": "^1.6.0",
+						"loglevel-plugin-prefix": "^0.8.4",
+						"safe-regex2": "^5.0.0",
+						"strip-ansi": "^7.1.0"
+					}
+				},
+				"@wdio/reporter": {
+					"version": "9.29.1",
+					"resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.29.1.tgz",
+					"integrity": "sha512-CKAcVy9BGwvufokMcl3H+yNcvD11Klku/1BPz8bKSRv7/KzueXR06s1cPbJH3tv9r9zxPErxgdVMpulN8I0qAg==",
+					"dev": true,
+					"requires": {
+						"@types/node": "^20.1.0",
+						"@wdio/logger": "9.29.1",
+						"@wdio/types": "9.29.1",
+						"diff": "^8.0.2",
+						"object-inspect": "^1.12.0"
+					}
+				},
+				"@wdio/types": {
+					"version": "9.29.1",
+					"resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.29.1.tgz",
+					"integrity": "sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==",
+					"dev": true,
+					"requires": {
+						"@types/node": "^20.1.0"
+					}
+				},
+				"chalk": {
+					"version": "5.6.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+					"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+					"dev": true
+				}
+			}
+		},
 		"@wdio/appium-service": {
 			"version": "9.23.0",
 			"resolved": "https://registry.npmjs.org/@wdio/appium-service/-/appium-service-9.23.0.tgz",
@@ -21410,6 +21658,15 @@
 					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 					"optional": true
 				}
+			}
+		},
+		"allure-js-commons": {
+			"version": "3.10.2",
+			"resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.10.2.tgz",
+			"integrity": "sha512-5nAjUF1iNPSQMwKtEsadclSta8C3L705/k/pIzGb9M6P9krgfRaCyaEHt8pkLlCP9NFj5xk3grjtnAhiLeT+Kg==",
+			"dev": true,
+			"requires": {
+				"md5": "^2.3.0"
 			}
 		},
 		"ansi-colors": {
@@ -24977,6 +25234,12 @@
 			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
 			"dev": true
 		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"dev": true
+		},
 		"cheerio": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -25343,6 +25606,12 @@
 				"which": "^2.0.1"
 			}
 		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"dev": true
+		},
 		"css-select": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -25373,6 +25642,12 @@
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
 			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
 			"devOptional": true
+		},
+		"csv-stringify": {
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.2.tgz",
+			"integrity": "sha512-V0md5rBGlZb5WOfUmBWM8tr1+vvbe00EC2+ZhIYPKypA1GLvGuh0NzWEK0L+yRplocH7r37YGoT9uK0r1TtqBQ==",
+			"dev": true
 		},
 		"data-uri-to-buffer": {
 			"version": "6.0.2",
@@ -26793,6 +27068,12 @@
 				}
 			}
 		},
+		"html-entities": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+			"dev": true
+		},
 		"html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -27675,6 +27956,25 @@
 			"resolved": "https://registry.npmjs.org/maybe-combine-errors/-/maybe-combine-errors-1.0.0.tgz",
 			"integrity": "sha512-eefp6IduNPT6fVdwPp+1NgD0PML1NU5P6j1Mj5nz1nidX8/sWY7119WL8vTAHgqfsY74TzW0w1XPgdYEKkGZ5A==",
 			"dev": true
+		},
+		"md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"requires": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+					"dev": true
+				}
+			}
 		},
 		"media-typer": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"@typescript-eslint/parser": "^8.53.0",
 		"@vitest/coverage-istanbul": "^4.0.8",
 		"@vitest/ui": "^4.0.8",
+		"@wdio/allure-reporter": "^9.30.0",
 		"@wdio/cli": "^9.23.0",
 		"@wdio/globals": "^9.23.0",
 		"@wdio/local-runner": "^9.23.0",
@@ -48,8 +49,8 @@
 		"obsidian": "^1.8.7",
 		"tslib": "^2.8.1",
 		"typescript": "^5.9.2",
-		"vitest": "^4.0.8",
 		"unicorn-magic": "^0.4.0",
+		"vitest": "^4.0.8",
 		"wdio-obsidian-reporter": "^2.4.0",
 		"wdio-obsidian-service": "^2.4.0"
 	},


### PR DESCRIPTION
## Summary
Stacked on #327 (base branch will show a clean dependency-only diff once that merges).

Adds `@wdio/allure-reporter` as a devDependency, split into its own dedicated commit/PR per this repo's release-anti-pattern check (version files can't change alongside code files in the same PR). The actual wiring that uses it is in #328, stacked on top of this.

## Test plan
- [ ] `npm ci --legacy-peer-deps` installs cleanly

---

<!-- kody-pr-summary:start -->
## Summary

This PR adds the `@wdio/allure-reporter` development dependency and makes related CI/test hardening changes to address a breaking Obsidian 1.13.x change that affected the E2E settings flow.

## Changes

- **Added `@wdio/allure-reporter` (`^9.30.0`)** as a dev dependency, with corresponding `package-lock.json` updates, to enable Allure-formatted test reports from WebdriverIO E2E runs.
- **Pinned the Android E2E matrix** in `.github/workflows/e2e.yml` from floating `latest` to Obsidian `1.12.7`, because Obsidian `1.13.4` broke the `app:open-settings` flow on Android as well as desktop. The version will now be bumped deliberately after verification.
- **Updated the AVD cache step** in the Android workflow: bumped the cache key to `avd-v2-...` and removed `~/.android/adb*` from the cached paths.
- **Hardened the E2E settings-open test** in `test/e2e/basic.e2e.ts`:
  - Disables the new Obsidian 1.13+ `settingsPopoutWindow` setting so Settings opens as an in-page modal as expected by the test DOM queries.
  - Closes an existing popped-out settings singleton before opening, with platform-safe guards (no unconditional close on Android, where popout is not applicable).
  - Wraps the workaround in both in-page and bridge-level try/catch so a platform-specific failure does not block the test.
  - Replaces the fixed `browser.pause(500)` after `app:open-settings` with a `waitUntil` poll (up to 5 seconds) for the FIT settings tab.
  - Adds diagnostic DOM/state logging and an extra screenshot when the FIT tab cannot be found, to make future root-cause analysis easier.
- **Added a troubleshooting section** to `test/README.md` documenting how to investigate "passed on PR, failed after merge" scenarios, emphasizing floating external-version pins (Obsidian, browsers, tools) as a common root cause and warning against assuming race conditions, cache issues, or upstream flakes without evidence.
<!-- kody-pr-summary:end -->