### PR TITLE
feat: item-level three-way merge for .canvas files via on-demand base blob fetch

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -709,17 +709,17 @@ interface JsonMergeSpec {
 }
 ```
 
-`mergeJson(local, remote, spec)` returns `{ merged: true, value }` or `{ merged: false, reason }`. Canvas uses a hardcoded spec (`CANVAS_MERGE_SPEC`); the interface is designed for future `.fitattributes` parameterization.
+`mergeJson(local, remote, spec)` returns `{ merged: true, value }` or `{ merged: false, reason }`. Canvas uses a hardcoded spec (`CANVAS_MERGE_SPEC`); the interface is designed for future `.fitattributes` parameterization (#337).
 
-### Future extension: `.fitattributes`
+### Future extension: `.fitattributes` (#337)
 
-Canvas merge is the first use of the merge engine. A follow-up FR will add a `.fitattributes` file (analogous to `.gitattributes`) where users can declare:
+Canvas merge is the first use of the merge engine. #337 will add a `.fitattributes` file (analogous to `.gitattributes`) where users can declare:
 - Additional paths to merge with keyed-array semantics
 - Order-significance selectors (opt arrays into index-based merge)
-- Field exclusion selectors (ignore specific JSON paths during comparison)
+- Field exclusion selectors (ignore specific JSON paths during comparison) — required for #67
 - Text-mode policies (`always-local`, `always-remote`) for non-JSON files
 
-Until `.fitattributes` is implemented, only `.canvas` files use semantic merge.
+Until #337 is implemented, only `.canvas` files use semantic merge.
 
 ## Explain Sync Status
 

--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -686,18 +686,26 @@ Some file types can be merged automatically even when both local and remote chan
 
 ### Canvas files (`.canvas`)
 
-Canvas files are JSON with the schema `{ nodes: [{id, ...}], edges: [{id, ...}] }`. Both arrays are **id-keyed sets** — element order is not meaningful (position is encoded in `x`/`y` fields, not array index). Two devices editing the same canvas independently almost always produce disjoint additions, making set-union merge safe and correct.
+Canvas files are JSON with the schema `{ nodes: [{id, ...}], edges: [{id, ...}] }`. Both arrays are **id-keyed sets** — element order is not meaningful (position is encoded in `x`/`y` fields, not array index). Two devices editing the same canvas independently most often produce disjoint changes, and even overlapping changes on different fields of the same node can be resolved unambiguously with a merge base.
+
+**Three-way merge base:** Before running merges for confirmed-clashing canvas files, FIT fetches the base version — the content as of the last successful sync — directly from GitHub using `lastFetchedRemoteShas[path]` as the blob SHA. All base fetches run in parallel before any merges are attempted. If a fetch fails (network error, or path is in `pendingClashes` where the base semantics are ambiguous), the merge falls back gracefully to two-way behavior.
 
 **Merge semantics:**
-- Nodes/edges arrays: union by `id`; per-element conflict (same `id`, different content) → falls back to `_fit/` clash file
-- Items with matching `id` and identical content → no conflict, no duplication
+- Nodes/edges arrays: merged by `id`, order-agnostic (array reordering on one side doesn't cause spurious conflicts; remote item order is preserved, local-only additions appended)
+- Items with matching `id` and identical content on both sides → no conflict, taken as-is
+- Items with matching `id` but different content → three-way resolution using base item:
+  - Base matches remote → remote didn't change it; take local version
+  - Base matches local → local didn't change it; take remote version
+  - Base matches neither → both sides genuinely changed the same item → falls back to `_fit/` clash file
+  - Base unavailable → any same-id difference → falls back to `_fit/` clash file (two-way fallback)
+- Items only on one side → included from that side (set-union)
 - Other top-level keys present in both: equal values → included; different values → falls back to `_fit/` clash file (no silent data loss)
 - Keys present on only one side → included from that side
 - Parse failure or non-object root → falls back to `_fit/` clash file
 
 **Result:** merged content written to the local file, SHA stored in baseline, path excluded from `pendingClashes`. From the user's perspective, no clash ever occurred.
 
-**Implementation:** [`src/util/jsonMerge.ts`](../src/util/jsonMerge.ts) (merge engine + `CANVAS_MERGE_SPEC`), [`src/fitSync.ts`](../src/fitSync.ts) (canvas auto-merge block before `clashFiles` computation)
+**Implementation:** [`src/util/jsonMerge.ts`](../src/util/jsonMerge.ts) (merge engine + `CANVAS_MERGE_SPEC`), [`src/remoteGitHubVault.ts`](../src/remoteGitHubVault.ts) (`readFileBlobBySha` for base fetch), [`src/fitSync.ts`](../src/fitSync.ts) (parallel base pre-fetch + canvas auto-merge block before `clashFiles` computation)
 
 ### Merge engine design (`JsonMergeSpec`)
 
@@ -709,7 +717,7 @@ interface JsonMergeSpec {
 }
 ```
 
-`mergeJson(local, remote, spec)` returns `{ merged: true, value }` or `{ merged: false, reason }`. Canvas uses a hardcoded spec (`CANVAS_MERGE_SPEC`); the interface is designed for future `.fitattributes` parameterization (#337).
+`mergeJson(base, local, remote, spec)` returns `{ merged: true, value }` or `{ merged: false, reason }`. `base` is `null` when unavailable; the engine degrades to two-way merge in that case (same-id item difference → immediate conflict, no three-way resolution). Canvas uses a hardcoded spec (`CANVAS_MERGE_SPEC`); the interface is designed for future `.fitattributes` parameterization (#337).
 
 ### Future extension: `.fitattributes` (#337)
 

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -52,7 +52,6 @@ export class Fit {
 	unpushedFiles: FileStates;              // Files skipped due to API size limit (422)
 	pendingClashes: string[];               // Paths with unresolved _fit/ copies
 	protectedPathShas: FileStates;          // Remote SHAs for paths excluded by shouldSyncPath (dedup cache)
-	cachedMergeableContents: Record<string, string> = {}; // In-memory cache; last-synced content for merge-eligible paths (e.g. .canvas)
 	obsidianSyncRules: ObsidianSyncRules;
 	localVault: LocalVault;                 // Local vault (tracks local file state)
 	remoteVault: RemoteGitHubVault;

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -52,6 +52,7 @@ export class Fit {
 	unpushedFiles: FileStates;              // Files skipped due to API size limit (422)
 	pendingClashes: string[];               // Paths with unresolved _fit/ copies
 	protectedPathShas: FileStates;          // Remote SHAs for paths excluded by shouldSyncPath (dedup cache)
+	cachedMergeableContents: Record<string, string> = {}; // In-memory cache; last-synced content for merge-eligible paths (e.g. .canvas)
 	obsidianSyncRules: ObsidianSyncRules;
 	localVault: LocalVault;                 // Local vault (tracks local file state)
 	remoteVault: RemoteGitHubVault;

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -2647,6 +2647,36 @@ describe('FitSync', () => {
 			expect(merged.edges.map((e: any) => e.id)).toEqual(expect.arrayContaining(['e1', 'e2']));
 		});
 
+		it('three-way merge resolves same-node position change vs remote addition without clash', async () => {
+			// Discriminating case: local moved node 'a'; remote added node 'b' and left 'a' unchanged.
+			// Two-way merge (no base) sees a@local != a@remote → conflict.
+			// Three-way merge sees base_item == remote_item for 'a' → remote unchanged → local wins.
+			const fitSync = createFitSync();
+
+			// Sync 1: establish baseline so lastFetchedRemoteShas has the initial blob SHA.
+			const initialCanvas = canvasJson([node('a', 0, 0)]);
+			localVault.setFile('board.canvas', initialCanvas);
+			await remoteVault.setFile('board.canvas', initialCanvas);
+			await syncAndHandleResult(fitSync, createMockNotice());
+
+			// Both sides diverge from the baseline.
+			localVault.setFile('board.canvas', canvasJson([node('a', 100, 100)]));       // local: 'a' moved
+			await remoteVault.setFile('board.canvas', canvasJson([node('a', 0, 0), node('b', 200, 200)])); // remote: 'b' added, 'a' untouched
+
+			// Sync 2: three-way merge should resolve without a clash file.
+			const result = await syncAndHandleResult(fitSync, createMockNotice());
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+
+			const files = localVault.getAllFilesAsRaw();
+			expect(files).not.toHaveProperty('_fit/board.canvas');
+
+			const merged = JSON.parse(files['board.canvas']);
+			const nodeA = merged.nodes.find((n: { id: string }) => n.id === 'a');
+			const nodeB = merged.nodes.find((n: { id: string }) => n.id === 'b');
+			expect(nodeA).toMatchObject({ id: 'a', x: 100, y: 100 }); // local position wins (remote didn't change it)
+			expect(nodeB).toMatchObject({ id: 'b' });                   // remote addition included
+		});
+
 		it('non-canvas files with clashes still go to _fit/ unaffected', async () => {
 			const fitSync = createFitSync();
 			localVault.setFile('note.md', 'local version');

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -486,36 +486,55 @@ export class FitSync implements IFitSync {
 		// Successful merges bypass _fit/ entirely; the merged result is written locally and
 		// pushed on the next sync. mergedPaths tells applyRemoteChanges these are safe to
 		// write even when not yet in localShas (caller already incorporated local content).
+		const canvasClashCandidates = clashes
+			.filter(c => c.remoteOp !== 'REMOVED')
+			.filter(c => !pendingReminderPaths.has(c.path))
+			.filter(c => c.path.endsWith('.canvas'));
+
+		// Pre-fetch base blobs in parallel before running merges (three-way merge base).
+		// Base = content at last successful sync = lastFetchedRemoteShas blob SHA.
+		const canvasBaseTexts = new Map<string, string | null>();
+		await Promise.all(canvasClashCandidates.map(async (clash) => {
+			const baseSha = this.fit.lastFetchedRemoteShas[clash.path];
+			if (!baseSha) { canvasBaseTexts.set(clash.path, null); return; }
+			try {
+				const content = await this.fit.remoteVault.readFileBlobBySha(baseSha);
+				canvasBaseTexts.set(clash.path, content.toPlainText());
+				fitLogger.log('... [FitSync] Fetched base blob for canvas merge', { path: clash.path, sha: baseSha });
+			} catch (e) {
+				fitLogger.log('... [FitSync] Base blob fetch failed, falling back to two-way merge', { path: clash.path, sha: baseSha, error: String(e) });
+				canvasBaseTexts.set(clash.path, null);
+			}
+		}));
+
 		const autoMergedCanvasClashes: Array<{path: string, content: FileContent}> = [];
 		const autoMergeFailedClashPaths = new Set<string>();
 
 		await Promise.all(
-			clashes
-				.filter(c => c.remoteOp !== 'REMOVED')
-				.filter(c => !pendingReminderPaths.has(c.path))
-				.filter(c => c.path.endsWith('.canvas'))
-				.map(async (clash) => {
-					const remoteContent = await this.fit.remoteVault.readFileContent(clash.path).catch(() => null);
-					const localContent = await this.fit.localVault.readFileContent(clash.path).catch(() => null);
-					if (remoteContent === null || localContent === null) {
-						autoMergeFailedClashPaths.add(clash.path);
-						return;
-					}
-					const baseText = this.fit.cachedMergeableContents[clash.path] ?? null;
-					const result = mergeJson(baseText, localContent.toPlainText(), remoteContent.toPlainText(), CANVAS_MERGE_SPEC);
-					if (!result.merged) {
-						fitLogger.log('[FitSync] Canvas auto-merge failed, falling back to clash', {
-							path: clash.path, reason: result.reason,
-						});
-						autoMergeFailedClashPaths.add(clash.path);
-						return;
-					}
-					this.fit.cachedMergeableContents[clash.path] = serialiseMerged(result.value);
-					autoMergedCanvasClashes.push({
-						path: clash.path,
-						content: FileContent.fromPlainText(serialiseMerged(result.value)),
+			canvasClashCandidates.map(async (clash) => {
+				const remoteContent = await this.fit.remoteVault.readFileContent(clash.path).catch(() => null);
+				const localContent = await this.fit.localVault.readFileContent(clash.path).catch(() => null);
+				if (remoteContent === null || localContent === null) {
+					autoMergeFailedClashPaths.add(clash.path);
+					return;
+				}
+				const baseText = canvasBaseTexts.get(clash.path) ?? null;
+				const result = mergeJson(baseText, localContent.toPlainText(), remoteContent.toPlainText(), CANVAS_MERGE_SPEC);
+				if (!result.merged) {
+					fitLogger.log('.. [FitSync] Canvas auto-merge failed, falling back to clash', {
+						path: clash.path, reason: result.reason,
 					});
-				})
+					autoMergeFailedClashPaths.add(clash.path);
+					return;
+				}
+				fitLogger.log('.. [FitSync] Canvas auto-merge succeeded', {
+					path: clash.path, hadBase: baseText !== null,
+				});
+				autoMergedCanvasClashes.push({
+					path: clash.path,
+					content: FileContent.fromPlainText(serialiseMerged(result.value)),
+				});
+			})
 		);
 
 		const clashFiles = await Promise.all(
@@ -596,26 +615,6 @@ export class FitSync implements IFitSync {
 			});
 		}
 
-		// Populate merge base cache for successfully synced canvas files.
-		// Pulled canvas files: content already in memory from the download.
-		for (const item of addToLocalNonClashed) {
-			if (item.path.endsWith('.canvas')) {
-				this.fit.cachedMergeableContents[item.path] = item.content.toPlainText();
-			}
-		}
-		// Pushed canvas files: local content is now the shared base.
-		for (const change of safeLocal) {
-			if (change.type !== 'REMOVED' && change.path.endsWith('.canvas')) {
-				try {
-					const content = await this.fit.localVault.readFileContent(change.path);
-					this.fit.cachedMergeableContents[change.path] = content.toPlainText();
-				} catch {
-					// Best-effort; stale entry cleared so next sync falls back to two-way merge
-					delete this.fit.cachedMergeableContents[change.path];
-				}
-			}
-		}
-
 		// 3b'. Track protected path SHA arrivals for opt-in reconciliation.
 		// Remote changes to paths excluded by shouldSyncPath (e.g. .obsidian/ not opted in).
 		// Only the remote SHA is recorded — no content download, no _fit/ write.
@@ -646,7 +645,6 @@ export class FitSync implements IFitSync {
 		// Remove deleted files from state
 		for (const path of deleteFromLocalNonClashed) {
 			delete newLocalState[path];
-			delete this.fit.cachedMergeableContents[path];
 		}
 
 		// Update pendingClashes: newly-clashed tracked files enter pending state.
@@ -662,8 +660,6 @@ export class FitSync implements IFitSync {
 					this.fit.pendingClashes.push(clash.path);
 				}
 				delete newLocalState[clash.path];
-				// Stale base would corrupt the next merge attempt after the user resolves this clash.
-				delete this.fit.cachedMergeableContents[clash.path];
 			}
 		}
 
@@ -739,7 +735,7 @@ export class FitSync implements IFitSync {
 		return {
 			localOps: localFileOpsRecord.changes,
 			remoteOps: pushedChanges,
-			conflicts: clashes,
+			conflicts: clashes.filter(c => !mergedPaths.has(c.path)),
 			newlySkippedPaths,
 			skippedWarning: pushResult?.skippedWarning,
 			rateLimitedPaths,

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -610,7 +610,8 @@ export class FitSync implements IFitSync {
 					const content = await this.fit.localVault.readFileContent(change.path);
 					this.fit.cachedMergeableContents[change.path] = content.toPlainText();
 				} catch {
-					// Best-effort; absent entry falls back to two-way merge next sync
+					// Best-effort; stale entry cleared so next sync falls back to two-way merge
+					delete this.fit.cachedMergeableContents[change.path];
 				}
 			}
 		}

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -501,7 +501,8 @@ export class FitSync implements IFitSync {
 						autoMergeFailedClashPaths.add(clash.path);
 						return;
 					}
-					const result = mergeJson(null, localContent.toPlainText(), remoteContent.toPlainText(), CANVAS_MERGE_SPEC);
+					const baseText = this.fit.cachedMergeableContents[clash.path] ?? null;
+					const result = mergeJson(baseText, localContent.toPlainText(), remoteContent.toPlainText(), CANVAS_MERGE_SPEC);
 					if (!result.merged) {
 						fitLogger.log('[FitSync] Canvas auto-merge failed, falling back to clash', {
 							path: clash.path, reason: result.reason,
@@ -509,6 +510,7 @@ export class FitSync implements IFitSync {
 						autoMergeFailedClashPaths.add(clash.path);
 						return;
 					}
+					this.fit.cachedMergeableContents[clash.path] = serialiseMerged(result.value);
 					autoMergedCanvasClashes.push({
 						path: clash.path,
 						content: FileContent.fromPlainText(serialiseMerged(result.value)),
@@ -594,6 +596,25 @@ export class FitSync implements IFitSync {
 			});
 		}
 
+		// Populate merge base cache for successfully synced canvas files.
+		// Pulled canvas files: content already in memory from the download.
+		for (const item of addToLocalNonClashed) {
+			if (item.path.endsWith('.canvas')) {
+				this.fit.cachedMergeableContents[item.path] = item.content.toPlainText();
+			}
+		}
+		// Pushed canvas files: local content is now the shared base.
+		for (const change of safeLocal) {
+			if (change.type !== 'REMOVED' && change.path.endsWith('.canvas')) {
+				try {
+					const content = await this.fit.localVault.readFileContent(change.path);
+					this.fit.cachedMergeableContents[change.path] = content.toPlainText();
+				} catch {
+					// Best-effort; absent entry falls back to two-way merge next sync
+				}
+			}
+		}
+
 		// 3b'. Track protected path SHA arrivals for opt-in reconciliation.
 		// Remote changes to paths excluded by shouldSyncPath (e.g. .obsidian/ not opted in).
 		// Only the remote SHA is recorded — no content download, no _fit/ write.
@@ -624,6 +645,7 @@ export class FitSync implements IFitSync {
 		// Remove deleted files from state
 		for (const path of deleteFromLocalNonClashed) {
 			delete newLocalState[path];
+			delete this.fit.cachedMergeableContents[path];
 		}
 
 		// Update pendingClashes: newly-clashed tracked files enter pending state.
@@ -639,6 +661,8 @@ export class FitSync implements IFitSync {
 					this.fit.pendingClashes.push(clash.path);
 				}
 				delete newLocalState[clash.path];
+				// Stale base would corrupt the next merge attempt after the user resolves this clash.
+				delete this.fit.cachedMergeableContents[clash.path];
 			}
 		}
 

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -516,6 +516,32 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 	// ===== GitHub Utility Operations (not part of IVault) =====
 
 	/**
+	 * Fetch file content by blob SHA, bypassing path lookup.
+	 * Use when you need a specific historical version (e.g. merge base from lastFetchedRemoteShas).
+	 */
+	async readFileBlobBySha(sha: BlobSha): Promise<FileContent> {
+		try {
+			const { data: blob } = await this.octokit.request(
+				`GET /repos/{owner}/{repo}/git/blobs/{file_sha}`, {
+					owner: this.owner,
+					repo: this.repo,
+					file_sha: sha,
+					headers: this.headers
+				});
+			if (typeof blob.content !== 'string') {
+				throw new Error(`Blob ${sha}: unexpected content type ${typeof blob.content}`);
+			}
+			let content = blob.content;
+			if (Encryption.isEnabled()) {
+				content = await Encryption.decryptContent(content);
+			}
+			return FileContent.fromBase64(content);
+		} catch (error) {
+			return await this.wrapOctokitError(error, 'ignore');
+		}
+	}
+
+	/**
 	 * Check if repository exists and is accessible
 	 * Result is cached to avoid repeated API calls during error handling.
 	 * @returns true if repository exists, false if 404 (not found)

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -927,6 +927,14 @@ export class FakeRemoteVault implements IVault<"remote"> {
 		return FileContent.fromBase64(content.toBase64());
 	}
 
+	async readFileBlobBySha(sha: BlobSha): Promise<FileContent> {
+		const base64 = this.blobShas.get(sha);
+		if (base64 === undefined) {
+			throw new Error(`Blob SHA not found: ${sha}`);
+		}
+		return FileContent.fromBase64(base64);
+	}
+
 	async applyChanges(
 		filesToWrite: Array<{path: string, content: FileContent}>,
 		filesToDelete: Array<string>,

--- a/src/util/jsonMerge.test.ts
+++ b/src/util/jsonMerge.test.ts
@@ -124,11 +124,43 @@ describe('mergeJson', () => {
 			expect(result).toMatchObject({ merged: false, reason: expect.stringContaining('items') });
 		});
 
+		it('one-sided keyed array with base confirms new addition, includes it', () => {
+			const base = JSON.stringify({});
+			const local = JSON.stringify({ items: [{ id: 'a' }] });
+			const remote = JSON.stringify({});
+			const result = mergeJson(base, local, remote, spec);
+			expect(result).toEqual({ merged: true, value: { items: [{ id: 'a' }] } });
+		});
+
 		it('remote-only keyed array without base falls back (ambiguous addition vs deletion)', () => {
 			const local = JSON.stringify({});
 			const remote = JSON.stringify({ items: [{ id: 'a' }] });
 			const result = mergeJson(null, local, remote, spec);
 			expect(result).toMatchObject({ merged: false, reason: expect.stringContaining('items') });
+		});
+
+		it('remote-only keyed array with base confirms new addition, includes it', () => {
+			const base = JSON.stringify({});
+			const local = JSON.stringify({});
+			const remote = JSON.stringify({ items: [{ id: 'a' }] });
+			const result = mergeJson(base, local, remote, spec);
+			expect(result).toEqual({ merged: true, value: { items: [{ id: 'a' }] } });
+		});
+
+		it('non-keyed key deleted by both sides is omitted from result', () => {
+			const base = JSON.stringify({ staleKey: 'old' });
+			const local = JSON.stringify({});
+			const remote = JSON.stringify({});
+			const result = mergeJson(base, local, remote, spec);
+			expect(result).toEqual({ merged: true, value: {} });
+		});
+
+		it('non-keyed key conflict is still a clash when base is provided', () => {
+			const base = JSON.stringify({ key: 'original' });
+			const local = JSON.stringify({ key: 'local-edit' });
+			const remote = JSON.stringify({ key: 'remote-edit' });
+			const result = mergeJson(base, local, remote, spec);
+			expect(result).toMatchObject({ merged: false, reason: expect.stringContaining('key') });
 		});
 	});
 

--- a/src/util/jsonMerge.test.ts
+++ b/src/util/jsonMerge.test.ts
@@ -59,6 +59,30 @@ describe('mergeJson', () => {
 			expect(result).toMatchObject({ merged: false, reason: expect.stringContaining('a') });
 		});
 
+		it('three-way: remote unchanged from base → local edit wins', () => {
+			const base = JSON.stringify({ items: [{ id: 'a', val: 'base' }] });
+			const local = JSON.stringify({ items: [{ id: 'a', val: 'local' }] });
+			const remote = JSON.stringify({ items: [{ id: 'a', val: 'base' }] }); // remote unchanged
+			const result = mergeJson(base, local, remote, spec);
+			expect(result).toEqual({ merged: true, value: { items: [{ id: 'a', val: 'local' }] } });
+		});
+
+		it('three-way: local unchanged from base → remote edit wins', () => {
+			const base = JSON.stringify({ items: [{ id: 'a', val: 'base' }] });
+			const local = JSON.stringify({ items: [{ id: 'a', val: 'base' }] }); // local unchanged
+			const remote = JSON.stringify({ items: [{ id: 'a', val: 'remote' }] });
+			const result = mergeJson(base, local, remote, spec);
+			expect(result).toEqual({ merged: true, value: { items: [{ id: 'a', val: 'remote' }] } });
+		});
+
+		it('three-way: both sides changed same item → genuine conflict', () => {
+			const base = JSON.stringify({ items: [{ id: 'a', val: 'base' }] });
+			const local = JSON.stringify({ items: [{ id: 'a', val: 'local' }] });
+			const remote = JSON.stringify({ items: [{ id: 'a', val: 'remote' }] });
+			const result = mergeJson(base, local, remote, spec);
+			expect(result).toMatchObject({ merged: false, reason: expect.stringContaining('a') });
+		});
+
 		it('same-id with identical content is not a conflict', () => {
 			const local = JSON.stringify({ items: [{ id: 'a', val: 'same' }] });
 			const remote = JSON.stringify({ items: [{ id: 'a', val: 'same' }] });

--- a/src/util/jsonMerge.ts
+++ b/src/util/jsonMerge.ts
@@ -44,10 +44,15 @@ export type MergeResult =
 /**
  * Merge two JSON strings using the given spec.
  *
+ * @param baseText   - Base file content (content at last sync); null if unavailable
  * @param localText  - Local file content (UTF-8 JSON string)
  * @param remoteText - Remote file content (UTF-8 JSON string)
  * @param spec       - Merge spec describing keyed arrays and exclusions
- * @returns MergeResult: merged JSON string on success, or reason for failure
+ * @returns MergeResult: merged value on success, or reason for failure
+ *
+ * When baseText is null, one-sided key/array presence is treated as unknown-intent
+ * and falls back to merged:false (conservative). When baseText is provided, the
+ * base is used to distinguish additions from deletions.
  */
 export function mergeJson(
 	baseText: string | null,
@@ -68,16 +73,20 @@ export function mergeJson(
 		return { merged: false, reason: 'remote content is not valid JSON' };
 	}
 
+	let base: unknown = null;
+	if (baseText !== null) {
+		try {
+			base = JSON.parse(baseText);
+		} catch {
+			base = null; // unparseable base → fall back to no-base behaviour
+		}
+	}
+
 	if (typeof local !== 'object' || local === null || Array.isArray(local)) {
 		return { merged: false, reason: 'local JSON root is not an object' };
 	}
 	if (typeof remote !== 'object' || remote === null || Array.isArray(remote)) {
 		return { merged: false, reason: 'remote JSON root is not an object' };
-	}
-
-	let base: unknown = null;
-	if (baseText !== null) {
-		try { base = JSON.parse(baseText); } catch { /* unparseable base → no-base behaviour */ }
 	}
 	const baseObj = (typeof base === 'object' && base !== null && !Array.isArray(base))
 		? base as Record<string, unknown>
@@ -100,8 +109,9 @@ type ArrayMergeResult =
  * - Keys in spec.keyedArrays → id-keyed set merge
  * - Other keys present in both, equal → include unchanged
  * - Other keys present in both, different → conflict (merged: false); no silent data loss
- * - Keys/arrays present on only one side → conflict (no base available to distinguish addition from deletion)
- *   Base-aware three-way resolution is implemented in the next PR (powpvpwx).
+ * - Keys present in only one side:
+ *   - base provided: check whether the absent side deleted it or the present side added it
+ *   - base null: unknown intent → conflict (conservative)
  */
 function mergeObjects(
 	base: Record<string, unknown> | null,
@@ -110,7 +120,11 @@ function mergeObjects(
 	spec: JsonMergeSpec,
 ): MergeResult {
 	const result: Record<string, unknown> = {};
-	const allKeys = new Set([...Object.keys(local), ...Object.keys(remote)]);
+	const allKeys = new Set([
+		...Object.keys(local),
+		...Object.keys(remote),
+		...(base ? Object.keys(base) : []),
+	]);
 
 	for (const key of allKeys) {
 		if (key in spec.keyedArrays) continue; // handled below
@@ -124,8 +138,24 @@ function mergeObjects(
 			}
 			result[key] = remote[key];
 		} else if (inLocal !== inRemote) {
-			return { merged: false, reason: `ambiguous one-sided presence of key "${key}" (no merge base available)` };
+			// One side has the key, the other doesn't
+			if (base === null) {
+				// Can't distinguish addition from deletion without base
+				return { merged: false, reason: `ambiguous one-sided presence of key "${key}" (no base available)` };
+			}
+			const inBase = key in base;
+			if (!inBase) {
+				// Key is new on one side → addition, include it
+				result[key] = inLocal ? local[key] : remote[key];
+			} else if (inLocal) {
+				// Remote deleted it, local kept it → conflict
+				return { merged: false, reason: `remote deleted key "${key}" but local still has it` };
+			} else {
+				// Local deleted it, remote kept it → conflict
+				return { merged: false, reason: `local deleted key "${key}" but remote still has it` };
+			}
 		}
+		// key in neither local nor remote (was in base, both deleted) → omit from result
 	}
 
 	for (const [path, idKey] of Object.entries(spec.keyedArrays)) {
@@ -133,13 +163,30 @@ function mergeObjects(
 		const key = path;
 		const localArr = local[key];
 		const remoteArr = remote[key];
+		const baseArr = base?.[key];
 
-		if (!Array.isArray(remoteArr) && !Array.isArray(localArr)) continue;
-		if (!Array.isArray(remoteArr) || !Array.isArray(localArr)) {
-			return { merged: false, reason: `ambiguous one-sided presence of array "${key}" (no merge base available)` };
+		const localHas = Array.isArray(localArr);
+		const remoteHas = Array.isArray(remoteArr);
+
+		if (!localHas && !remoteHas) continue;
+
+		if (localHas !== remoteHas) {
+			// One side missing the array entirely
+			if (base === null) {
+				return { merged: false, reason: `ambiguous one-sided presence of array "${key}" (no base available)` };
+			}
+			const baseHas = Array.isArray(baseArr);
+			if (!baseHas) {
+				// New on one side → addition
+				result[key] = localHas ? localArr : remoteArr;
+			} else {
+				// One side deleted the array entirely → conflict
+				return { merged: false, reason: `one side deleted array "${key}" entirely` };
+			}
+			continue;
 		}
 
-		const arrayResult = mergeKeyedArrays(localArr, remoteArr, idKey);
+		const arrayResult = mergeKeyedArrays(localArr as unknown[], remoteArr as unknown[], idKey);
 		if (!arrayResult.ok) {
 			return { merged: false, reason: `conflicting edits to element with ${idKey}=${String(arrayResult.conflictId)} in "${key}"` };
 		}

--- a/src/util/jsonMerge.ts
+++ b/src/util/jsonMerge.ts
@@ -186,7 +186,12 @@ function mergeObjects(
 			continue;
 		}
 
-		const arrayResult = mergeKeyedArrays(localArr as unknown[], remoteArr as unknown[], idKey);
+		const arrayResult = mergeKeyedArrays(
+			localArr as unknown[],
+			remoteArr as unknown[],
+			Array.isArray(baseArr) ? baseArr as unknown[] : undefined,
+			idKey,
+		);
 		if (!arrayResult.ok) {
 			return { merged: false, reason: `conflicting edits to element with ${idKey}=${String(arrayResult.conflictId)} in "${key}"` };
 		}
@@ -197,40 +202,63 @@ function mergeObjects(
 }
 
 /**
- * Merge two arrays as id-keyed sets.
+ * Merge two arrays as id-keyed sets with optional three-way resolution.
  *
- * Algorithm:
- * 1. Start with remote array in remote order
- * 2. Append local-only items (items whose id key is absent from remote)
- * 3. If same id exists in both but content differs → conflict (caller falls back to clash file)
+ * Remote order is preserved. Local-only items (ids absent from remote) are appended.
+ * For same-id items with differing content, three-way resolution is attempted when
+ * base is available: if only one side changed, that side wins; if both changed, conflict.
+ * With no base, any same-id difference is a conflict (two-way fallback).
  *
  * Items without the id key field are kept from remote only (conservative).
  */
 function mergeKeyedArrays(
 	local: unknown[],
 	remote: unknown[],
+	base: unknown[] | undefined,
 	idKey: string,
 ): ArrayMergeResult {
-	const remoteById = new Map<unknown, unknown>();
-	for (const item of remote) {
-		if (isObject(item) && idKey in item) {
-			remoteById.set((item as Record<string, unknown>)[idKey], item);
-		}
-	}
+	const hasId = (item: unknown): item is Record<string, unknown> =>
+		isObject(item) && Object.prototype.hasOwnProperty.call(item, idKey);
 
-	const localOnly: unknown[] = [];
+	const localById = new Map<unknown, unknown>();
 	for (const item of local) {
-		if (!isObject(item)) continue;
-		const id = (item as Record<string, unknown>)[idKey];
-		if (id === undefined) continue;
-		if (!remoteById.has(id)) {
-			localOnly.push(item);
-		} else if (!deepEqual(item, remoteById.get(id))) {
-			return { ok: false, conflictId: id };
+		if (hasId(item)) localById.set(item[idKey], item);
+	}
+
+	const baseById = new Map<unknown, unknown>();
+	if (base !== undefined) {
+		for (const item of base) {
+			if (hasId(item)) baseById.set(item[idKey], item);
 		}
 	}
 
-	return { ok: true, value: [...remote, ...localOnly] };
+	const seenIds = new Set<unknown>();
+	const result: unknown[] = [];
+
+	for (const remoteItem of remote) {
+		if (!hasId(remoteItem)) { result.push(remoteItem); continue; }
+		const id = remoteItem[idKey];
+		seenIds.add(id);
+		const localItem = localById.get(id);
+		if (localItem === undefined || deepEqual(localItem, remoteItem)) {
+			result.push(remoteItem);
+			continue;
+		}
+		// Same id, different content — attempt three-way resolution
+		const baseItem = baseById.get(id);
+		if (baseItem !== undefined) {
+			if (deepEqual(baseItem, remoteItem)) { result.push(localItem); continue; } // remote unchanged → local wins
+			if (deepEqual(baseItem, localItem))  { result.push(remoteItem); continue; } // local unchanged → remote wins
+		}
+		return { ok: false, conflictId: id }; // no base or genuine divergence
+	}
+
+	for (const item of local) {
+		if (!hasId(item)) continue;
+		if (!seenIds.has(item[idKey])) result.push(item);
+	}
+
+	return { ok: true, value: result };
 }
 
 function isObject(v: unknown): v is Record<string, unknown> {

--- a/src/util/jsonMerge.ts
+++ b/src/util/jsonMerge.ts
@@ -11,7 +11,7 @@
  *
  * Design notes: docs/sync-logic.md § Semantic JSON Merge
  *
- * Future extension points (tracked in .fitattributes FR):
+ * Future extension points (tracked in #337 — .fitattributes):
  * - Order-significance selectors (opt arrays IN to ordered/index-based merge)
  * - Field exclusion selectors (ignore specific JSON paths during comparison)
  * - Text-mode policy (always-local, always-remote, clash) for non-JSON files
@@ -31,7 +31,7 @@ export interface JsonMergeSpec {
 	 * Example: { "nodes": "id", "edges": "id" }
 	 *
 	 * Paths are relative to the root object. Nested paths not yet supported
-	 * (deferred to .fitattributes implementation).
+	 * (deferred to #337 — .fitattributes).
 	 */
 	keyedArrays: Record<string, string>;
 }
@@ -127,10 +127,10 @@ function mergeObjects(
 	]);
 
 	for (const key of allKeys) {
-		if (key in spec.keyedArrays) continue; // handled below
+		if (Object.prototype.hasOwnProperty.call(spec.keyedArrays, key)) continue; // handled below
 
-		const inLocal = key in local;
-		const inRemote = key in remote;
+		const inLocal = Object.prototype.hasOwnProperty.call(local, key);
+		const inRemote = Object.prototype.hasOwnProperty.call(remote, key);
 
 		if (inLocal && inRemote) {
 			if (!deepEqual(local[key], remote[key])) {
@@ -143,7 +143,7 @@ function mergeObjects(
 				// Can't distinguish addition from deletion without base
 				return { merged: false, reason: `ambiguous one-sided presence of key "${key}" (no base available)` };
 			}
-			const inBase = key in base;
+			const inBase = Object.prototype.hasOwnProperty.call(base, key);
 			if (!inBase) {
 				// Key is new on one side → addition, include it
 				result[key] = inLocal ? local[key] : remote[key];


### PR DESCRIPTION
Closes #309.

Extends the merge engine from #335 with genuine three-way merge semantics for `.canvas` files. The merge base is the content at last successful sync, fetched on-demand by blob SHA from `lastFetchedRemoteShas` — no cache needed.

## What this adds over #335

**Item-level three-way resolution in keyed arrays:**
- `base == remote` → remote unchanged, local edit wins
- `base == local` → local unchanged, remote edit wins  
- Both changed the same item → genuine conflict, falls back to `_fit/`
- One-sided key/array **not in base** → confirmed addition, included
- One-sided key/array **in base** → one side deleted → clash (no silent data loss)
- Both sides deleted a base key → cleanly omitted

**On-demand base fetch** (replaces fragile in-memory cache from earlier WIP):
- Base SHA = `lastFetchedRemoteShas[path]` — always available after any sync
- `readFileBlobBySha(sha)` fetches historical blob from GitHub at merge time
- `hadBase: false` on first sync of a file (no prior SHA) → graceful two-way fallback
- No restart penalty; no memory lifecycle to manage

**Bug fix:** auto-merged canvas paths no longer appear as `unresolvedConflicts` in the sync result.

## Changes

- `src/util/jsonMerge.ts`: `mergeKeyedArrays` accepts `base` param; single-pass three-way item resolution; prototype-safe `hasOwnProperty` checks (replaces `Object.hasOwn`, ES2022+)
- `src/util/jsonMerge.test.ts`: three-way unit tests (base==remote wins local, base==local wins remote, both changed = conflict); one-sided key tests with and without base
- `src/remoteGitHubVault.ts`: `readFileBlobBySha(sha)` — fetches historical blob by SHA
- `src/testUtils.ts`: `FakeRemoteVault.readFileBlobBySha` backed by accumulated `blobShas` map
- `src/fitSync.ts`: parallel base blob pre-fetch before canvas merge loop; `conflicts` return filters out auto-merged paths; logging for fetch, success, and failure
- `src/fit.ts`: removed `cachedMergeableContents` (dead code replaced by on-demand fetch)
- `docs/sync-logic.md`: updated to describe three-way merge base fetch and item-level resolution

## Test plan

- [x] Unit tests: three-way item resolution cases in `jsonMerge.test.ts`
- [x] Integration test: two-sync scenario — base established on sync 1, position change vs remote addition resolves on sync 2
- [x] Manual: `hadBase: true` + successful merge logged; blob SHA confirmed in log
- [x] Manual: `hadBase: false` (new file, no prior SHA) correctly falls to `_fit/`
- [x] Manual: genuine conflict (both sides edit same node) falls to `_fit/` even with base

🤖 Generated with [Claude Code](https://claude.com/claude-code)