### PR TITLE
chore: sync package-lock.json libc metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5194,6 +5194,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -5209,6 +5212,9 @@
 			"integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -5616,6 +5622,13 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/appium-uiautomator2-driver/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"extraneous": true,
+			"license": "Python-2.0"
+		},
 		"node_modules/appium-uiautomator2-driver/node_modules/async": {
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -5955,6 +5968,92 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/appium-uiautomator2-driver/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/chalk/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"extraneous": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"extraneous": true,
+			"license": "MIT"
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/appium-uiautomator2-driver/node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6010,6 +6109,16 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/consola": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.10.0"
 			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/console-control-strings": {
@@ -6207,6 +6316,16 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/appium-uiautomator2-driver/node_modules/diff": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+			"extraneous": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/appium-uiautomator2-driver/node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6307,6 +6426,16 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/escape-html": {
@@ -6612,6 +6741,29 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/appium-uiautomator2-driver/node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"extraneous": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/get-east-asian-width": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/appium-uiautomator2-driver/node_modules/get-intrinsic": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6725,6 +6877,16 @@
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
 			"license": "MIT",
 			"optional": true
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/has-symbols": {
 			"version": "1.1.0",
@@ -7128,6 +7290,19 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
+		"node_modules/appium-uiautomator2-driver/node_modules/lilconfig": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
+			}
+		},
 		"node_modules/appium-uiautomator2-driver/node_modules/lockfile": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
@@ -7280,6 +7455,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/minimalistic-assert": {
@@ -7488,6 +7673,22 @@
 			"optional": true,
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/p-limit": {
@@ -8544,6 +8745,13 @@
 				"utf8-byte-length": "^1.0.1"
 			}
 		},
+		"node_modules/appium-uiautomator2-driver/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"extraneous": true,
+			"license": "0BSD"
+		},
 		"node_modules/appium-uiautomator2-driver/node_modules/type-fest": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
@@ -8694,6 +8902,24 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
+		"node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi-cjs": {
 			"name": "wrap-ansi",
 			"version": "7.0.0",
@@ -8711,6 +8937,60 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"extraneous": true,
+			"license": "MIT"
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/wrappy": {
@@ -8760,6 +9040,101 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"extraneous": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/yaml": {
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+			"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+			"extraneous": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/yargs": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^7.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"extraneous": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"extraneous": true,
+			"license": "MIT"
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"extraneous": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/appium-uiautomator2-driver/node_modules/yauzl": {
@@ -21352,6 +21727,14 @@
 					"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
 					"optional": true
 				},
+				"@emnapi/runtime": {
+					"version": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+					"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+					"extraneous": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				},
 				"@img/colour": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -21646,6 +22029,11 @@
 						}
 					}
 				},
+				"argparse": {
+					"version": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"extraneous": true
+				},
 				"async": {
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -21858,6 +22246,65 @@
 						"get-intrinsic": "^1.3.0"
 					}
 				},
+				"chalk": {
+					"version": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"extraneous": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+							"extraneous": true,
+							"requires": {
+								"has-flag": "^4.0.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+					"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+					"extraneous": true,
+					"requires": {
+						"string-width": "^7.2.0",
+						"strip-ansi": "^7.1.0",
+						"wrap-ansi": "^9.0.0"
+					},
+					"dependencies": {
+						"emoji-regex": {
+							"version": "10.6.0",
+							"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+							"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+							"extraneous": true
+						},
+						"string-width": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+							"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+							"extraneous": true,
+							"requires": {
+								"emoji-regex": "^10.3.0",
+								"get-east-asian-width": "^1.0.0",
+								"strip-ansi": "^7.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+							"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+							"extraneous": true,
+							"requires": {
+								"ansi-regex": "^6.2.2"
+							}
+						}
+					}
+				},
 				"color-convert": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -21900,6 +22347,11 @@
 						"normalize-path": "^3.0.0",
 						"readable-stream": "^4.0.0"
 					}
+				},
+				"consola": {
+					"version": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+					"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+					"extraneous": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
@@ -22020,6 +22472,11 @@
 					"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 					"optional": true
 				},
+				"diff": {
+					"version": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+					"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+					"extraneous": true
+				},
 				"dunder-proto": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -22093,6 +22550,12 @@
 						"has-tostringtag": "^1.0.2",
 						"hasown": "^2.0.2"
 					}
+				},
+				"escalade": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+					"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+					"extraneous": true
 				},
 				"escape-html": {
 					"version": "1.0.3",
@@ -22302,6 +22765,18 @@
 					"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 					"optional": true
 				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"extraneous": true
+				},
+				"get-east-asian-width": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+					"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+					"extraneous": true
+				},
 				"get-intrinsic": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -22376,6 +22851,12 @@
 					"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
 					"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
 					"optional": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"extraneous": true
 				},
 				"has-symbols": {
 					"version": "1.1.0",
@@ -22658,6 +23139,11 @@
 						}
 					}
 				},
+				"lilconfig": {
+					"version": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+					"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+					"extraneous": true
+				},
 				"lockfile": {
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
@@ -22762,6 +23248,12 @@
 					"requires": {
 						"mime-db": "^1.54.0"
 					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"extraneous": true
 				},
 				"minimalistic-assert": {
 					"version": "1.0.1",
@@ -22907,6 +23399,14 @@
 					"optional": true,
 					"requires": {
 						"wrappy": "1"
+					}
+				},
+				"onetime": {
+					"version": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+					"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+					"extraneous": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
 					}
 				},
 				"p-limit": {
@@ -23647,6 +24147,12 @@
 						"utf8-byte-length": "^1.0.1"
 					}
 				},
+				"tslib": {
+					"version": "2.8.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+					"extraneous": true
+				},
 				"type-fest": {
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
@@ -23749,6 +24255,51 @@
 						"isexe": "^4.0.0"
 					}
 				},
+				"wrap-ansi": {
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+					"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+					"extraneous": true,
+					"requires": {
+						"ansi-styles": "^6.2.1",
+						"string-width": "^7.0.0",
+						"strip-ansi": "^7.1.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "6.2.3",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+							"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+							"extraneous": true
+						},
+						"emoji-regex": {
+							"version": "10.6.0",
+							"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+							"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+							"extraneous": true
+						},
+						"string-width": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+							"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+							"extraneous": true,
+							"requires": {
+								"emoji-regex": "^10.3.0",
+								"get-east-asian-width": "^1.0.0",
+								"strip-ansi": "^7.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+							"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+							"extraneous": true,
+							"requires": {
+								"ansi-regex": "^6.2.2"
+							}
+						}
+					}
+				},
 				"wrap-ansi-cjs": {
 					"version": "npm:wrap-ansi@7.0.0",
 					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -23783,6 +24334,64 @@
 					"resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
 					"integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
 					"optional": true
+				},
+				"y18n": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+					"extraneous": true
+				},
+				"yaml": {
+					"version": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+					"integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+					"extraneous": true
+				},
+				"yargs": {
+					"version": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+					"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+					"extraneous": true,
+					"requires": {
+						"cliui": "^9.0.1",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"string-width": "^7.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^22.0.0"
+					},
+					"dependencies": {
+						"emoji-regex": {
+							"version": "10.6.0",
+							"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+							"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+							"extraneous": true
+						},
+						"string-width": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+							"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+							"extraneous": true,
+							"requires": {
+								"emoji-regex": "^10.3.0",
+								"get-east-asian-width": "^1.0.0",
+								"strip-ansi": "^7.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+							"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+							"extraneous": true,
+							"requires": {
+								"ansi-regex": "^6.2.2"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "22.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+					"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+					"extraneous": true
 				},
 				"yauzl": {
 					"version": "3.3.0",


### PR DESCRIPTION
Adds the `libc` field npm now records for optional native packages under `appium-uiautomator2-driver`'s dependency tree (glibc/musl platform targeting). Pure metadata addition — no version or resolution changes.

Why this exists: this diff first showed up as unexplained noise in an unrelated contributor PR (#333). Root cause of why their environment produced it is still unconfirmed — couldn't reproduce it locally from a clean checkout with either default or force-allowed install scripts. Verified safe here: `npm ci` accepts the resulting lockfile, and a follow-up `npm install` doesn't churn it further. Landing it directly so future contributors on similar npm versions stop hitting it as incidental diff noise in unrelated PRs.