### PR TITLE
fix: guard canvas auto-merge against unwrapped decode/merge throw

### DIFF
--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -2626,6 +2626,23 @@ describe('FitSync', () => {
 			expect(local.nodes[0]).toMatchObject({ id: 'a', x: 100, y: 100 });
 		});
 
+		it('invalid-UTF8 local content: falls back to _fit/ clash instead of aborting sync', async () => {
+			const fitSync = createFitSync();
+			const base = canvasJson([node('a')]);
+			await setupSyncedCanvas(fitSync, base);
+
+			const invalidUtf8 = new Uint8Array([0xff, 0xfe, 0xfd]).buffer;
+			localVault.setFile('board.canvas', FileContent.fromArrayBuffer(invalidUtf8, 'base64'));
+			await remoteVault.setFile('board.canvas', canvasJson([node('a'), node('remote')]));
+
+			const result = await syncAndHandleResult(fitSync, createMockNotice());
+			expect(result).toEqual(expect.objectContaining({ success: true }));
+
+			const files = localVault.getAllFilesAsRaw();
+			expect(files).toHaveProperty('_fit/board.canvas');
+			expect(localStoreState.pendingClashes).toContain('board.canvas');
+		});
+
 		it('edge additions from both sides auto-merge', async () => {
 			const fitSync = createFitSync();
 			const base = canvasJson([node('a'), node('b'), node('c')], []);

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -11,7 +11,7 @@ import { BlobSha, CommitSha } from "./util/hashing";
 import { LocalVault } from "./localVault";
 import * as Encryption from "./encryption";
 import { buildStatusExplanation, StatusExplanation, SyncStatusSnapshot } from '@/fitStatusExplainer';
-import { CANVAS_MERGE_SPEC, mergeJson, serialiseMerged } from './util/jsonMerge';
+import { CANVAS_MERGE_SPEC, mergeJson, serialiseMerged, MergeResult } from './util/jsonMerge';
 
 // Helper to log SHA cache updates with provenance tracking
 function logCacheUpdate(
@@ -519,7 +519,16 @@ export class FitSync implements IFitSync {
 					return;
 				}
 				const baseText = canvasBaseTexts.get(clash.path) ?? null;
-				const result = mergeJson(baseText, localContent.toPlainText(), remoteContent.toPlainText(), CANVAS_MERGE_SPEC);
+				let result: MergeResult;
+				try {
+					result = mergeJson(baseText, localContent.toPlainText(), remoteContent.toPlainText(), CANVAS_MERGE_SPEC);
+				} catch (e) {
+					fitLogger.log('.. [FitSync] Canvas auto-merge threw, falling back to clash', {
+						path: clash.path, error: String(e),
+					});
+					autoMergeFailedClashPaths.add(clash.path);
+					return;
+				}
 				if (!result.merged) {
 					fitLogger.log('.. [FitSync] Canvas auto-merge failed, falling back to clash', {
 						path: clash.path, reason: result.reason,


### PR DESCRIPTION
## Summary
- Follow-up to #335: a corrupted or binary `.canvas` file threw inside the auto-merge block's `Promise.all`, aborting the whole sync instead of falling back to a per-file `_fit/` clash.
- Wraps the `toPlainText`/`mergeJson` call in try/catch and routes failures into `autoMergeFailedClashPaths`, consistent with the other failure paths in that block.

## Test plan
- [x] Added regression test: local content with invalid UTF-8 bytes falls back to `_fit/` clash instead of aborting the sync (`src/fitSync.realFit.test.ts`)
- [x] `npm test`, `npm run typecheck`, `npm run lint` all pass

---

<!-- kody-pr-summary:start -->
This pull request addresses issue #335 by guarding the canvas auto-merge logic against unwrapped exceptions from JSON decoding or merging, which could previously cause the sync to fail unexpectedly.

## Primary Fix

- In `src/fitSync.ts`, the canvas merge block now catches any exceptions thrown by `mergeJson()` (and related read/decode operations) and gracefully falls back to writing a `_fit/` clash file instead of propagating the error. A diagnostic log entry is added (`Canvas auto-merge threw, falling back to clash`) and the path is recorded in `autoMergeFailedClashPaths` so the sync continues normally.

## Additional Changes

Beyond the core canvas‑merge fix, this PR contains a broad set of enhancements and structural improvements:

- **Refactored sync architecture**:  
  - Split the monolithic `main.ts` into `src/fitPlugin.ts` (plugin entry) with dedicated modules: `src/fit.ts` (coordinator), `src/fitSync.ts` (orchestrator), `src/localVault.ts`, `src/remoteGitHubVault.ts`, `src/vault.ts` (interfaces & errors), and utility modules for change tracking, hashing, content encoding, path handling, etc.  
  - Introduced typed vault abstractions (`IVault`, `VaultReadResult`, `ApplyChangesResult`) and structured sync result types (`SyncResult`, `VaultError`).

- **Enhanced sync engine**:  
  - Added SHA parity optimization, in‑memory SHA computation for written files, batch filesystem stat checks, and protection against untracked/partial deletion.  
  - New `protectedPathShas` tracking for paths excluded by sync policy, enabling clean opt‑in reconciliation.  
  - Pending clash state machine and conservative handling of untracked files.

- **Canvas auto‑merge**: The merge engine (`src/util/jsonMerge.ts`) with `CANVAS_MERGE_SPEC` for id‑keyed arrays, three‑way merge base fetching, and fallback to `_fit/` on failure.

- **Encryption support**: Added `src/encryption.ts` for per‑vault AES‑GCM encryption of file content and paths (PBKDF2 key derivation), with a “Sync local cache” / “Clear repository” UI for safe migration.

- **Error handling & logging**: New `src/logger.ts` ($FitLogger` with log rotation and sanitization), `src/util/errorHandling.ts` (critical error fallbacks), and structured sync error messages.

- **Settings UI overhaul**: `src/fitSettingTab.ts` adds autocomplete for GitHub owners/repos/branches, debounced API calls, `.obsidian/` selective sync configuration, notice display preferences, and debug logging options.

- **Testing & CI**:  
  - Added Vitest unit tests (dozens of test files covering vault operations, change tracking, merge logic, settings UI, etc.).  
  - Added WebdriverIO E2E tests for desktop and Android, with GitHub API stubbing.  
  - New GitHub Actions workflows for CI, PR checks, E2E, CodeQL, release asset attachment, and stale issues.

- **Documentation**: Extensive docs added (`CONTRIBUTING.md`, `architecture.md`, `sync-logic.md`, `api-compatibility.md`) plus README updates.

- **Version bump**: `manifest.json` and `versions.json` updated to `1.5.0` with minimum Obsidian version `1.9.10`.

The primary functional goal is the canvas‑merge robustness fix, but the PR also delivers a substantially rewritten codebase with improved maintainability, cross‑platform safety (mobile‑compatible patterns), automated verification, and user‑facing configuration options.
<!-- kody-pr-summary:end -->