### PR TITLE
feat(#214): Explicit debug logging for sync failures with error info

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -1389,6 +1389,23 @@ When enabled (Settings → Enable debug logging), FIT writes to `.obsidian/plugi
 }
 ```
 
+**Example log trace with a GitHub API failure (e.g. an outage returning 4xx/5xx):**
+
+Every failed GitHub API request logs its status, method, and endpoint at the
+point `wrapOctokitError` reclassifies it, and every sync that ends in failure
+logs an explicit `❌ [FitSync] Sync failed` line — so debug.log always shows
+both *what HTTP call failed* and *that the sync as a whole failed*, even on
+mobile where there's no other error surface.
+```
+🔄 [Sync] Checking local and remote changes (parallel)...
+.. ☁️ [RemoteVault] Fetching from GitHub...
+.. ❌ [RemoteVault] GitHub API request failed: {
+  "status": 503, "method": "GET", "url": "/repos/{owner}/{repo}/git/trees/{tree_sha}",
+  "message": "Service Unavailable"
+}
+❌ [FitSync] Sync failed: { "errorType": "network", "message": "Couldn't reach GitHub API" }
+```
+
 ## Further Reading
 
 - [Architecture Overview](./architecture.md) - High-level system design

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1568,8 +1568,11 @@ describe('FitSync', () => {
 				]}
 			]);
 
-			// Verify: Logger was called even during failed sync
-			expect(fitLoggerLogSpy).toHaveBeenCalled();
+			// Verify: failure itself is explicitly logged, not just earlier in-flight steps
+			expectLoggerCalledWith('❌ [FitSync] Sync failed', {
+				errorType: 'network',
+				message: "Couldn't reach GitHub API",
+			});
 			expect(consoleLogSpy).toHaveBeenCalled();
 		});
 

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -1095,6 +1095,7 @@ export class FitSync implements IFitSync {
 
 			// VaultError from vault operations (both LocalVault and RemoteGitHubVault)
 			if (error instanceof VaultError) {
+				fitLogger.log('❌ [FitSync] Sync failed', { errorType: error.type, message: error.message });
 				return { success: false, error };
 			}
 
@@ -1104,6 +1105,7 @@ export class FitSync implements IFitSync {
 				: (error && typeof error === 'object' && 'message' in error)
 					? String((error as { message: unknown }).message)
 					: `Generic error: ${String(error)}`; // May result in '[object Object]' but it's the best we can do
+			fitLogger.log('❌ [FitSync] Sync failed', { errorType: 'unknown', message: errorMessage });
 			return { success: false, error: SyncErrors.unknown(errorMessage, { originalError: error }) };
 		}
 	}

--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -595,5 +595,22 @@ describe("RemoteGitHubVault", () => {
 				);
 			});
 		});
+
+		it("should log status and endpoint for every failed GitHub API request", async () => {
+			// Arrange - repo exists but branch ref doesn't, so getRef fails with 404
+			fakeOctokit.setRepoExists(true);
+			const logSpy = vi.spyOn(fitLogger, 'log').mockImplementation(() => {});
+
+			// Act
+			await expect(vault.readFromSource()).rejects.toThrow();
+
+			// Assert - the raw status/endpoint is captured before the error is
+			// reclassified into a VaultError, so it's not lost by the time the
+			// sync-level catch block logs the final failure.
+			expect(logSpy).toHaveBeenCalledWith(
+				'.. ❌ [RemoteVault] GitHub API request failed',
+				expect.objectContaining({ status: 404 })
+			);
+		});
 	});
 });

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -125,7 +125,7 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		error: unknown,
 		notFoundStrategy: 'repo' | 'repo-or-branch' | 'ignore'
 	): Promise<never> {
-		const errorObj = error as { status?: number | null; response?: unknown; message?: string; request?: unknown };
+		const errorObj = error as { status?: number | null; response?: unknown; message?: string; request?: { method?: string; url?: string } };
 
 		// Non-Octokit errors (plugin bugs, ReferenceErrors, etc.) — re-throw without misclassifying as network.
 		// Octokit errors always have a numeric status (HTTP errors) or a 'request' property (network failures).
@@ -134,6 +134,13 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		if (!hasNumericStatus && !hasOctokitRequest) {
 			throw error;
 		}
+
+		fitLogger.log('.. ❌ [RemoteVault] GitHub API request failed', {
+			status: errorObj.status ?? null,
+			method: errorObj.request?.method,
+			url: errorObj.request?.url,
+			message: errorObj.message,
+		});
 
 		// No status or no response indicates network/connectivity issue
 		if (errorObj.status === null || errorObj.status === undefined || !errorObj.response) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances debug logging to explicitly capture sync failures and their underlying causes. The following changes were made:

- **Explicit sync failure logging**: In `src/fitSync.ts`, both catch blocks (for `VaultError` and unknown errors) now log a dedicated `❌ [FitSync] Sync failed` entry, including the error type (`network`, `unknown`, etc.) and a descriptive message. This ensures that any failed sync produces a clear, searchable log line, even on platforms without an error UI.
- **Detailed API request failure logging**: In `src/remoteGitHubVault.ts`, the error-handling function now logs a `.. ❌ [RemoteVault] GitHub API request failed` entry containing the HTTP status, HTTP method, endpoint URL, and original error message for every failed GitHub API request. This preserves diagnostic details before the error is reclassified into a `VaultError`.
- **Documentation update**: `docs/sync-logic.md` now includes an example log trace illustrating both the API-level failure and the overall sync failure, explaining how these entries appear during a GitHub API outage.
- **Test coverage**: Added/updated tests in `src/remoteGitHubVault.test.ts` (verifies status/endpoint logging) and `src/fitSync.realFit.test.ts` (verifies explicit sync-failure logging) to confirm the new behavior.

The changes provide better observability for debugging sync failures, especially in mobile environments where error details are not otherwise surfaced.
<!-- kody-pr-summary:end -->

Tagged this as related to #214 (indirectly) since I was especially missing error details after a sync failed possibly related to auth.