### PR TITLE
feat(#214): distinguish rate-limit and SSO-required 403s from real credentials failures

### DIFF
--- a/src/fitNotice.ts
+++ b/src/fitNotice.ts
@@ -57,7 +57,7 @@ export default class FitNotice {
 	}
 
 	// allows error display to override muted
-	setMessage(message: string, isError?: boolean): void {
+	setMessage(message: string | DocumentFragment, isError?: boolean): void {
 		if (isError) {
 			if (!this.notice) {
 				this.notice = new Notice(message, 0);

--- a/src/fitPlugin.test.ts
+++ b/src/fitPlugin.test.ts
@@ -290,7 +290,7 @@ describe('FitPlugin sync-success notice duration wiring', () => {
 
 describe('FitPlugin sync-error notice content (#214)', () => {
 	// A plain authentication failure (bad/revoked/expired token — indistinguishable from
-	// the response) is the one case worth making actionable: settings link + new-token link.
+	// the response) is the one case worth making actionable: a settings link.
 	// rate_limited/sso_required aren't fixed by touching the token, so getSyncErrorMessage's
 	// own message text is trusted as-is there — no separate check needed here.
 	function makeConfiguredPlugin() {
@@ -304,7 +304,7 @@ describe('FitPlugin sync-error notice content (#214)', () => {
 		return plugin;
 	}
 
-	it('adds a settings link (wired to openPluginSettings) and a create-token link for a plain authentication failure', async () => {
+	it('adds a settings link (wired to openPluginSettings) for a plain authentication failure', async () => {
 		const plugin = makeConfiguredPlugin();
 		const openSettingsSpy = vi.spyOn(plugin, 'openPluginSettings').mockImplementation(() => {});
 		const stub = plugin.fitSync as unknown as StubFitSync;
@@ -316,9 +316,6 @@ describe('FitPlugin sync-error notice content (#214)', () => {
 		const errorNotice = (plugin as any).currentSyncNotice.notice;
 		const [message] = errorNotice.setMessage.mock.calls.at(-1);
 		const links = Array.from((message as DocumentFragment).querySelectorAll('a'));
-
-		expect(links.find(a => a.textContent === 'create a new token')?.href)
-			.toBe('https://github.com/settings/tokens/new');
 
 		links.find(a => a.textContent === 'Open plugin settings')!.dispatchEvent(new MouseEvent('click'));
 		expect(openSettingsSpy).toHaveBeenCalled();

--- a/src/fitPlugin.test.ts
+++ b/src/fitPlugin.test.ts
@@ -287,3 +287,40 @@ describe('FitPlugin sync-success notice duration wiring', () => {
 		expect(NoticeCtor).not.toHaveBeenCalledWith('', expect.anything());
 	});
 });
+
+describe('FitPlugin sync-error notice content (#214)', () => {
+	// A plain authentication failure (bad/revoked/expired token — indistinguishable from
+	// the response) is the one case worth making actionable: settings link + new-token link.
+	// rate_limited/sso_required aren't fixed by touching the token, so getSyncErrorMessage's
+	// own message text is trusted as-is there — no separate check needed here.
+	function makeConfiguredPlugin() {
+		const plugin = makePlugin();
+		plugin.settings = {
+			...DEFAULT_SETTINGS,
+			pat: 'token', owner: 'alice', repo: 'notes', branch: 'main',
+		};
+		plugin.fit = { loadLocalStore: vi.fn(), loadSettings: vi.fn() } as any;
+		plugin.fitSyncRibbonIconEl = { addClass: vi.fn(), removeClass: vi.fn() } as any;
+		return plugin;
+	}
+
+	it('adds a settings link (wired to openPluginSettings) and a create-token link for a plain authentication failure', async () => {
+		const plugin = makeConfiguredPlugin();
+		const openSettingsSpy = vi.spyOn(plugin, 'openPluginSettings').mockImplementation(() => {});
+		const stub = plugin.fitSync as unknown as StubFitSync;
+		stub.sync.mockResolvedValue({ success: false, error: { type: 'authentication', details: {} } });
+		stub.getSyncErrorMessage.mockReturnValue('Bad credentials. Check your GitHub personal access token.');
+
+		await (plugin as any).executeSyncWithUICoordination('manual');
+
+		const errorNotice = (plugin as any).currentSyncNotice.notice;
+		const [message] = errorNotice.setMessage.mock.calls.at(-1);
+		const links = Array.from((message as DocumentFragment).querySelectorAll('a'));
+
+		expect(links.find(a => a.textContent === 'create a new token')?.href)
+			.toBe('https://github.com/settings/tokens/new');
+
+		links.find(a => a.textContent === 'Open plugin settings')!.dispatchEvent(new MouseEvent('click'));
+		expect(openSettingsSpy).toHaveBeenCalled();
+	});
+});

--- a/src/fitPlugin.ts
+++ b/src/fitPlugin.ts
@@ -74,6 +74,53 @@ export default class FitPlugin extends Plugin {
 		appWithSetting.setting.openTabById("fit");
 	}
 
+	/**
+	 * Build the sync-failure notice content. Plain authentication failures (bad/revoked/expired
+	 * token — GitHub's response doesn't distinguish which) get actionable links; rate-limit and
+	 * SSO subtypes aren't fixed by touching the token, so they stay plain text (see #214).
+	 */
+	private buildSyncErrorNoticeMessage(error: { type: string; message: string; details?: Record<string, unknown> }): string | DocumentFragment {
+		const baseText = `Sync failed: ${error.message}`;
+		if (error.type !== 'authentication') {
+			return baseText;
+		}
+		const authSubtype = error.details?.authSubtype;
+		if (authSubtype === 'rate_limited') {
+			return baseText;
+		}
+
+		const fragment = document.createDocumentFragment();
+		fragment.appendChild(document.createTextNode(baseText + ' '));
+
+		if (authSubtype === 'sso_required') {
+			const ssoUrl = error.details?.ssoUrl;
+			if (typeof ssoUrl === 'string') {
+				const link = document.createElement('a');
+				link.href = ssoUrl;
+				link.textContent = 'Authorize SSO';
+				fragment.appendChild(link);
+			}
+			return fragment;
+		}
+
+		// No subtype — an actual credentials problem. Offer next steps rather than
+		// just saying "check your token" with no way to act on it.
+		const settingsLink = document.createElement('a');
+		settingsLink.textContent = 'Open plugin settings';
+		settingsLink.style.cursor = 'pointer';
+		settingsLink.addEventListener('click', () => this.openPluginSettings());
+		fragment.appendChild(settingsLink);
+
+		fragment.appendChild(document.createTextNode(' or '));
+
+		const createTokenLink = document.createElement('a');
+		createTokenLink.href = 'https://github.com/settings/tokens/new';
+		createTokenLink.textContent = 'create a new token';
+		fragment.appendChild(createTokenLink);
+
+		return fragment;
+	}
+
 	checkSettingsConfigured(): boolean {
 		const actionItems: Array<string> = [];
 		if (this.settings.pat === "") {
@@ -351,7 +398,7 @@ export default class FitPlugin extends Plugin {
 
 			case 'error':
 				// Show sticky error notice
-				this.currentSyncNotice!.setMessage(`Sync failed: ${outcome.error.message}`, true);
+				this.currentSyncNotice!.setMessage(this.buildSyncErrorNoticeMessage(outcome.error), true);
 
 				// Clean up state WITHOUT nullifying the error notice reference
 				this.onSyncError(triggerType);

--- a/src/fitPlugin.ts
+++ b/src/fitPlugin.ts
@@ -76,8 +76,9 @@ export default class FitPlugin extends Plugin {
 
 	/**
 	 * Build the sync-failure notice content. Plain authentication failures (bad/revoked/expired
-	 * token — GitHub's response doesn't distinguish which) get actionable links; rate-limit and
-	 * SSO subtypes aren't fixed by touching the token, so they stay plain text (see #214).
+	 * token — GitHub's response doesn't distinguish which) get an actionable settings link;
+	 * rate-limit and SSO subtypes aren't fixed by touching the token, so they stay plain text
+	 * (see #214).
 	 */
 	private buildSyncErrorNoticeMessage(error: { type: string; message: string; details?: Record<string, unknown> }): string | DocumentFragment {
 		const baseText = `Sync failed: ${error.message}`;
@@ -103,20 +104,13 @@ export default class FitPlugin extends Plugin {
 			return fragment;
 		}
 
-		// No subtype — an actual credentials problem. Offer next steps rather than
+		// No subtype — an actual credentials problem. Offer a next step rather than
 		// just saying "check your token" with no way to act on it.
 		const settingsLink = document.createElement('a');
 		settingsLink.textContent = 'Open plugin settings';
 		settingsLink.style.cursor = 'pointer';
 		settingsLink.addEventListener('click', () => this.openPluginSettings());
 		fragment.appendChild(settingsLink);
-
-		fragment.appendChild(document.createTextNode(' or '));
-
-		const createTokenLink = document.createElement('a');
-		createTokenLink.href = 'https://github.com/settings/tokens/new';
-		createTokenLink.textContent = 'create a new token';
-		fragment.appendChild(createTokenLink);
 
 		return fragment;
 	}

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1598,6 +1598,43 @@ describe('FitSync', () => {
 			]);
 		});
 
+		it.each([
+			{
+				name: 'rate-limited 403',
+				error: VaultError.authentication('API rate limit exceeded', {
+					authSubtype: 'rate_limited',
+					rateLimitResetAt: new Date('2026-01-01T00:00:00Z').getTime(),
+				}),
+				expectedMessage:
+					`Sync failed: API rate limit exceeded. Try again after ${new Date('2026-01-01T00:00:00Z').toLocaleTimeString()}.`,
+			},
+			{
+				name: 'org SSO enforcement',
+				error: VaultError.authentication('Resource protected by organization SAML enforcement', {
+					authSubtype: 'sso_required',
+					ssoUrl: 'https://github.com/orgs/acme/sso?authorization_request=abc123',
+				}),
+				expectedMessage:
+					'Sync failed: Resource protected by organization SAML enforcement. Authorize your token for SSO, then try again.',
+			},
+		])('should not blame the token for $name', async ({ error, expectedMessage }) => {
+			// Arrange
+			const fitSync = createFitSync();
+			localVault.setFile('test.md', 'content');
+			remoteVault.setFailure(error);
+
+			const mockNotice = createMockNotice();
+
+			// Act
+			await syncAndHandleResult(fitSync, mockNotice);
+
+			// Assert - subtype-specific message replaces the generic "check your token" wording
+			expect(mockNotice._calls).toEqual([
+				{ method: 'setMessage', args: ['Checking for changes...'] },
+				{ method: 'setMessage', args: [expectedMessage, true] }
+			]);
+		});
+
 		it('should handle remote not found errors with user-friendly message', async () => {
 			// Arrange
 			const fitSync = createFitSync();

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -1213,7 +1213,19 @@ export class FitSync implements IFitSync {
 					baseMessage = `${syncError.message}. Please check your internet connection.`;
 					break;
 				case 'authentication':
-					baseMessage = `${syncError.message}. Check your GitHub personal access token.`;
+					switch (syncError.details?.authSubtype) {
+						case 'rate_limited': {
+							const resetAt = syncError.details?.rateLimitResetAt;
+							const resetNote = resetAt ? ` Try again after ${new Date(resetAt).toLocaleTimeString()}.` : ' Try again shortly.';
+							baseMessage = `${syncError.message}.${resetNote}`;
+							break;
+						}
+						case 'sso_required':
+							baseMessage = `${syncError.message}. Authorize your token for SSO, then try again.`;
+							break;
+						default:
+							baseMessage = `${syncError.message}. Check your GitHub personal access token.`;
+					}
 					break;
 				case 'remote_not_found':
 					baseMessage = `${syncError.message}. Check your repo and branch settings.`;

--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -596,6 +596,63 @@ describe("RemoteGitHubVault", () => {
 			});
 		});
 
+		describe("403 subtypes", () => {
+			it("should distinguish rate limiting from a real credentials problem", async () => {
+				// Arrange - 403 with rate-limit headers exhausted
+				const rateLimitError: any = new Error("API rate limit exceeded");
+				rateLimitError.status = 403;
+				rateLimitError.response = {
+					headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1700000000' },
+				};
+				fakeOctokit.simulateError("GET /repos/{owner}/{repo}/commits/{ref}", rateLimitError);
+
+				// Act
+				const error = await vault.readFromSource().catch(e => e);
+
+				// Assert - not misreported as a token problem
+				expect(error.type).toBe('authentication');
+				expect(error.details).toMatchObject({
+					authSubtype: 'rate_limited',
+					rateLimitResetAt: 1700000000 * 1000,
+				});
+			});
+
+			it("should distinguish org SSO enforcement from a real credentials problem", async () => {
+				// Arrange - 403 with an SSO authorization header
+				const ssoError: any = new Error("Resource protected by organization SAML enforcement");
+				ssoError.status = 403;
+				ssoError.response = {
+					headers: { 'x-github-sso': 'required; url=https://github.com/orgs/acme/sso?authorization_request=abc123' },
+				};
+				fakeOctokit.simulateError("GET /repos/{owner}/{repo}/commits/{ref}", ssoError);
+
+				// Act
+				const error = await vault.readFromSource().catch(e => e);
+
+				// Assert - not misreported as "check your token"
+				expect(error.type).toBe('authentication');
+				expect(error.details).toMatchObject({
+					authSubtype: 'sso_required',
+					ssoUrl: 'https://github.com/orgs/acme/sso?authorization_request=abc123',
+				});
+			});
+
+			it("should fall back to a generic authentication error when 403 has no distinguishing header", async () => {
+				// Arrange - 403 with no rate-limit or SSO signal
+				const genericError: any = new Error("Resource not accessible by personal access token");
+				genericError.status = 403;
+				genericError.response = { headers: {} };
+				fakeOctokit.simulateError("GET /repos/{owner}/{repo}/commits/{ref}", genericError);
+
+				// Act
+				const error = await vault.readFromSource().catch(e => e);
+
+				// Assert
+				expect(error.type).toBe('authentication');
+				expect(error.details?.authSubtype).toBeUndefined();
+			});
+		});
+
 		it("should log status and endpoint for every failed GitHub API request", async () => {
 			// Arrange - repo exists but branch ref doesn't, so getRef fails with 404
 			fakeOctokit.setRepoExists(true);

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -171,8 +171,31 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 			throw VaultError.remoteNotFound(detailMessage, { originalError: error });
 		}
 
-		// 401/403: Authentication/authorization failures
+		// 401/403: Authentication/authorization failures. A 403 in particular can mean
+		// several unrelated things (rate limiting, org SSO enforcement, or an actual
+		// permission/token problem) — GitHub already tells us which via response headers,
+		// so check those for a narrower cause before defaulting to "check your token".
 		if (errorObj.status === 401 || errorObj.status === 403) {
+			const headers = (errorObj.response as { headers?: Record<string, string> } | undefined)?.headers ?? {};
+
+			if (errorObj.status === 403 && headers['x-ratelimit-remaining'] === '0') {
+				const resetHeader = headers['x-ratelimit-reset'];
+				const resetAt = resetHeader ? Number(resetHeader) * 1000 : undefined;
+				throw VaultError.authentication(
+					errorObj.message || 'GitHub API rate limit exceeded',
+					{ originalError: error, authSubtype: 'rate_limited', rateLimitResetAt: resetAt }
+				);
+			}
+
+			const ssoHeader = errorObj.status === 403 ? headers['x-github-sso'] : undefined;
+			const ssoUrlMatch = ssoHeader?.match(/url=(\S+)/);
+			if (ssoUrlMatch) {
+				throw VaultError.authentication(
+					errorObj.message || 'Organization requires SSO authorization for this token',
+					{ originalError: error, authSubtype: 'sso_required', ssoUrl: ssoUrlMatch[1] }
+				);
+			}
+
 			throw VaultError.authentication(
 				errorObj.message || 'Authentication failed',
 				{ originalError: error }

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -82,6 +82,15 @@ export type VaultErrorType =
   | 'filesystem';       // Local file system errors
 
 /**
+ * Narrower cause within an 'authentication' VaultError, when GitHub's response gives us
+ * a specific enough signal to say more than "check your token" (e.g. it isn't a token
+ * problem at all). Absent when the response didn't distinguish — the generic message applies.
+ */
+export type AuthErrorSubtype =
+  | 'rate_limited'  // 403 + x-ratelimit-remaining: 0 — not a credentials problem
+  | 'sso_required'; // 403 + x-github-sso header — org requires SAML SSO authorization for this token
+
+/**
  * Vault-layer error with categorized error types.
  * Use static factory methods (VaultError.network(), VaultError.remoteNotFound(), etc.) to construct.
  *
@@ -98,6 +107,12 @@ export class VaultError extends Error {
 			originalError?: unknown;
 			failedPaths?: string[];
 			errors?: Array<{ path: string; error: unknown }>;
+			/** authentication only, when distinguishable — see AuthErrorSubtype */
+			authSubtype?: AuthErrorSubtype;
+			/** authSubtype 'rate_limited' only: when the rate limit resets, as epoch milliseconds */
+			rateLimitResetAt?: number;
+			/** authSubtype 'sso_required' only: the org's SSO authorization URL, from the x-github-sso response header */
+			ssoUrl?: string;
 		}
 	) {
 		super(message);
@@ -106,11 +121,7 @@ export class VaultError extends Error {
 
 	// Generic factory helper
 	private static create(type: VaultErrorType) {
-		return (message: string, details?: {
-			originalError?: unknown;
-			failedPaths?: string[];
-			errors?: Array<{ path: string; error: unknown }>;
-		}) =>
+		return (message: string, details?: VaultError['details']) =>
 			new VaultError(type, message, details);
 	}
 
@@ -120,7 +131,7 @@ export class VaultError extends Error {
 	/** Remote resource not found (404 - repository, branch, etc.) */
 	static remoteNotFound = VaultError.create('remote_not_found');
 
-	/** Authentication/authorization failure (401, 403) */
+	/** Authentication/authorization failure (401, 403). See `details.authSubtype` for a narrower cause. */
 	static authentication = VaultError.create('authentication');
 
 	/** Local file system error (EACCES, ENOENT, etc.) */


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Address issue #214 by distinguishing three different causes of GitHub 403 errors when syncing with Obsidian:

- **Rate limit exceeded** (`x-ratelimit-remaining: 0`)
- **Org SSO enforcement** (`x-github-sso` header)
- **Actual credential/permission failure** (no distinguishing header)

Previously, all of these were reported as a generic "Check your GitHub personal access token" message, which was misleading for rate limits and SSO issues that aren’t fixed by changing the token.

## What changed

**Error classification** (`remoteGitHubVault.ts`, `vault.ts`)
- 403 responses now inspect GitHub’s response headers to detect rate limiting (`x-ratelimit-remaining: 0`) and SSO enforcement (`x-github-sso` header).
- `VaultError` now carries an optional `authSubtype` (`'rate_limited'` or `'sso_required'`) plus additional details (rate-limit reset time, SSO URL).

**User-facing error messages** (`fitSync.ts`)
- Rate-limited errors now show when the limit resets (or a generic “try again shortly” message).
- SSO-required errors instruct the user to authorize their token for SSO.
- Only real token problems still suggest checking the personal access token.

**Actionable notice links** (`fitPlugin.ts`, `fitNotice.ts`)
- For a plain authentication failure, the error notice now includes a clickable **“Open plugin settings”** link (wired to the plugin settings dialog).
- For SSO-required errors, a **“Authorize SSO”** link is shown when the SSO URL is available from the response header.
- These links are rendered as a `DocumentFragment` (the notice component now accepts fragments).

## Why

This improves the sync-error experience by giving users a clear, actionable path for each distinct 403 cause – reducing confusion and unnecessary token changes.
<!-- kody-pr-summary:end -->

Fixes #214.