### PR TITLE
feat: add support for github enterprise hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ See [docs/architecture.md § Design Principles](docs/architecture.md#design-prin
 
 NOTE: For security, it's recommended to limit the token scope to only the necessary repository for your vault and avoid sharing your entire plugin settings file that contains this token.
 
+The plugin defaults to github.com, but also supports github enterprise server hosts
+
 ## How Sync Works
 
 ### What gets synced

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,7 +53,7 @@ _These priorities operationalize the philosophy in [architecture.md § Design Pr
 
 **🚀 Platform Expansion**:
 - **Selective `.obsidian/` sync** - v1 shipped in 1.6 (replace-strategy + field tracking); v2: field-level exclusion (#67)
-- **Multi-platform backends** - GitLab, Gitea, self-hosted Git servers
+- **Multi-platform backends** - GitLab or Gitea
 - **Multi-repo sync** - Multiple vaults or vault partitions
 
 **🔒 Security & Privacy**:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,10 +94,10 @@ Both local and remote caches use the canonical Git blob SHA format: `SHA1("blob 
   - Handles both sync and push-only operations
 
 **Remote Backend Integration**:
-- Current implementation: GitHub backend with two components:
+- Current implementation: GitHub backend with three components:
   - `GitHubConnection`: PAT-based operations (authentication, repo/branch discovery) for settings UI
   - `RemoteGitHubVault`: Repository-specific sync operations using `@octokit/core` with automatic retry handling
-- Architecture supports adding GitLab/Gitea backends via IVault interface (would require corresponding connection classes)
+  - `githubHost` is resolved with the `resolveGitHubHost()` function which returns the API url for Octokit to use. This is designed for both github.com & github enterprise server since they use the same API
 
 ### Support Systems
 - **FitLogger**: Cross-platform diagnostic logging (enabled by default, writes to `.obsidian/plugins/fit/debug.log`)
@@ -239,7 +239,7 @@ interface IVault {
 
 **Current implementations**:
 - `LocalVault`: Obsidian vault
-- `RemoteGitHubVault`: GitHub repositories
+- `RemoteGitHubVault`: GitHub repositories (github.com and GitHub Enterprise Server)
 
 ### Custom Conflict Resolution
 Extend `FitSync` class to implement custom conflict resolution strategies:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ Both local and remote caches use the canonical Git blob SHA format: `SHA1("blob 
 - Current implementation: GitHub backend with two components:
   - `GitHubConnection`: PAT-based operations (authentication, repo/branch discovery) for settings UI
   - `RemoteGitHubVault`: Repository-specific sync operations using `@octokit/core` with automatic retry handling
-- Both resolve the `githubHost` setting through `resolveGitHubHost()` (`src/remotes/githubHost.ts`) to get the Octokit `baseUrl`, so github.com and GitHub Enterprise Server share one code path — they expose the same API
+- Both derive their Octokit `baseUrl` from the `githubHost` setting via `apiBaseUrl()` (`src/remotes/githubHost.ts`), so github.com and GitHub Enterprise Server share one code path — they expose the same API
 - Architecture supports adding GitLab/Gitea backends via IVault interface (would require corresponding connection classes)
 
 ### Support Systems

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,10 +94,11 @@ Both local and remote caches use the canonical Git blob SHA format: `SHA1("blob 
   - Handles both sync and push-only operations
 
 **Remote Backend Integration**:
-- Current implementation: GitHub backend with three components:
+- Current implementation: GitHub backend with two components:
   - `GitHubConnection`: PAT-based operations (authentication, repo/branch discovery) for settings UI
   - `RemoteGitHubVault`: Repository-specific sync operations using `@octokit/core` with automatic retry handling
-  - `githubHost` is resolved with the `resolveGitHubHost()` function which returns the API url for Octokit to use. This is designed for both github.com & github enterprise server since they use the same API
+- Both resolve the `githubHost` setting through `resolveGitHubHost()` (`src/remotes/githubHost.ts`) to get the Octokit `baseUrl`, so github.com and GitHub Enterprise Server share one code path — they expose the same API
+- Architecture supports adding GitLab/Gitea backends via IVault interface (would require corresponding connection classes)
 
 ### Support Systems
 - **FitLogger**: Cross-platform diagnostic logging (enabled by default, writes to `.obsidian/plugins/fit/debug.log`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,7 @@ interface IVault {
 
 **Current implementations**:
 - `LocalVault`: Obsidian vault
-- `RemoteGitHubVault`: GitHub repositories (github.com and GitHub Enterprise Server)
+- `RemoteGitHubVault`: GitHub repositories
 
 ### Custom Conflict Resolution
 Extend `FitSync` class to implement custom conflict resolution strategies:

--- a/src/__mocks__/@octokit/core.ts
+++ b/src/__mocks__/@octokit/core.ts
@@ -1,12 +1,19 @@
 // Registry for test to inject their fake Octokit instance
 let mockOctokitInstance: any = null;
+let lastConstructorOptions: Record<string, any> | null = null;
 
 export function __setMockOctokitInstance(instance: any) {
 	mockOctokitInstance = instance;
 }
 
+// Options from the most recent Octokit construction, for asserting client config (baseUrl, auth)
+export function __getLastOctokitOptions(): Record<string, any> | null {
+	return lastConstructorOptions;
+}
+
 export class Octokit {
-	constructor(_options?: { auth?: string }) {
+	constructor(options?: Record<string, any>) {
+		lastConstructorOptions = options ?? null;
 		// If a mock instance is registered, return it instead
 		if (mockOctokitInstance) {
 			return mockOctokitInstance;

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -96,7 +96,8 @@ export class Fit {
 			setting.owner,
 			setting.repo,
 			setting.branch,
-			setting.deviceName
+			setting.deviceName,
+			setting.githubHost
 		);
 	}
 

--- a/src/fitPlugin.test.ts
+++ b/src/fitPlugin.test.ts
@@ -144,7 +144,7 @@ describe('FitPlugin persistence lifecycle', () => {
 		it('saveSettings includes localStore fields so concurrent saveLocalStore cannot lose them', async () => {
 			const plugin = makePlugin();
 			plugin.fit = { loadLocalStore: vi.fn(), loadSettings: vi.fn() } as any;
-			plugin.settings = { pat: 'token', owner: 'alice', repo: 'r', branch: 'main', checkEveryXMinutes: 5 } as any;
+			plugin.settings = { ...DEFAULT_SETTINGS, pat: 'token', owner: 'alice', repo: 'r', branch: 'main', checkEveryXMinutes: 5 };
 			plugin.localStore = { localShas: {}, pendingClashes: ['x.md'], lastFetchedCommitSha: null, lastFetchedRemoteShas: {}, lastFetchedRemoteSha: undefined, unpushedFiles: {} };
 			plugin.startOrUpdateAutoSyncInterval = vi.fn() as any;
 
@@ -158,7 +158,7 @@ describe('FitPlugin persistence lifecycle', () => {
 		it('concurrent saveLocalStore + saveSettings both land in the final persisted state', async () => {
 			const plugin = makePlugin();
 			plugin.fit = { loadLocalStore: vi.fn(), loadSettings: vi.fn() } as any;
-			plugin.settings = { pat: 'token' } as any;
+			plugin.settings = { ...DEFAULT_SETTINGS, pat: 'token' };
 			plugin.localStore = { localShas: {}, pendingClashes: ['x.md'], lastFetchedCommitSha: null, lastFetchedRemoteShas: {}, lastFetchedRemoteSha: undefined, unpushedFiles: {} };
 			plugin.startOrUpdateAutoSyncInterval = vi.fn() as any;
 
@@ -191,6 +191,22 @@ describe('FitPlugin persistence lifecycle', () => {
 			mockLoad(plugin, { lastFetchedRemoteSha: { 'file.md': sha('oldsha') } });
 			await plugin.loadLocalStore();
 			expect(plugin.localStore.lastFetchedRemoteShas).toEqual({ 'file.md': 'oldsha' });
+		});
+	});
+
+	describe('loadSettings from disk', () => {
+		it('defaults githubHost to github.com for vaults saved before enterprise host support', async () => {
+			const plugin = makePlugin();
+			mockLoad(plugin, { pat: 'token', owner: 'alice', repo: 'notes', branch: 'main' });
+			await plugin.loadSettings();
+			expect(plugin.settings.githubHost).toBe('github.com');
+		});
+
+		it('keeps a stored enterprise host', async () => {
+			const plugin = makePlugin();
+			mockLoad(plugin, { githubHost: 'github.example.com' });
+			await plugin.loadSettings();
+			expect(plugin.settings.githubHost).toBe('github.example.com');
 		});
 	});
 });

--- a/src/fitPlugin.ts
+++ b/src/fitPlugin.ts
@@ -10,7 +10,7 @@ import { fitLogger } from '@/logger';
 import { LocalStores, parseLocalStore } from '@/localStores';
 import { handleCriticalError } from '@/util/errorHandling';
 import { GitHubConnection } from '@/remotes/githubConnection';
-import { resolveGitHubHost, treeUrl } from '@/remotes/githubHost';
+import { treeUrl } from '@/remotes/githubHost';
 import * as Encryption from "@/encryption";
 import { FitSettings, DEFAULT_SETTINGS, findNewFields } from '@/fitSettings';
 
@@ -424,7 +424,7 @@ export default class FitPlugin extends Plugin {
 		const { owner, repo, autoSync, checkEveryXMinutes } = this.settings;
 		const sha = this.localStore.lastFetchedCommitSha;
 		const commitUrl = (owner && repo && sha)
-			? treeUrl(resolveGitHubHost(this.settings.githubHost), owner, repo, sha)
+			? treeUrl(this.settings.githubHost, owner, repo, sha)
 			: null;
 		const autoSyncInfo: AutoSyncInfo = {
 			enabled: autoSync !== 'off',

--- a/src/fitPlugin.ts
+++ b/src/fitPlugin.ts
@@ -421,10 +421,10 @@ export default class FitPlugin extends Plugin {
 
 		const explanation = await this.fitSync.explainStatus();
 
-		const { owner, repo, autoSync, checkEveryXMinutes } = this.settings;
+		const { owner, repo, autoSync, checkEveryXMinutes, githubHost } = this.settings;
 		const sha = this.localStore.lastFetchedCommitSha;
 		const commitUrl = (owner && repo && sha)
-			? treeUrl(this.settings.githubHost, owner, repo, sha)
+			? treeUrl(githubHost, owner, repo, sha)
 			: null;
 		const autoSyncInfo: AutoSyncInfo = {
 			enabled: autoSync !== 'off',

--- a/src/fitPlugin.ts
+++ b/src/fitPlugin.ts
@@ -10,6 +10,7 @@ import { fitLogger } from '@/logger';
 import { LocalStores, parseLocalStore } from '@/localStores';
 import { handleCriticalError } from '@/util/errorHandling';
 import { GitHubConnection } from '@/remotes/githubConnection';
+import { resolveGitHubHost, treeUrl } from '@/remotes/githubHost';
 import * as Encryption from "@/encryption";
 import { FitSettings, DEFAULT_SETTINGS, findNewFields } from '@/fitSettings';
 
@@ -57,6 +58,7 @@ export default class FitPlugin extends Plugin {
 	logger = fitLogger; // Explicit reference to singleton for future refactoring
 	private activeSyncRequests = 0; // Track number of active sync attempts
 	private lastGithubConnectionPat: string | null = null; // Track PAT changes
+	private lastGithubConnectionHost: string | null = null; // Track host changes (cached auth user is per-host)
 	private activeManualSyncRequests = 0; // Track number of active manual sync attempts
 	private currentSyncNotice: FitNotice | null = null; // The active sync notice (shared by concurrent requests)
 
@@ -422,7 +424,7 @@ export default class FitPlugin extends Plugin {
 		const { owner, repo, autoSync, checkEveryXMinutes } = this.settings;
 		const sha = this.localStore.lastFetchedCommitSha;
 		const commitUrl = (owner && repo && sha)
-			? `https://github.com/${owner}/${repo}/tree/${sha}`
+			? treeUrl(resolveGitHubHost(this.settings.githubHost), owner, repo, sha)
 			: null;
 		const autoSyncInfo: AutoSyncInfo = {
 			enabled: autoSync !== 'off',
@@ -490,7 +492,7 @@ export default class FitPlugin extends Plugin {
 			Encryption.init(this);
 
 			this.githubConnection = this.settings.pat
-				? new GitHubConnection(this.settings.pat)
+				? new GitHubConnection(this.settings.pat, this.settings.githubHost)
 				: null;
 			this.fit = new Fit(this.settings, this.localStore, this.app.vault, this.manifest.dir ?? undefined);
 			this.fitSync = new FitSync(this.fit, this.saveLocalStoreCallback);
@@ -599,14 +601,17 @@ export default class FitPlugin extends Plugin {
 		// sync settings to Fit class as well upon saving
 		this.fit.loadSettings(this.settings);
 
-		// Update GitHubConnection only when PAT changes
-		if (this.settings.pat !== this.lastGithubConnectionPat) {
+		// Update GitHubConnection only when PAT or host changes
+		if (this.settings.pat !== this.lastGithubConnectionPat
+			|| this.settings.githubHost !== this.lastGithubConnectionHost) {
 			if (this.settings.pat) {
-				this.githubConnection = new GitHubConnection(this.settings.pat);
+				this.githubConnection = new GitHubConnection(this.settings.pat, this.settings.githubHost);
 				this.lastGithubConnectionPat = this.settings.pat;
+				this.lastGithubConnectionHost = this.settings.githubHost;
 			} else {
 				this.githubConnection = null;
 				this.lastGithubConnectionPat = null;
+				this.lastGithubConnectionHost = null;
 			}
 		}
 	}

--- a/src/fitSetting.test.ts
+++ b/src/fitSetting.test.ts
@@ -17,7 +17,7 @@ import FitSettingTab from './fitSettingTab';
 import { FitLogger } from './logger';
 import { findNewFields } from '@/fitSettings';
 
-const EMPTY_SETTINGS = { pat: '', avatarUrl: '', owner: '', repo: '', branch: '' };
+const EMPTY_SETTINGS = { pat: '', githubHost: '', avatarUrl: '', owner: '', repo: '', branch: '' };
 
 // Helper functions to find elements by their user-visible labels
 function findInputByLabel(container: HTMLElement, labelText: string): HTMLInputElement | null {
@@ -282,17 +282,20 @@ describe('FitSettingTab - GitHub settings', () => {
 		expect(branches).toEqual(['main', 'develop', 'feature-x']);
 	});
 
-	it('should generate correct GitHub link for owner/repo/branch', async () => {
+	it.each([
+		['', 'https://github.com/bob/project-x/tree/feature-123'],
+		['github.example.com', 'https://github.example.com/bob/project-x/tree/feature-123'],
+	])('should generate correct GitHub link for owner/repo/branch on host %j', async (githubHost, expectedLink) => {
 		const fakePlugin: any = {
 			githubConnection: null,
-			settings: { owner: 'bob', repo: 'project-x', branch: 'feature-123' },
+			settings: { githubHost, owner: 'bob', repo: 'project-x', branch: 'feature-123' },
 			logger: mockLogger
 		};
 
 		const settingTab = new FitSettingTab({} as any, fakePlugin);
 
 		// Verify: Link uses settings values
-		expect(settingTab.getLatestLink()).toBe('https://github.com/bob/project-x/tree/feature-123');
+		expect(settingTab.getLatestLink()).toBe(expectedLink);
 	});
 
 	it('should clear branches when fetching fails (repo not found)', async () => {

--- a/src/fitSetting.test.ts
+++ b/src/fitSetting.test.ts
@@ -15,9 +15,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { MockInstance } from 'vitest';
 import FitSettingTab from './fitSettingTab';
 import { FitLogger } from './logger';
-import { findNewFields } from '@/fitSettings';
+import { DEFAULT_SETTINGS, findNewFields } from '@/fitSettings';
 
-const EMPTY_SETTINGS = { pat: '', githubHost: '', avatarUrl: '', owner: '', repo: '', branch: '' };
+const EMPTY_SETTINGS = { ...DEFAULT_SETTINGS };
 
 // Helper functions to find elements by their user-visible labels
 function findInputByLabel(container: HTMLElement, labelText: string): HTMLInputElement | null {
@@ -283,7 +283,7 @@ describe('FitSettingTab - GitHub settings', () => {
 	});
 
 	it.each([
-		['', 'https://github.com/bob/project-x/tree/feature-123'],
+		['github.com', 'https://github.com/bob/project-x/tree/feature-123'],
 		['github.example.com', 'https://github.example.com/bob/project-x/tree/feature-123'],
 	])('should generate correct GitHub link for owner/repo/branch on host %j', async (githubHost, expectedLink) => {
 		const fakePlugin: any = {

--- a/src/fitSettingTab.ts
+++ b/src/fitSettingTab.ts
@@ -365,7 +365,7 @@ export default class FitSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('GitHub host (advanced)')
-			.setDesc('If using a GitHub Enterprise Server enter the host, leave blank for github.com')
+			.setDesc('Default: github.com')
 			.addText(text => text
 				.setPlaceholder('github.com')
 				.setValue(this.plugin.settings.githubHost)

--- a/src/fitSettingTab.ts
+++ b/src/fitSettingTab.ts
@@ -4,6 +4,7 @@ import { OBSIDIAN_ALWAYS_EXCLUDED, OBSIDIAN_NEEDS_MERGE } from "@/fit";
 import { App, PluginSettingTab, Setting, TextComponent } from "obsidian";
 import { setEqual } from "./utils";
 import { GitHubOwnerSuggest, GitHubRepoSuggest, ObsidianPathSuggest } from "./util/obsidianHelpers";
+import { resolveGitHubHost, tokenCreationUrl, treeUrl } from "./remotes/githubHost";
 import { VaultError } from "./vault";
 import { fitLogger } from "./logger";
 import FitNotice from "./fitNotice";
@@ -190,9 +191,9 @@ export default class FitSettingTab extends PluginSettingTab {
 	};
 
 	getLatestLink = (): string => {
-		const {owner: owner, repo, branch} = this.plugin.settings;
+		const {owner, repo, branch, githubHost} = this.plugin.settings;
 		if (owner.length > 0 && repo.length > 0 && branch.length > 0) {
-			return `https://github.com/${owner}/${repo}/tree/${branch}`;
+			return treeUrl(resolveGitHubHost(githubHost), owner, repo, branch);
 		}
 		return "";
 	};
@@ -322,7 +323,7 @@ export default class FitSettingTab extends PluginSettingTab {
 
 		this.patSetting = new Setting(containerEl)
 			.setName('Github personal access token')
-			.setDesc('Make sure Permissions has Contents: "Read and write". Recommended: Limit to selected repository, adjust expiration.')
+			.setDesc('Fine-grained token: Permissions needs Contents: "Read and write". Classic token: the "repo" scope. Recommended: Limit to selected repository, adjust expiration.')
 			.addText(text => text
 				.setPlaceholder('GitHub personal access token')
 				.setValue(this.plugin.settings.pat)
@@ -358,9 +359,26 @@ export default class FitSettingTab extends PluginSettingTab {
 				.setIcon('external-link')
 				.setTooltip("Create a token")
 				.onClick(async ()=>{
-					window.open(
-						"https://github.com/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write",
-						'_blank');
+					// Resolved on click, not at render, so a host edit takes effect without reopening settings
+					window.open(tokenCreationUrl(resolveGitHubHost(this.plugin.settings.githubHost)), '_blank');
+				}));
+
+		new Setting(containerEl)
+			.setName('advanced: GitHub host')
+			.setDesc('if using a GitHub Enterprise Server enter the host, leave blank for github.com')
+			.addText(text => text
+				.setPlaceholder('github.com')
+				.setValue(this.plugin.settings.githubHost)
+				.onChange(async (value) => {
+					if (value === this.plugin.settings.githubHost) return;
+					this.plugin.settings.githubHost = value;
+					// Suggestions and the authenticated user belong to the previous host.
+					// Owner/repo/branch are left alone - they are still what the user asked to sync.
+					this.clearAuthState();
+					this.suggestedOwners = [];
+					this.ownerSuggest?.updateSuggestions([]);
+					this.repoSuggest?.updateSuggestions([]);
+					await this.plugin.saveSettings();
 				}));
 	};
 
@@ -383,12 +401,12 @@ export default class FitSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setDesc("Make sure you are logged in to github on your browser.")
+			.setDesc("Make sure you are logged in to GitHub on your browser.")
 			.addExtraButton(button => button
 				.setIcon('github')
 				.setTooltip("Create a new repository")
 				.onClick(() => {
-					window.open(`https://github.com/new`, '_blank');
+					window.open(`${resolveGitHubHost(this.plugin.settings.githubHost).webBaseUrl}/new`, '_blank');
 				}));
 
 		// Repository owner combo box (supports both dropdown suggestions and freeform text)

--- a/src/fitSettingTab.ts
+++ b/src/fitSettingTab.ts
@@ -369,7 +369,7 @@ export default class FitSettingTab extends PluginSettingTab {
 			.addText(text => text
 				.setPlaceholder('github.com')
 				.setValue(this.plugin.settings.githubHost)
-				.onChange(async (value) => {
+				.onChange((value) => {
 					this.plugin.settings.githubHost = value;
 					// Suggestions and the authenticated user belong to the previous host.
 					// Owner/repo/branch are left alone - they are still what the user asked to sync.
@@ -377,7 +377,7 @@ export default class FitSettingTab extends PluginSettingTab {
 					this.suggestedOwners = [];
 					this.ownerSuggest?.updateSuggestions([]);
 					this.repoSuggest?.updateSuggestions([]);
-					await this.plugin.saveSettings();
+					this.debouncedSaveSettings();
 				}));
 	};
 

--- a/src/fitSettingTab.ts
+++ b/src/fitSettingTab.ts
@@ -364,13 +364,12 @@ export default class FitSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
-			.setName('advanced: GitHub host')
-			.setDesc('if using a GitHub Enterprise Server enter the host, leave blank for github.com')
+			.setName('GitHub host (advanced)')
+			.setDesc('If using a GitHub Enterprise Server enter the host, leave blank for github.com')
 			.addText(text => text
 				.setPlaceholder('github.com')
 				.setValue(this.plugin.settings.githubHost)
 				.onChange(async (value) => {
-					if (value === this.plugin.settings.githubHost) return;
 					this.plugin.settings.githubHost = value;
 					// Suggestions and the authenticated user belong to the previous host.
 					// Owner/repo/branch are left alone - they are still what the user asked to sync.

--- a/src/fitSettingTab.ts
+++ b/src/fitSettingTab.ts
@@ -371,8 +371,6 @@ export default class FitSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.githubHost)
 				.onChange((value) => {
 					this.plugin.settings.githubHost = value;
-					// Suggestions and the authenticated user belong to the previous host.
-					// Owner/repo/branch are left alone - they are still what the user asked to sync.
 					this.clearAuthState();
 					this.suggestedOwners = [];
 					this.ownerSuggest?.updateSuggestions([]);
@@ -400,7 +398,7 @@ export default class FitSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setDesc("Make sure you are logged in to GitHub on your browser.")
+			.setDesc("Make sure you are logged in to github on your browser.")
 			.addExtraButton(button => button
 				.setIcon('github')
 				.setTooltip("Create a new repository")

--- a/src/fitSettingTab.ts
+++ b/src/fitSettingTab.ts
@@ -4,7 +4,7 @@ import { OBSIDIAN_ALWAYS_EXCLUDED, OBSIDIAN_NEEDS_MERGE } from "@/fit";
 import { App, PluginSettingTab, Setting, TextComponent } from "obsidian";
 import { setEqual } from "./utils";
 import { GitHubOwnerSuggest, GitHubRepoSuggest, ObsidianPathSuggest } from "./util/obsidianHelpers";
-import { resolveGitHubHost, tokenCreationUrl, treeUrl } from "./remotes/githubHost";
+import { tokenCreationUrl, treeUrl, webBaseUrl } from "./remotes/githubHost";
 import { VaultError } from "./vault";
 import { fitLogger } from "./logger";
 import FitNotice from "./fitNotice";
@@ -193,7 +193,7 @@ export default class FitSettingTab extends PluginSettingTab {
 	getLatestLink = (): string => {
 		const {owner, repo, branch, githubHost} = this.plugin.settings;
 		if (owner.length > 0 && repo.length > 0 && branch.length > 0) {
-			return treeUrl(resolveGitHubHost(githubHost), owner, repo, branch);
+			return treeUrl(githubHost, owner, repo, branch);
 		}
 		return "";
 	};
@@ -360,7 +360,7 @@ export default class FitSettingTab extends PluginSettingTab {
 				.setTooltip("Create a token")
 				.onClick(async ()=>{
 					// Resolved on click, not at render, so a host edit takes effect without reopening settings
-					window.open(tokenCreationUrl(resolveGitHubHost(this.plugin.settings.githubHost)), '_blank');
+					window.open(tokenCreationUrl(this.plugin.settings.githubHost), '_blank');
 				}));
 
 		new Setting(containerEl)
@@ -405,7 +405,7 @@ export default class FitSettingTab extends PluginSettingTab {
 				.setIcon('github')
 				.setTooltip("Create a new repository")
 				.onClick(() => {
-					window.open(`${resolveGitHubHost(this.plugin.settings.githubHost).webBaseUrl}/new`, '_blank');
+					window.open(`${webBaseUrl(this.plugin.settings.githubHost)}/new`, '_blank');
 				}));
 
 		// Repository owner combo box (supports both dropdown suggestions and freeform text)

--- a/src/fitSettings.ts
+++ b/src/fitSettings.ts
@@ -33,6 +33,7 @@ export interface FitSettings {
 	// See RemoteVaultProvider type in src/vault.ts for provider enum.
 	encryptionPassword: string;
 	pat: string;
+	githubHost: string;  // Empty for github.com, otherwise a GitHub Enterprise Server host (see resolveGitHubHost)
 	owner: string;       // Owner of the repo (may differ from authenticated user for contributor repos)
 	avatarUrl: string;
 	repo: string;
@@ -51,6 +52,7 @@ export interface FitSettings {
 export const DEFAULT_SETTINGS: FitSettings = {
 	encryptionPassword: "",
 	pat: "",
+	githubHost: "",
 	owner: "",
 	avatarUrl: "",
 	repo: "",

--- a/src/fitSettings.ts
+++ b/src/fitSettings.ts
@@ -33,7 +33,7 @@ export interface FitSettings {
 	// See RemoteVaultProvider type in src/vault.ts for provider enum.
 	encryptionPassword: string;
 	pat: string;
-	githubHost: string;  // Empty for github.com, otherwise a GitHub Enterprise Server host (see remotes/githubHost.ts)
+	githubHost: string;  // GitHub Enterprise Server hostname, github.com by default (see remotes/githubHost.ts)
 	owner: string;       // Owner of the repo (may differ from authenticated user for contributor repos)
 	avatarUrl: string;
 	repo: string;
@@ -52,7 +52,7 @@ export interface FitSettings {
 export const DEFAULT_SETTINGS: FitSettings = {
 	encryptionPassword: "",
 	pat: "",
-	githubHost: "",
+	githubHost: "github.com",
 	owner: "",
 	avatarUrl: "",
 	repo: "",

--- a/src/fitSettings.ts
+++ b/src/fitSettings.ts
@@ -33,7 +33,7 @@ export interface FitSettings {
 	// See RemoteVaultProvider type in src/vault.ts for provider enum.
 	encryptionPassword: string;
 	pat: string;
-	githubHost: string;  // GitHub Enterprise Server hostname, github.com by default (see remotes/githubHost.ts)
+	githubHost: string;
 	owner: string;       // Owner of the repo (may differ from authenticated user for contributor repos)
 	avatarUrl: string;
 	repo: string;

--- a/src/fitSettings.ts
+++ b/src/fitSettings.ts
@@ -33,7 +33,7 @@ export interface FitSettings {
 	// See RemoteVaultProvider type in src/vault.ts for provider enum.
 	encryptionPassword: string;
 	pat: string;
-	githubHost: string;  // Empty for github.com, otherwise a GitHub Enterprise Server host (see resolveGitHubHost)
+	githubHost: string;  // Empty for github.com, otherwise a GitHub Enterprise Server host (see remotes/githubHost.ts)
 	owner: string;       // Owner of the repo (may differ from authenticated user for contributor repos)
 	avatarUrl: string;
 	repo: string;

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -45,6 +45,7 @@ describe('FitSync', () => {
 	// Realistic settings that get passed through to RemoteGitHubVault
 	const testSettings = {
 		pat: 'fake-test-token',
+		githubHost: '',
 		owner: 'test-owner',
 		repo: 'test-repo',
 		branch: 'test-branch',

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -13,7 +13,7 @@ import { Fit } from './fit';
 import { Vault } from 'obsidian';
 import { FakeLocalVault, FakeRemoteVault } from './testUtils';
 import { LocalVault } from './localVault';
-import { FitSettings } from '@/fitSettings';
+import { DEFAULT_SETTINGS, FitSettings } from '@/fitSettings';
 import { LocalStores } from '@/localStores';
 import { VaultError } from './vault';
 import { fitLogger } from './logger';
@@ -45,7 +45,7 @@ describe('FitSync', () => {
 	// Realistic settings that get passed through to RemoteGitHubVault
 	const testSettings = {
 		pat: 'fake-test-token',
-		githubHost: '',
+		githubHost: 'github.com',
 		owner: 'test-owner',
 		repo: 'test-repo',
 		branch: 'test-branch',
@@ -2216,7 +2216,7 @@ describe('FitSync', () => {
 
 			// Given: Stored settings as of v1.3
 			const fit = new Fit(
-				v13settings as FitSettings,
+				{ ...DEFAULT_SETTINGS, ...v13settings },
 				localStoreState,
 				{} as unknown as Vault
 			);

--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { RemoteGitHubVault, TreeNode } from "./remoteGitHubVault";
 import { BlobSha, CommitSha, EMPTY_TREE_SHA, TreeSha } from "./util/hashing";
 import { FakeOctokit } from "./testUtils";
-import { __setMockOctokitInstance } from "./__mocks__/@octokit/core";
+import { __getLastOctokitOptions, __setMockOctokitInstance } from "./__mocks__/@octokit/core";
 import { FileContent } from "./util/contentEncoding";
 import { fitLogger } from "./logger";
 import { init as initEncryption } from "./encryption";
@@ -45,6 +45,20 @@ describe("RemoteGitHubVault", () => {
 	afterEach(() => {
 		__setMockOctokitInstance(null);
 		vi.restoreAllMocks();
+	});
+
+	describe("Client Configuration", () => {
+		it("should target the instance API when a GitHub Enterprise Server host is configured", () => {
+			new RemoteGitHubVault("fake-pat-token", "testowner", "testrepo", "main", "test-device", "github.example.com");
+
+			expect(__getLastOctokitOptions()?.baseUrl).toBe("https://github.example.com/api/v3");
+		});
+
+		it("should target api.github.com when no host is configured", () => {
+			new RemoteGitHubVault("fake-pat-token", "testowner", "testrepo", "main", "test-device");
+
+			expect(__getLastOctokitOptions()?.baseUrl).toBe("https://api.github.com");
+		});
 	});
 
 	describe("Read Operations", () => {

--- a/src/remoteGitHubVault.test.ts
+++ b/src/remoteGitHubVault.test.ts
@@ -38,7 +38,8 @@ describe("RemoteGitHubVault", () => {
 			"testowner",
 			"testrepo",
 			"main",
-			"test-device"
+			"test-device",
+			"github.com"
 		);
 	});
 
@@ -52,12 +53,6 @@ describe("RemoteGitHubVault", () => {
 			new RemoteGitHubVault("fake-pat-token", "testowner", "testrepo", "main", "test-device", "github.example.com");
 
 			expect(__getLastOctokitOptions()?.baseUrl).toBe("https://github.example.com/api/v3");
-		});
-
-		it("should target api.github.com when no host is configured", () => {
-			new RemoteGitHubVault("fake-pat-token", "testowner", "testrepo", "main", "test-device");
-
-			expect(__getLastOctokitOptions()?.baseUrl).toBe("https://api.github.com");
 		});
 	});
 

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -8,6 +8,7 @@
 import { LocalStores } from "@/localStores";
 import { Octokit } from "@octokit/core";
 import { retry } from "@octokit/plugin-retry";
+import { resolveGitHubHost } from "./remotes/githubHost";
 import { ApplyChangesResult, IVault, VaultError, VaultReadResult } from "./vault";
 import { FileChange, FileStates } from "./util/changeTracking";
 import { BlobSha, CommitSha, EMPTY_TREE_SHA, TreeSha } from "./util/hashing";
@@ -68,17 +69,22 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 	private latestKnownCommitSha: CommitSha | null = null;
 	private latestKnownState: FileStates | null = null;
 
+	/**
+	 * @param githubHost - github server host, defaults to github.com
+	 */
 	constructor(
 		pat: string,
 		owner: string,
 		repo: string,
 		branch: string,
-		deviceName: string
+		deviceName: string,
+		githubHost = ""
 	) {
 		// Use Octokit with retry plugin for enhanced rate limiting handling
 		const OctokitWithRetry = Octokit.plugin(retry);
 		this.octokit = new OctokitWithRetry({
-			auth: pat
+			auth: pat,
+			baseUrl: resolveGitHubHost(githubHost).apiBaseUrl
 			// Retry plugin operates silently - users will simply experience fewer rate limit errors
 			// Future: Could add verbose logging option to plugin settings
 		});

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -8,7 +8,7 @@
 import { LocalStores } from "@/localStores";
 import { Octokit } from "@octokit/core";
 import { retry } from "@octokit/plugin-retry";
-import { resolveGitHubHost } from "./remotes/githubHost";
+import { apiBaseUrl } from "./remotes/githubHost";
 import { ApplyChangesResult, IVault, VaultError, VaultReadResult } from "./vault";
 import { FileChange, FileStates } from "./util/changeTracking";
 import { BlobSha, CommitSha, EMPTY_TREE_SHA, TreeSha } from "./util/hashing";
@@ -69,9 +69,7 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 	private latestKnownCommitSha: CommitSha | null = null;
 	private latestKnownState: FileStates | null = null;
 
-	/**
-	 * @param githubHost - Enterprise Server host; empty means github.com
-	 */
+	/** @param githubHost - Enterprise Server host; empty means github.com */
 	constructor(
 		pat: string,
 		owner: string,
@@ -84,7 +82,7 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 		const OctokitWithRetry = Octokit.plugin(retry);
 		this.octokit = new OctokitWithRetry({
 			auth: pat,
-			baseUrl: resolveGitHubHost(githubHost).apiBaseUrl
+			baseUrl: apiBaseUrl(githubHost)
 			// Retry plugin operates silently - users will simply experience fewer rate limit errors
 			// Future: Could add verbose logging option to plugin settings
 		});

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -69,14 +69,14 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 	private latestKnownCommitSha: CommitSha | null = null;
 	private latestKnownState: FileStates | null = null;
 
-	/** @param githubHost - Enterprise Server host; empty means github.com */
+	/** @param githubHost - Hostname to sync with, e.g. "github.com" or a GitHub Enterprise Server */
 	constructor(
 		pat: string,
 		owner: string,
 		repo: string,
 		branch: string,
 		deviceName: string,
-		githubHost = ""
+		githubHost: string
 	) {
 		// Use Octokit with retry plugin for enhanced rate limiting handling
 		const OctokitWithRetry = Octokit.plugin(retry);

--- a/src/remoteGitHubVault.ts
+++ b/src/remoteGitHubVault.ts
@@ -70,7 +70,7 @@ export class RemoteGitHubVault implements IVault<"remote"> {
 	private latestKnownState: FileStates | null = null;
 
 	/**
-	 * @param githubHost - github server host, defaults to github.com
+	 * @param githubHost - Enterprise Server host; empty means github.com
 	 */
 	constructor(
 		pat: string,

--- a/src/remotes/githubConnection.test.ts
+++ b/src/remotes/githubConnection.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { GitHubConnection } from './githubConnection';
+import { __getLastOctokitOptions } from '../__mocks__/@octokit/core';
+
+describe('GitHubConnection', () => {
+	it('targets api.github.com when no host is configured', () => {
+		new GitHubConnection('fake-pat');
+		expect(__getLastOctokitOptions()?.baseUrl).toBe('https://api.github.com');
+	});
+
+	it('targets the instance API when an Enterprise Server host is configured', () => {
+		new GitHubConnection('fake-pat', 'github.example.com');
+		expect(__getLastOctokitOptions()?.baseUrl).toBe('https://github.example.com/api/v3');
+	});
+});

--- a/src/remotes/githubConnection.test.ts
+++ b/src/remotes/githubConnection.test.ts
@@ -3,8 +3,8 @@ import { GitHubConnection } from './githubConnection';
 import { __getLastOctokitOptions } from '../__mocks__/@octokit/core';
 
 describe('GitHubConnection', () => {
-	it('targets api.github.com when no host is configured', () => {
-		new GitHubConnection('fake-pat');
+	it('targets api.github.com', () => {
+		new GitHubConnection('fake-pat', "github.com");
 		expect(__getLastOctokitOptions()?.baseUrl).toBe('https://api.github.com');
 	});
 

--- a/src/remotes/githubConnection.ts
+++ b/src/remotes/githubConnection.ts
@@ -14,6 +14,7 @@
 
 import { Octokit } from "@octokit/core";
 import { retry } from "@octokit/plugin-retry";
+import { resolveGitHubHost } from "./githubHost";
 import { VaultError } from "../vault";
 
 /**
@@ -51,11 +52,16 @@ export class GitHubConnection {
 	// Cached authenticated user info (populated on first getAuthenticatedUser call)
 	private cachedAuthUser: AuthenticatedUser | null = null;
 
-	constructor(pat: string) {
+	/**
+	 * @param pat - Personal access token
+	 * @param githubHost - github server host, defaults to github.com
+	 */
+	constructor(pat: string, githubHost = "") {
 		this.pat = pat;
 		const OctokitWithRetry = Octokit.plugin(retry);
 		this.octokit = new OctokitWithRetry({
 			auth: pat,
+			baseUrl: resolveGitHubHost(githubHost).apiBaseUrl,
 			request: {
 				retries: 3,
 				doNotRetry: [400, 401, 403, 404, 422]

--- a/src/remotes/githubConnection.ts
+++ b/src/remotes/githubConnection.ts
@@ -40,7 +40,7 @@ export class ConnectionConfigError extends Error {
  * Handles authentication, repository discovery, and Octokit instance management.
  *
  * Usage:
- *   const conn = new GitHubConnection(pat);
+ *   const conn = new GitHubConnection(pat, githubHost);
  *   const user = await conn.getAuthenticatedUser();
  *   const repos = await conn.getReposForOwner(user.owner);
  */
@@ -52,8 +52,8 @@ export class GitHubConnection {
 	// Cached authenticated user info (populated on first getAuthenticatedUser call)
 	private cachedAuthUser: AuthenticatedUser | null = null;
 
-	/** @param githubHost - Enterprise Server host; empty means github.com */
-	constructor(pat: string, githubHost = "") {
+	/** @param githubHost - Hostname to connect to */
+	constructor(pat: string, githubHost: string) {
 		this.pat = pat;
 		const OctokitWithRetry = Octokit.plugin(retry);
 		this.octokit = new OctokitWithRetry({

--- a/src/remotes/githubConnection.ts
+++ b/src/remotes/githubConnection.ts
@@ -52,7 +52,6 @@ export class GitHubConnection {
 	// Cached authenticated user info (populated on first getAuthenticatedUser call)
 	private cachedAuthUser: AuthenticatedUser | null = null;
 
-	/** @param githubHost - Hostname to connect to */
 	constructor(pat: string, githubHost: string) {
 		this.pat = pat;
 		const OctokitWithRetry = Octokit.plugin(retry);

--- a/src/remotes/githubConnection.ts
+++ b/src/remotes/githubConnection.ts
@@ -52,10 +52,7 @@ export class GitHubConnection {
 	// Cached authenticated user info (populated on first getAuthenticatedUser call)
 	private cachedAuthUser: AuthenticatedUser | null = null;
 
-	/**
-	 * @param pat - Personal access token
-	 * @param githubHost - github server host, defaults to github.com
-	 */
+	/** @param githubHost - Enterprise Server host; empty means github.com */
 	constructor(pat: string, githubHost = "") {
 		this.pat = pat;
 		const OctokitWithRetry = Octokit.plugin(retry);

--- a/src/remotes/githubConnection.ts
+++ b/src/remotes/githubConnection.ts
@@ -14,7 +14,7 @@
 
 import { Octokit } from "@octokit/core";
 import { retry } from "@octokit/plugin-retry";
-import { resolveGitHubHost } from "./githubHost";
+import { apiBaseUrl } from "./githubHost";
 import { VaultError } from "../vault";
 
 /**
@@ -58,7 +58,7 @@ export class GitHubConnection {
 		const OctokitWithRetry = Octokit.plugin(retry);
 		this.octokit = new OctokitWithRetry({
 			auth: pat,
-			baseUrl: resolveGitHubHost(githubHost).apiBaseUrl,
+			baseUrl: apiBaseUrl(githubHost),
 			request: {
 				retries: 3,
 				doNotRetry: [400, 401, 403, 404, 422]

--- a/src/remotes/githubHost.test.ts
+++ b/src/remotes/githubHost.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { resolveGitHubHost, tokenCreationUrl, treeUrl } from './githubHost';
+
+describe('resolveGitHubHost', () => {
+	it.each([
+		['', 'https://api.github.com', 'https://github.com', false],
+		['github.com', 'https://api.github.com', 'https://github.com', false],
+		['  https://github.com/  ', 'https://api.github.com', 'https://github.com', false],
+		['github.example.com', 'https://github.example.com/api/v3', 'https://github.example.com', true],
+		['https://github.example.com/api/v3', 'https://github.example.com/api/v3', 'https://github.example.com', true],
+		['http://git.internal', 'http://git.internal/api/v3', 'http://git.internal', true],
+	])('resolves %j to the right base URLs', (githubHost, apiBaseUrl, webBaseUrl, isEnterprise) => {
+		const urls = resolveGitHubHost(githubHost as string);
+		expect(urls.apiBaseUrl).toBe(apiBaseUrl);
+		expect(urls.webBaseUrl).toBe(webBaseUrl);
+		expect(urls.isEnterprise).toBe(isEnterprise);
+	});
+});
+
+describe('web URLs', () => {
+	it('links the classic token page on Enterprise Server, fine-grained on github.com', () => {
+		expect(tokenCreationUrl(resolveGitHubHost('github.example.com')))
+			.toBe('https://github.example.com/settings/tokens/new?description=Obsidian%20FIT&scopes=repo');
+		expect(tokenCreationUrl(resolveGitHubHost(''))).toContain('https://github.com/settings/personal-access-tokens/new');
+	});
+
+	it('builds tree URLs on the configured host', () => {
+		expect(treeUrl(resolveGitHubHost('github.example.com'), 'alice', 'vault', 'main'))
+			.toBe('https://github.example.com/alice/vault/tree/main');
+	});
+});

--- a/src/remotes/githubHost.test.ts
+++ b/src/remotes/githubHost.test.ts
@@ -18,10 +18,11 @@ describe('resolveGitHubHost', () => {
 });
 
 describe('web URLs', () => {
-	it('links the classic token page on Enterprise Server, fine-grained on github.com', () => {
+	it('links the classic token page on every host', () => {
 		expect(tokenCreationUrl(resolveGitHubHost('github.example.com')))
 			.toBe('https://github.example.com/settings/tokens/new?description=Obsidian%20FIT&scopes=repo');
-		expect(tokenCreationUrl(resolveGitHubHost(''))).toContain('https://github.com/settings/personal-access-tokens/new');
+		expect(tokenCreationUrl(resolveGitHubHost('')))
+			.toBe('https://github.com/settings/tokens/new?description=Obsidian%20FIT&scopes=repo');
 	});
 
 	it('builds tree URLs on the configured host', () => {

--- a/src/remotes/githubHost.test.ts
+++ b/src/remotes/githubHost.test.ts
@@ -3,12 +3,10 @@ import { apiBaseUrl, tokenCreationUrl, treeUrl, webBaseUrl } from './githubHost'
 
 describe('githubHost', () => {
 	it.each([
-		['', 'https://api.github.com', 'https://github.com'],
 		['github.com', 'https://api.github.com', 'https://github.com'],
-		['  https://github.com/  ', 'https://api.github.com', 'https://github.com'],
+		['  github.com  ', 'https://api.github.com', 'https://github.com'],
+		['GitHub.com', 'https://api.github.com', 'https://github.com'],
 		['github.example.com', 'https://github.example.com/api/v3', 'https://github.example.com'],
-		['https://github.example.com/api/v3', 'https://github.example.com/api/v3', 'https://github.example.com'],
-		['http://git.internal', 'http://git.internal/api/v3', 'http://git.internal'],
 	])('resolves %j to the right base URLs', (githubHost, expectedApiUrl, expectedWebUrl) => {
 		expect(apiBaseUrl(githubHost)).toBe(expectedApiUrl);
 		expect(webBaseUrl(githubHost)).toBe(expectedWebUrl);
@@ -17,7 +15,7 @@ describe('githubHost', () => {
 	it('links the fine-grained token page on every host', () => {
 		expect(tokenCreationUrl('github.example.com'))
 			.toBe('https://github.example.com/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write');
-		expect(tokenCreationUrl(''))
+		expect(tokenCreationUrl('github.com'))
 			.toBe('https://github.com/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write');
 	});
 

--- a/src/remotes/githubHost.test.ts
+++ b/src/remotes/githubHost.test.ts
@@ -3,17 +3,16 @@ import { resolveGitHubHost, tokenCreationUrl, treeUrl } from './githubHost';
 
 describe('resolveGitHubHost', () => {
 	it.each([
-		['', 'https://api.github.com', 'https://github.com', false],
-		['github.com', 'https://api.github.com', 'https://github.com', false],
-		['  https://github.com/  ', 'https://api.github.com', 'https://github.com', false],
-		['github.example.com', 'https://github.example.com/api/v3', 'https://github.example.com', true],
-		['https://github.example.com/api/v3', 'https://github.example.com/api/v3', 'https://github.example.com', true],
-		['http://git.internal', 'http://git.internal/api/v3', 'http://git.internal', true],
-	])('resolves %j to the right base URLs', (githubHost, apiBaseUrl, webBaseUrl, isEnterprise) => {
-		const urls = resolveGitHubHost(githubHost as string);
+		['', 'https://api.github.com', 'https://github.com'],
+		['github.com', 'https://api.github.com', 'https://github.com'],
+		['  https://github.com/  ', 'https://api.github.com', 'https://github.com'],
+		['github.example.com', 'https://github.example.com/api/v3', 'https://github.example.com'],
+		['https://github.example.com/api/v3', 'https://github.example.com/api/v3', 'https://github.example.com'],
+		['http://git.internal', 'http://git.internal/api/v3', 'http://git.internal'],
+	])('resolves %j to the right base URLs', (githubHost, apiBaseUrl, webBaseUrl) => {
+		const urls = resolveGitHubHost(githubHost);
 		expect(urls.apiBaseUrl).toBe(apiBaseUrl);
 		expect(urls.webBaseUrl).toBe(webBaseUrl);
-		expect(urls.isEnterprise).toBe(isEnterprise);
 	});
 });
 

--- a/src/remotes/githubHost.test.ts
+++ b/src/remotes/githubHost.test.ts
@@ -14,11 +14,11 @@ describe('githubHost', () => {
 		expect(webBaseUrl(githubHost)).toBe(expectedWebUrl);
 	});
 
-	it('links the classic token page on every host', () => {
+	it('links the fine-grained token page on every host', () => {
 		expect(tokenCreationUrl('github.example.com'))
-			.toBe('https://github.example.com/settings/tokens/new?description=Obsidian%20FIT&scopes=repo');
+			.toBe('https://github.example.com/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write');
 		expect(tokenCreationUrl(''))
-			.toBe('https://github.com/settings/tokens/new?description=Obsidian%20FIT&scopes=repo');
+			.toBe('https://github.com/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write');
 	});
 
 	it('builds tree URLs on the configured host', () => {

--- a/src/remotes/githubHost.test.ts
+++ b/src/remotes/githubHost.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { resolveGitHubHost, tokenCreationUrl, treeUrl } from './githubHost';
+import { apiBaseUrl, tokenCreationUrl, treeUrl, webBaseUrl } from './githubHost';
 
-describe('resolveGitHubHost', () => {
+describe('githubHost', () => {
 	it.each([
 		['', 'https://api.github.com', 'https://github.com'],
 		['github.com', 'https://api.github.com', 'https://github.com'],
@@ -9,23 +9,20 @@ describe('resolveGitHubHost', () => {
 		['github.example.com', 'https://github.example.com/api/v3', 'https://github.example.com'],
 		['https://github.example.com/api/v3', 'https://github.example.com/api/v3', 'https://github.example.com'],
 		['http://git.internal', 'http://git.internal/api/v3', 'http://git.internal'],
-	])('resolves %j to the right base URLs', (githubHost, apiBaseUrl, webBaseUrl) => {
-		const urls = resolveGitHubHost(githubHost);
-		expect(urls.apiBaseUrl).toBe(apiBaseUrl);
-		expect(urls.webBaseUrl).toBe(webBaseUrl);
+	])('resolves %j to the right base URLs', (githubHost, expectedApiUrl, expectedWebUrl) => {
+		expect(apiBaseUrl(githubHost)).toBe(expectedApiUrl);
+		expect(webBaseUrl(githubHost)).toBe(expectedWebUrl);
 	});
-});
 
-describe('web URLs', () => {
 	it('links the classic token page on every host', () => {
-		expect(tokenCreationUrl(resolveGitHubHost('github.example.com')))
+		expect(tokenCreationUrl('github.example.com'))
 			.toBe('https://github.example.com/settings/tokens/new?description=Obsidian%20FIT&scopes=repo');
-		expect(tokenCreationUrl(resolveGitHubHost('')))
+		expect(tokenCreationUrl(''))
 			.toBe('https://github.com/settings/tokens/new?description=Obsidian%20FIT&scopes=repo');
 	});
 
 	it('builds tree URLs on the configured host', () => {
-		expect(treeUrl(resolveGitHubHost('github.example.com'), 'alice', 'vault', 'main'))
+		expect(treeUrl('github.example.com', 'alice', 'vault', 'main'))
 			.toBe('https://github.example.com/alice/vault/tree/main');
 	});
 });

--- a/src/remotes/githubHost.ts
+++ b/src/remotes/githubHost.ts
@@ -41,11 +41,11 @@ export function apiBaseUrl(githubHost: string): string {
 }
 
 /**
- * URL of the classic token creation page, pre-filled with the access FIT needs.
- * fine-grained tokens also work, but are not turned on for all instances
+ * URL of the fine-grained token creation page, pre-filled with the access FIT needs.
+ * classic tokens also work, but are less desirable from a security perspective
  */
 export function tokenCreationUrl(githubHost: string): string {
-	return `${webBaseUrl(githubHost)}/settings/tokens/new?description=Obsidian%20FIT&scopes=repo`;
+	return `${webBaseUrl(githubHost)}/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write`;
 }
 
 /** URL of the web view of a repository at a branch or commit. */

--- a/src/remotes/githubHost.ts
+++ b/src/remotes/githubHost.ts
@@ -1,13 +1,8 @@
 /**
  * GitHub Host Resolution
  *
- * Resolves the configured host into the API base URL used by Octokit and the web
- * base URL used for browser links. GitHub Enterprise Server serves the same v3
- * REST API as github.com under /api/v3, so pointing both at a different origin is
- * all that separates a self-hosted instance from github.com.
- *
- * Note: this is host resolution for GitHub only, not provider selection. GitLab and
- * Gitea need different API clients — see the TODO in githubConnection.ts.
+ * Resolves the configured host into the API base URL used by Octokit
+ * this handles differentiating github.com and self-hosted github instances - though they use the same api
  */
 
 export const DOTCOM_HOST = "github.com";
@@ -23,6 +18,7 @@ export interface GitHubHostUrls {
 	isEnterprise: boolean;
 }
 
+// default hosts used when a specific host is not specified
 const DOTCOM_URLS: GitHubHostUrls = {
 	host: DOTCOM_HOST,
 	apiBaseUrl: "https://api.github.com",
@@ -31,12 +27,10 @@ const DOTCOM_URLS: GitHubHostUrls = {
 };
 
 /**
- * Resolve the githubHost setting into API and web base URLs.
- *
- * Accepts bare hostnames ("github.example.com"), full URLs ("https://github.example.com")
- * and API URLs ("https://github.example.com/api/v3"), since users copy whichever of the
- * three they have at hand. An explicit http:// scheme is preserved for instances that
- * aren't served over TLS; everything else defaults to https.
+ * Resolve the githubHost setting into API and web base URLs. Accepts:
+ * - hostnames: github.example.com
+ * - urls: https://github.example.com
+ * - api urls: https://github.example.com/api/v3
  *
  * @param githubHost - The githubHost setting; empty means github.com
  */
@@ -50,7 +44,7 @@ export function resolveGitHubHost(githubHost: string): GitHubHostUrls {
 	const scheme = schemeMatch ? schemeMatch[1].toLowerCase() : "https";
 	const host = (schemeMatch ? schemeMatch[2] : configured)
 		.replace(/\/+$/, "")
-		.replace(/\/api\/v3$/i, "")   // user pasted the API URL instead of the host
+		.replace(/\/api\/v3$/i, "")
 		.replace(/\/+$/, "");
 
 	if (DOTCOM_ALIASES.has(host.toLowerCase())) {
@@ -67,17 +61,11 @@ export function resolveGitHubHost(githubHost: string): GitHubHostUrls {
 }
 
 /**
- * URL of the token creation page, pre-filled with the access FIT needs.
- *
- * Enterprise Server gets the classic token page: fine-grained tokens have to be
- * enabled by the instance administrator, while classic tokens are always available.
- * The `repo` scope is the narrowest classic scope that grants Contents: Read and Write.
+ * URL of the classic token creation page, pre-filled with the access FIT needs.
+ * fine-grained tokens also work, but are not turned on for all instances
  */
 export function tokenCreationUrl(urls: GitHubHostUrls): string {
-	if (urls.isEnterprise) {
-		return `${urls.webBaseUrl}/settings/tokens/new?description=Obsidian%20FIT&scopes=repo`;
-	}
-	return `${urls.webBaseUrl}/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write`;
+	return `${urls.webBaseUrl}/settings/tokens/new?description=Obsidian%20FIT&scopes=repo`;
 }
 
 /** URL of the web view of a repository at a branch or commit. */

--- a/src/remotes/githubHost.ts
+++ b/src/remotes/githubHost.ts
@@ -1,0 +1,86 @@
+/**
+ * GitHub Host Resolution
+ *
+ * Resolves the configured host into the API base URL used by Octokit and the web
+ * base URL used for browser links. GitHub Enterprise Server serves the same v3
+ * REST API as github.com under /api/v3, so pointing both at a different origin is
+ * all that separates a self-hosted instance from github.com.
+ *
+ * Note: this is host resolution for GitHub only, not provider selection. GitLab and
+ * Gitea need different API clients — see the TODO in githubConnection.ts.
+ */
+
+export const DOTCOM_HOST = "github.com";
+
+/** Hosts that resolve to github.com rather than an Enterprise Server instance. */
+const DOTCOM_ALIASES = new Set([DOTCOM_HOST, "www.github.com", "api.github.com"]);
+
+/** Where to reach a configured GitHub host, for API calls and for browser links. */
+export interface GitHubHostUrls {
+	host: string;         // Bare hostname, e.g. "github.com" or "github.example.com"
+	apiBaseUrl: string;   // Octokit baseUrl, e.g. "https://api.github.com"
+	webBaseUrl: string;   // Origin for user-facing links, e.g. "https://github.com"
+	isEnterprise: boolean;
+}
+
+const DOTCOM_URLS: GitHubHostUrls = {
+	host: DOTCOM_HOST,
+	apiBaseUrl: "https://api.github.com",
+	webBaseUrl: "https://github.com",
+	isEnterprise: false,
+};
+
+/**
+ * Resolve the githubHost setting into API and web base URLs.
+ *
+ * Accepts bare hostnames ("github.example.com"), full URLs ("https://github.example.com")
+ * and API URLs ("https://github.example.com/api/v3"), since users copy whichever of the
+ * three they have at hand. An explicit http:// scheme is preserved for instances that
+ * aren't served over TLS; everything else defaults to https.
+ *
+ * @param githubHost - The githubHost setting; empty means github.com
+ */
+export function resolveGitHubHost(githubHost: string): GitHubHostUrls {
+	const configured = githubHost.trim();
+	if (configured === "") {
+		return DOTCOM_URLS;
+	}
+
+	const schemeMatch = configured.match(/^(https?):\/\/(.*)$/i);
+	const scheme = schemeMatch ? schemeMatch[1].toLowerCase() : "https";
+	const host = (schemeMatch ? schemeMatch[2] : configured)
+		.replace(/\/+$/, "")
+		.replace(/\/api\/v3$/i, "")   // user pasted the API URL instead of the host
+		.replace(/\/+$/, "");
+
+	if (DOTCOM_ALIASES.has(host.toLowerCase())) {
+		return DOTCOM_URLS;
+	}
+
+	const webBaseUrl = `${scheme}://${host}`;
+	return {
+		host,
+		apiBaseUrl: `${webBaseUrl}/api/v3`,
+		webBaseUrl,
+		isEnterprise: true,
+	};
+}
+
+/**
+ * URL of the token creation page, pre-filled with the access FIT needs.
+ *
+ * Enterprise Server gets the classic token page: fine-grained tokens have to be
+ * enabled by the instance administrator, while classic tokens are always available.
+ * The `repo` scope is the narrowest classic scope that grants Contents: Read and Write.
+ */
+export function tokenCreationUrl(urls: GitHubHostUrls): string {
+	if (urls.isEnterprise) {
+		return `${urls.webBaseUrl}/settings/tokens/new?description=Obsidian%20FIT&scopes=repo`;
+	}
+	return `${urls.webBaseUrl}/settings/personal-access-tokens/new?name=Obsidian%20FIT&description=Obsidian%20FIT%20plugin&contents=write`;
+}
+
+/** URL of the web view of a repository at a branch or commit. */
+export function treeUrl(urls: GitHubHostUrls, owner: string, repo: string, ref: string): string {
+	return `${urls.webBaseUrl}/${owner}/${repo}/tree/${ref}`;
+}

--- a/src/remotes/githubHost.ts
+++ b/src/remotes/githubHost.ts
@@ -5,39 +5,27 @@
  * this handles differentiating github.com and self-hosted github instances - though they use the same api
  */
 
-const DOTCOM_WEB_URL = "https://github.com";
+const DOTCOM_HOST = "github.com";
 const DOTCOM_API_URL = "https://api.github.com";
 
-/** Hosts that resolve to github.com rather than an Enterprise Server instance. */
-const DOTCOM_ALIASES = new Set(["github.com", "www.github.com", "api.github.com"]);
+function normalizeHost(githubHost: string): string {
+	return githubHost.trim().toLowerCase();
+}
 
 /**
- * Origin for user-facing links, e.g. "https://github.example.com". Accepts:
- * - hostnames: github.example.com
- * - urls: https://github.example.com
- * - api urls: https://github.example.com/api/v3
+ * Origin for user-facing links, e.g. "https://github.example.com".
  *
- * @param githubHost - The githubHost setting; empty means github.com
+ * @param githubHost - Bare hostname, e.g. "github.example.com" or "github.com"
  */
 export function webBaseUrl(githubHost: string): string {
-	const configured = githubHost.trim();
-	const schemeMatch = configured.match(/^(https?):\/\/(.*)$/i);
-	const host = (schemeMatch ? schemeMatch[2] : configured)
-		.replace(/\/+$/, "")
-		.replace(/\/api\/v3$/i, "");
-
-	if (host === "" || DOTCOM_ALIASES.has(host.toLowerCase())) {
-		return DOTCOM_WEB_URL;
-	}
-	const scheme = schemeMatch ? schemeMatch[1].toLowerCase() : "https";
-	return `${scheme}://${host}`;
+	return `https://${normalizeHost(githubHost)}`;
 }
 
 /** Octokit baseUrl for the configured host. */
 export function apiBaseUrl(githubHost: string): string {
-	const webUrl = webBaseUrl(githubHost);
+	const host = normalizeHost(githubHost);
 	// github.com is the only host that serves its API from a separate origin
-	return webUrl === DOTCOM_WEB_URL ? DOTCOM_API_URL : `${webUrl}/api/v3`;
+	return host === DOTCOM_HOST ? DOTCOM_API_URL : `https://${host}/api/v3`;
 }
 
 /**

--- a/src/remotes/githubHost.ts
+++ b/src/remotes/githubHost.ts
@@ -5,25 +5,19 @@
  * this handles differentiating github.com and self-hosted github instances - though they use the same api
  */
 
-export const DOTCOM_HOST = "github.com";
-
 /** Hosts that resolve to github.com rather than an Enterprise Server instance. */
-const DOTCOM_ALIASES = new Set([DOTCOM_HOST, "www.github.com", "api.github.com"]);
+const DOTCOM_ALIASES = new Set(["github.com", "www.github.com", "api.github.com"]);
 
 /** Where to reach a configured GitHub host, for API calls and for browser links. */
 export interface GitHubHostUrls {
-	host: string;         // Bare hostname, e.g. "github.com" or "github.example.com"
 	apiBaseUrl: string;   // Octokit baseUrl, e.g. "https://api.github.com"
 	webBaseUrl: string;   // Origin for user-facing links, e.g. "https://github.com"
-	isEnterprise: boolean;
 }
 
 // default hosts used when a specific host is not specified
 const DOTCOM_URLS: GitHubHostUrls = {
-	host: DOTCOM_HOST,
 	apiBaseUrl: "https://api.github.com",
 	webBaseUrl: "https://github.com",
-	isEnterprise: false,
 };
 
 /**
@@ -44,8 +38,7 @@ export function resolveGitHubHost(githubHost: string): GitHubHostUrls {
 	const scheme = schemeMatch ? schemeMatch[1].toLowerCase() : "https";
 	const host = (schemeMatch ? schemeMatch[2] : configured)
 		.replace(/\/+$/, "")
-		.replace(/\/api\/v3$/i, "")
-		.replace(/\/+$/, "");
+		.replace(/\/api\/v3$/i, "");
 
 	if (DOTCOM_ALIASES.has(host.toLowerCase())) {
 		return DOTCOM_URLS;
@@ -53,10 +46,8 @@ export function resolveGitHubHost(githubHost: string): GitHubHostUrls {
 
 	const webBaseUrl = `${scheme}://${host}`;
 	return {
-		host,
 		apiBaseUrl: `${webBaseUrl}/api/v3`,
 		webBaseUrl,
-		isEnterprise: true,
 	};
 }
 

--- a/src/remotes/githubHost.ts
+++ b/src/remotes/githubHost.ts
@@ -5,61 +5,50 @@
  * this handles differentiating github.com and self-hosted github instances - though they use the same api
  */
 
+const DOTCOM_WEB_URL = "https://github.com";
+const DOTCOM_API_URL = "https://api.github.com";
+
 /** Hosts that resolve to github.com rather than an Enterprise Server instance. */
 const DOTCOM_ALIASES = new Set(["github.com", "www.github.com", "api.github.com"]);
 
-/** Where to reach a configured GitHub host, for API calls and for browser links. */
-export interface GitHubHostUrls {
-	apiBaseUrl: string;   // Octokit baseUrl, e.g. "https://api.github.com"
-	webBaseUrl: string;   // Origin for user-facing links, e.g. "https://github.com"
-}
-
-// default hosts used when a specific host is not specified
-const DOTCOM_URLS: GitHubHostUrls = {
-	apiBaseUrl: "https://api.github.com",
-	webBaseUrl: "https://github.com",
-};
-
 /**
- * Resolve the githubHost setting into API and web base URLs. Accepts:
+ * Origin for user-facing links, e.g. "https://github.example.com". Accepts:
  * - hostnames: github.example.com
  * - urls: https://github.example.com
  * - api urls: https://github.example.com/api/v3
  *
  * @param githubHost - The githubHost setting; empty means github.com
  */
-export function resolveGitHubHost(githubHost: string): GitHubHostUrls {
+export function webBaseUrl(githubHost: string): string {
 	const configured = githubHost.trim();
-	if (configured === "") {
-		return DOTCOM_URLS;
-	}
-
 	const schemeMatch = configured.match(/^(https?):\/\/(.*)$/i);
-	const scheme = schemeMatch ? schemeMatch[1].toLowerCase() : "https";
 	const host = (schemeMatch ? schemeMatch[2] : configured)
 		.replace(/\/+$/, "")
 		.replace(/\/api\/v3$/i, "");
 
-	if (DOTCOM_ALIASES.has(host.toLowerCase())) {
-		return DOTCOM_URLS;
+	if (host === "" || DOTCOM_ALIASES.has(host.toLowerCase())) {
+		return DOTCOM_WEB_URL;
 	}
+	const scheme = schemeMatch ? schemeMatch[1].toLowerCase() : "https";
+	return `${scheme}://${host}`;
+}
 
-	const webBaseUrl = `${scheme}://${host}`;
-	return {
-		apiBaseUrl: `${webBaseUrl}/api/v3`,
-		webBaseUrl,
-	};
+/** Octokit baseUrl for the configured host. */
+export function apiBaseUrl(githubHost: string): string {
+	const webUrl = webBaseUrl(githubHost);
+	// github.com is the only host that serves its API from a separate origin
+	return webUrl === DOTCOM_WEB_URL ? DOTCOM_API_URL : `${webUrl}/api/v3`;
 }
 
 /**
  * URL of the classic token creation page, pre-filled with the access FIT needs.
  * fine-grained tokens also work, but are not turned on for all instances
  */
-export function tokenCreationUrl(urls: GitHubHostUrls): string {
-	return `${urls.webBaseUrl}/settings/tokens/new?description=Obsidian%20FIT&scopes=repo`;
+export function tokenCreationUrl(githubHost: string): string {
+	return `${webBaseUrl(githubHost)}/settings/tokens/new?description=Obsidian%20FIT&scopes=repo`;
 }
 
 /** URL of the web view of a repository at a branch or commit. */
-export function treeUrl(urls: GitHubHostUrls, owner: string, repo: string, ref: string): string {
-	return `${urls.webBaseUrl}/${owner}/${repo}/tree/${ref}`;
+export function treeUrl(githubHost: string, owner: string, repo: string, ref: string): string {
+	return `${webBaseUrl(githubHost)}/${owner}/${repo}/tree/${ref}`;
 }


### PR DESCRIPTION
This PR adds support for non-github.com github hosts (github enterprise server instances).

Pretty much all it does is remove the hardcoded github.com and replace it with a field in the settings where the user can input their github host url. The default is a empty field, which is treated as github.com so it is backwards compatible.


Tested on linux desktop and iOS apps:

<img width="958" height="792" alt="image" src="https://github.com/user-attachments/assets/800538bf-b07c-4d09-9803-76011d0fdb47" />

I added some tests in src/remotes/githubHost.test.ts to make sure we got the url parsing right

---

<!-- kody-pr-summary:start -->
## Summary

This pull request adds support for **GitHub Enterprise Server** (self-hosted GitHub instances), allowing users to sync with repositories hosted on their own GitHub servers in addition to the default `github.com`.

## What's changed

### New `githubHost` setting
- Added a new `githubHost` field to `FitSettings`, defaulting to `github.com`.
- The settings tab now exposes a **"GitHub host (advanced)"** input where users can specify a custom hostname (e.g., `github.example.com`).
- Existing vaults without this field are automatically defaulted to `github.com` for backward compatibility.

### Host-aware API and web URL resolution
- New utility module (`src/remotes/githubHost.ts`) resolves:
  - **API base URL** for Octokit: `https://api.github.com` for `github.com`, or `https://<host>/api/v3` for enterprise instances.
  - **Web base URL** for user-facing links (repo pages, commit trees, token creation).
- The `GitHubConnection` and `RemoteGitHubVault` classes now accept the host and pass the correct `baseUrl` to Octokit, enabling authentication, repository discovery, and sync operations against enterprise instances.

### Updated UI links
- The token creation link, "Create new repository" button, and repository tree links now point to the configured host instead of always using `github.com`.

### Host change handling
- The plugin now detects when the host changes and recreates the GitHub connection accordingly (previously only PAT changes were detected).

### Tests and documentation
- Added unit tests covering host resolution (including trimming, case-insensitivity) and API base URL selection for both `github.com` and enterprise hosts.
- Updated tests to verify client configuration (baseUrl) and legacy settings migration.
- Documentation updated to mention GHE support (with a note that stable release wording is pending in the README).

## Backward compatibility
Existing users are unaffected – the default host remains `github.com`, and any saved settings without `githubHost` will be treated as `github.com`.
<!-- kody-pr-summary:end -->