### PR TITLE
fix: First sync doesn't download existing repo content on a fresh vault

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -1086,7 +1086,17 @@ This confusing message comes from Obsidian's Vault API when `createBinary()` fin
 **Fix:**
 `ensureFolderExists()` now validates type with `instanceof TFile` / `instanceof TFolder` checks, explicitly failing fast with clear error message when a file blocks folder creation.
 
+**Failure isolation:** `LocalVault.applyChanges()` writes files concurrently via `Promise.allSettled` and does not abort the batch when one file fails — the failing path is reported via `failedPaths` (excluded from the sync baseline so it's retried next sync) while every other file in the batch still lands normally. This also covers the more common trigger of this class of error: two files landing in the same not-yet-created folder race to create it, and one loses. Before this, `applyChanges()` treated any single per-file failure as cause to throw for the entire batch, discarding already-successful writes and — because nothing gets persisted on a thrown/failed sync — leaving the whole batch stuck retrying forever if the failure was deterministic (see "First sync downloads nothing" below).
+
 **Related:** PR #108 (race condition fix)
+
+### First sync downloads nothing beyond later edits
+
+**Scenario:** A brand-new (empty) local vault connects to an existing, populated remote repo. The first sync correctly detects every remote file as `ADDED` (see [Initial Sync](#initial-sync)), but none of them appear locally — only files edited by another client *after* that point ever show up.
+
+**Root cause:** `LocalVault.applyChanges()` used to throw a single `VaultError` for the *entire* write batch whenever any one file failed to write (see `ensureFolderExists()` race above) — even though writes run concurrently via `Promise.allSettled` specifically to isolate per-file failures. That throw aborted `FitSync._doSync()` before the sync-state persistence step, so nothing was saved — not even the files that wrote successfully moments earlier. Since a failed sync leaves the baseline untouched, every retry re-detected the exact same file set and was liable to hit the exact same race again, appearing to "never" download the pre-existing content. A later edit from another client syncs a single file in isolation, well clear of any folder-creation race, and goes through — which is why edits appear to work while the original bulk content never does.
+
+**Fix:** local write/delete failures are now reported per-file via `failedPaths` instead of throwing (see above). `FitSync.executeSync()` excludes `failedPaths` from the persisted baseline (`lastFetchedRemoteShas` for write failures; the file's existing `localShas` entry is preserved, not deleted, for delete failures) so those specific paths are re-detected as changed and retried on the next sync, while every other file in the batch is written and tracked normally in the same sync. A "Sync incomplete — N file(s) couldn't be written locally... They will be retried automatically on the next sync" notice surfaces this instead of it failing silently.
 
 ### Encoding Corruption (Issue #51)
 

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1774,12 +1774,9 @@ describe('FitSync', () => {
 			const result = await fitSync.sync(mockNotice as any);
 
 			expect(result.success).toBe(true);
-			expect(localVault.getAllFilesAsRaw()['good-file.md']).toBeDefined();
-			expect(localStoreState.localShas['good-file.md']).toBeDefined();
-			expect(localStoreState.localShas['readonly-file.md']).toBeUndefined();
-			expect(localStoreState.localShas['another-readonly.md']).toBeUndefined();
-			expect(localStoreState.lastFetchedRemoteShas['readonly-file.md']).toBeUndefined();
-			expect(localStoreState.lastFetchedRemoteShas['another-readonly.md']).toBeUndefined();
+			expect(localVault.getAllFilesAsRaw()).toHaveProperty('good-file.md');
+			expect(localStoreState.localShas).toEqual({ 'good-file.md': expect.any(String) });
+			expect(localStoreState.lastFetchedRemoteShas).toEqual({ 'good-file.md': expect.any(String) });
 
 			expect(mockNotice._calls).toEqual([
 				{ method: 'setMessage', args: ['Checking for changes...'] },
@@ -1796,8 +1793,39 @@ describe('FitSync', () => {
 			const mockNotice2 = createMockNotice();
 			const result2 = await fitSync.sync(mockNotice2 as any);
 			expect(result2.success).toBe(true);
-			expect(localVault.getAllFilesAsRaw()['readonly-file.md']).toBeDefined();
-			expect(localVault.getAllFilesAsRaw()['another-readonly.md']).toBeDefined();
+			expect(localVault.getAllFilesAsRaw()).toEqual(expect.objectContaining({
+				'readonly-file.md': expect.anything(),
+				'another-readonly.md': expect.anything(),
+			}));
+		});
+
+		it('should retry a failed local delete next sync instead of losing track of the file', async () => {
+			const fitSync = createFitSync();
+
+			remoteVault.setFile('doomed.md', 'content');
+			await syncAndHandleResult(fitSync, createMockNotice());
+
+			await remoteVault.applyChanges([], ['doomed.md']);
+			localVault.setMockDeleteFile(async (path) => {
+				if (path === 'doomed.md') {
+					throw new Error('EBUSY: resource busy');
+				}
+			});
+
+			const result = await fitSync.sync(createMockNotice() as any);
+
+			expect(result.success).toBe(true);
+			expect(localVault.getAllFilesAsRaw()).toHaveProperty('doomed.md');
+			expect(localStoreState.localShas).toEqual({ 'doomed.md': expect.any(String) });
+			expect(localStoreState.lastFetchedRemoteShas).toEqual({ 'doomed.md': expect.any(String) });
+
+			localVault.setMockDeleteFile(null);
+			const result2 = await fitSync.sync(createMockNotice() as any);
+
+			expect(result2.success).toBe(true);
+			expect(localVault.getAllFilesAsRaw()).not.toHaveProperty('doomed.md');
+			expect(localStoreState.localShas).toEqual({});
+			expect(localStoreState.lastFetchedRemoteShas).toEqual({});
 		});
 
 		it('should handle remote write failures with file path in error message', async () => {

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -1751,8 +1751,7 @@ describe('FitSync', () => {
 			]);
 		});
 
-		it('should handle per-file write failures to local vault with detailed error message', async () => {
-			// Arrange
+		it('should write successful files despite other per-file local write failures, and retry the failed ones next sync', async () => {
 			const fitSync = createFitSync();
 
 			// Set up remote files that will need to be written locally
@@ -1772,20 +1771,33 @@ describe('FitSync', () => {
 
 			const mockNotice = createMockNotice();
 
-			// Act
-			await syncAndHandleResult(fitSync, mockNotice);
+			const result = await fitSync.sync(mockNotice as any);
 
-			// Assert - Verify error message shows which file failed to write (both files should be mentioned)
+			expect(result.success).toBe(true);
+			expect(localVault.getAllFilesAsRaw()['good-file.md']).toBeDefined();
+			expect(localStoreState.localShas['good-file.md']).toBeDefined();
+			expect(localStoreState.localShas['readonly-file.md']).toBeUndefined();
+			expect(localStoreState.localShas['another-readonly.md']).toBeUndefined();
+			expect(localStoreState.lastFetchedRemoteShas['readonly-file.md']).toBeUndefined();
+			expect(localStoreState.lastFetchedRemoteShas['another-readonly.md']).toBeUndefined();
+
 			expect(mockNotice._calls).toEqual([
 				{ method: 'setMessage', args: ['Checking for changes...'] },
 				{ method: 'setMessage', args: ['Uploading local changes'] },
 				{ method: 'setMessage', args: ['Writing remote changes to local'] },
 				{
 					method: 'setMessage', args: [
-						expect.stringMatching(/Sync failed:[\s\S]*(readonly-file\.md[\s\S]*another-readonly\.md|another-readonly\.md[\s\S]*readonly-file\.md)/),
-						true]
+						expect.stringMatching(/Sync incomplete[\s\S]*(readonly-file\.md[\s\S]*another-readonly\.md|another-readonly\.md[\s\S]*readonly-file\.md)/)
+					]
 				}
 			]);
+
+			localVault.setMockWriteFile(null);
+			const mockNotice2 = createMockNotice();
+			const result2 = await fitSync.sync(mockNotice2 as any);
+			expect(result2.success).toBe(true);
+			expect(localVault.getAllFilesAsRaw()['readonly-file.md']).toBeDefined();
+			expect(localVault.getAllFilesAsRaw()['another-readonly.md']).toBeDefined();
 		});
 
 		it('should handle remote write failures with file path in error message', async () => {

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -654,6 +654,8 @@ export class FitSync implements IFitSync {
 					const previousSha = this.fit.lastFetchedRemoteShas[path];
 					if (previousSha !== undefined) {
 						latestRemoteTreeSha[path] = previousSha;
+					} else {
+						fitLogger.log('⚠️ [FitSync] Delete-failed path missing expected baseline SHA — retry may not be detected', { path });
 					}
 				} else {
 					delete latestRemoteTreeSha[path];

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -88,6 +88,7 @@ type SyncExecutionResult = {
 	skippedWarning?: string;
 	/** Paths not uploaded due to a transient failure (localShas cleared so they retry next sync) */
 	rateLimitedPaths: string[];
+	localFailedPaths: string[];
 };
 
 export type ConflictResolutionResult = {
@@ -624,6 +625,14 @@ export class FitSync implements IFitSync {
 			});
 		}
 
+		const localFailedPaths = localFileOpsRecord.failedPaths ?? [];
+		const localFailedPathsSet = new Set(localFailedPaths);
+		if (localFailedPathsSet.size > 0) {
+			fitLogger.log(`⚠️ [FitSync] ${localFailedPathsSet.size} file(s) failed to apply locally — will retry next sync`, {
+				paths: localFailedPaths
+			});
+		}
+
 		// 3b'. Track protected path SHA arrivals for opt-in reconciliation.
 		// Remote changes to paths excluded by shouldSyncPath (e.g. .obsidian/ not opted in).
 		// Only the remote SHA is recorded — no content download, no _fit/ write.
@@ -636,6 +645,13 @@ export class FitSync implements IFitSync {
 			}
 			const remoteSha = remoteUpdate.remoteTreeSha[change.path];
 			if (remoteSha) this.fit.protectedPathShas[change.path] = remoteSha;
+		}
+
+		if (localFailedPathsSet.size > 0) {
+			latestRemoteTreeSha = { ...latestRemoteTreeSha };
+			for (const path of localFailedPathsSet) {
+				delete latestRemoteTreeSha[path];
+			}
 		}
 
 		// 3c. Update local state using SHAs computed by LocalVault (performance optimization)
@@ -653,7 +669,9 @@ export class FitSync implements IFitSync {
 
 		// Remove deleted files from state
 		for (const path of deleteFromLocalNonClashed) {
-			delete newLocalState[path];
+			if (!localFailedPathsSet.has(path)) {
+				delete newLocalState[path];
+			}
 		}
 
 		// Update pendingClashes: newly-clashed tracked files enter pending state.
@@ -748,6 +766,7 @@ export class FitSync implements IFitSync {
 			newlySkippedPaths,
 			skippedWarning: pushResult?.skippedWarning,
 			rateLimitedPaths,
+			localFailedPaths,
 		};
 	}
 
@@ -1005,7 +1024,7 @@ export class FitSync implements IFitSync {
 			];
 
 			// Phase 3: Execute - push, pull, persist (atomic operation)
-			const { localOps, remoteOps, conflicts: executedConflicts, newlySkippedPaths, skippedWarning, rateLimitedPaths } = await this.executeSync(
+			const { localOps, remoteOps, conflicts: executedConflicts, newlySkippedPaths, skippedWarning, rateLimitedPaths, localFailedPaths } = await this.executeSync(
 				currentLocalState,
 				{
 					remoteChanges,
@@ -1063,9 +1082,18 @@ export class FitSync implements IFitSync {
 				);
 			}
 
+			if (localFailedPaths.length > 0) {
+				const fileList = localFailedPaths.map(p => `• ${p}`).join('\n');
+				syncNotice.setMessage(
+					`Sync incomplete — ${localFailedPaths.length} file(s) couldn't be written locally, ` +
+					`possibly due to a filesystem error or a temporary conflict. ` +
+					`They will be retried automatically on the next sync.\n${fileList}`
+				);
+			}
+
 			// Set success message (only when not already replaced by the unpushed-files reminder
 			// or the partial-sync notice above)
-			if (rateLimitedPaths.length === 0 && (remainingUnpushed.length === 0 || isAutoSync || newlySkippedPaths.length > 0)) {
+			if (rateLimitedPaths.length === 0 && localFailedPaths.length === 0 && (remainingUnpushed.length === 0 || isAutoSync || newlySkippedPaths.length > 0)) {
 				if (executedConflicts.length === 0) {
 					syncNotice.setMessage(`Sync successful`);
 				} else if (executedConflicts.some(f => f.remoteOp !== "REMOVED")) {

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -650,7 +650,14 @@ export class FitSync implements IFitSync {
 		if (localFailedPathsSet.size > 0) {
 			latestRemoteTreeSha = { ...latestRemoteTreeSha };
 			for (const path of localFailedPathsSet) {
-				delete latestRemoteTreeSha[path];
+				if (deleteFromLocalNonClashed.includes(path)) {
+					const previousSha = this.fit.lastFetchedRemoteShas[path];
+					if (previousSha !== undefined) {
+						latestRemoteTreeSha[path] = previousSha;
+					}
+				} else {
+					delete latestRemoteTreeSha[path];
+				}
 			}
 		}
 

--- a/src/localVault.test.ts
+++ b/src/localVault.test.ts
@@ -524,13 +524,12 @@ describe('LocalVault', () => {
 
 			const localVault = new LocalVault(mockVault as any as Vault);
 
-			// Should throw error detecting file at folder path
-			await expect(
-				localVault.applyChanges(
-					[{ path: '_fit/.obsidian/workspace.json', content: FileContent.fromPlainText('{}') }],
-					[]
-				)
-			).rejects.toThrow(/file already exists at this path/);
+			const result = await localVault.applyChanges(
+				[{ path: '_fit/.obsidian/workspace.json', content: FileContent.fromPlainText('{}') }],
+				[]
+			);
+			expect(result.changes).toEqual([]);
+			expect(result.failedPaths).toEqual(['_fit/.obsidian/workspace.json']);
 		});
 
 		it('should succeed when parent folder already exists as a folder (issue #153)', async () => {

--- a/src/localVault.ts
+++ b/src/localVault.ts
@@ -626,7 +626,7 @@ export class LocalVault implements IVault<"local"> {
 		);
 
 		// Collect successful operations and failures
-		const writeResults: Array<{change: FileChange, shaPromise?: Promise<BlobSha>}> = [];
+		const writeResults: Array<{index: number, change: FileChange, shaPromise?: Promise<BlobSha>}> = [];
 		const writeFailures = collectSettledFailures(writeSettledResults, filesToWrite.map(f => f.path));
 
 		for (let i = 0; i < writeSettledResults.length; i++) {
@@ -635,7 +635,7 @@ export class LocalVault implements IVault<"local"> {
 
 			if (result.status === 'fulfilled') {
 				const {change, shaPromise} = result.value;
-				writeResults.push({ change, shaPromise: shaPromise ?? undefined });
+				writeResults.push({ index: i, change, shaPromise: shaPromise ?? undefined });
 			} else {
 				const failure = writeFailures.find(f => f.path === path);
 				fitLogger.log(`❌ [LocalVault] Failed to write file: ${path}`, failure?.error);
@@ -657,22 +657,7 @@ export class LocalVault implements IVault<"local"> {
 			}
 		}
 
-		// If any operations failed, throw VaultError with details
-		if (writeFailures.length > 0 || deleteFailures.length > 0) {
-			const allFailures = [...writeFailures, ...deleteFailures];
-			const failedPaths = allFailures.map(f => f.path);
-			const primaryPath = failedPaths[0];
-			const primaryError = allFailures[0].error;
-			const primaryMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
-
-			throw VaultError.filesystem(
-				`Failed to write to ${primaryPath}: ${primaryMessage}`,
-				{
-					failedPaths,
-					errors: allFailures
-				}
-			);
-		}
+		const failedPaths = [...writeFailures, ...deleteFailures].map(f => f.path);
 
 		// Extract file operations for return value
 		const writeOps = writeResults.map(r => r.change);
@@ -683,11 +668,10 @@ export class LocalVault implements IVault<"local"> {
 		// Only includes files with SHA computations (direct writes + untracked clashes) (#169)
 		// Tracked clash files are excluded (null shaPromise) as they self-heal via local scan
 		const shaPromiseMap: Record<string, Promise<BlobSha>> = {};
-		for (let i = 0; i < writeResults.length; i++) {
-			const result = writeResults[i];
+		for (const result of writeResults) {
 			if (result.shaPromise) {
 				// Key by original path from filesToWrite, not the write path (which may be _fit/...)
-				const originalPath = filesToWrite[i].path;
+				const originalPath = filesToWrite[result.index].path;
 				shaPromiseMap[originalPath] = result.shaPromise;
 			}
 		}
@@ -704,7 +688,8 @@ export class LocalVault implements IVault<"local"> {
 		return {
 			changes,
 			newBaselineStates,
-			userWarning
+			userWarning,
+			...(failedPaths.length > 0 && { failedPaths })
 		};
 	}
 }

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -689,31 +689,19 @@ export class FakeLocalVault implements IVault<"local"> {
 			}
 		}
 
-		// If any operations failed, throw VaultError with details
-		if (writeFailures.length > 0) {
-			const failedPaths = writeFailures.map(f => f.path);
-			const primaryPath = failedPaths[0];
-			const primaryError = writeFailures[0].error;
-			const primaryMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
-
-			throw VaultError.filesystem(
-				`Failed to write to ${primaryPath}: ${primaryMessage}`,
-				{
-					failedPaths,
-					errors: writeFailures
-				}
-			);
-		}
+		const failedPaths = writeFailures.map(f => f.path);
+		const succeededWrites = filesToWrite.filter(f => !failedPaths.includes(f.path));
 
 		const changes = [...writeResults, ...deletionResults];
 
 		// Start computing SHAs for written files asynchronously (for later retrieval)
 		// Only for trackable files that will appear in future scans
-		const newBaselineStates = this.computeWrittenFileShas(filesToWrite, clashPaths);
+		const newBaselineStates = this.computeWrittenFileShas(succeededWrites, clashPaths);
 
 		return {
 			changes,
-			newBaselineStates
+			newBaselineStates,
+			...(failedPaths.length > 0 && { failedPaths })
 		};
 	}
 

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -410,6 +410,7 @@ export class FakeLocalVault implements IVault<"local"> {
 	private failureScenarios: Map<FailureScenario, Error> = new Map();
 	private statLog: string[] = []; // Track all stat operations for performance testing
 	private mockWriteFile: ((path: string) => Promise<void>) | null = null; // Mock for writeFile operations
+	private mockDeleteFile: ((path: string) => Promise<void>) | null = null; // Mock for deleteFile operations
 
 	/**
 	 * Configure the vault to fail on a specific operation.
@@ -438,6 +439,10 @@ export class FakeLocalVault implements IVault<"local"> {
 	 */
 	setMockWriteFile(mockFn: ((path: string) => Promise<void>) | null): void {
 		this.mockWriteFile = mockFn;
+	}
+
+	setMockDeleteFile(mockFn: ((path: string) => Promise<void>) | null): void {
+		this.mockDeleteFile = mockFn;
 	}
 
 	/**
@@ -681,15 +686,31 @@ export class FakeLocalVault implements IVault<"local"> {
 		}
 
 		// Process deletions
+		const deletionSettledResults = await Promise.allSettled(
+			filesToDelete.map(async (path) => {
+				if (this.mockDeleteFile) {
+					await this.mockDeleteFile(path);
+				}
+				const existed = this.files.has(path);
+				if (existed) {
+					this.files.delete(path);
+				}
+				return existed ? { path, type: 'REMOVED' as const } : null;
+			})
+		);
+
 		const deletionResults: FileChange[] = [];
-		for (const path of filesToDelete) {
-			if (this.files.has(path)) {
-				this.files.delete(path);
-				deletionResults.push({ path, type: 'REMOVED' });
+		const deleteFailures: Array<{path: string; error: unknown}> = [];
+		for (let i = 0; i < deletionSettledResults.length; i++) {
+			const result = deletionSettledResults[i];
+			if (result.status === 'fulfilled') {
+				if (result.value !== null) deletionResults.push(result.value);
+			} else {
+				deleteFailures.push({ path: filesToDelete[i], error: result.reason });
 			}
 		}
 
-		const failedPaths = writeFailures.map(f => f.path);
+		const failedPaths = [...writeFailures, ...deleteFailures].map(f => f.path);
 		const succeededWrites = filesToWrite.filter(f => !failedPaths.includes(f.path));
 
 		const changes = [...writeResults, ...deletionResults];

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -44,6 +44,7 @@ type ApplyChangesResultMap = {
 		/** Promise for file SHAs (computed from in-memory content during writes).
 		 * Await when ready to update local state - allows parallelization on mobile. */
 		newBaselineStates: Promise<FileStates>;
+		failedPaths?: string[];
 	};
 	/** Remote vault result - includes commit metadata and new state */
 	"remote": {


### PR DESCRIPTION
  Problem

New devices (or teammates) syncing an empty vault against an existing, populated repo would never get the pre-existing files on first sync — only files edited after that point by another client would show up.

  Root cause: LocalVault.applyChanges() writes files concurrently with Promise.allSettled specifically so one bad file shouldn't affect the rest, but then threw a single error for the whole batch if any one write failed — discarding
  every file that had already succeeded. A likely trigger is two new files racing to create the same not-yet-existing folder (no locking in ensureFolderExists()). Since a failed sync never persists state, retrying just replayed the
  exact same batch and hit the same failure again, forever.

  Fix

  applyChanges() now reports per-file failures via failedPaths instead of throwing, so files that succeed are still written and tracked. FitSync excludes those failed paths from the persisted baseline, so they're picked up and
  retried automatically on the next sync instead of being silently marked "already synced." Added a "Sync incomplete" notice so this is visible instead of silent, plus a regression test covering the exact scenario (multiple new
  files, one write fails, verify the rest land and the failed one retries next sync).

---

<!-- kody-pr-summary:start -->
This pull request fixes a bug where the first sync on a fresh (empty) local vault would not download existing repository content. The root cause was that `LocalVault.applyChanges()` treated any single per-file failure as fatal for the entire batch, throwing a `VaultError` that aborted the whole sync before sync-state persistence. This discarded all successfully written files and left the sync baseline untouched, causing every retry to reprocess the same set and potentially hit the same failure again (e.g., a folder-creation race between concurrent writes).

The fix introduces failure isolation on the local write/delete path:

- **Per-file failure reporting** – `applyChanges()` now continues processing the batch via `Promise.allSettled` and collects failed paths into a new `failedPaths` property instead of throwing for the entire batch.
- **Baseline adjustment** – `FitSync.executeSync()` excludes failed paths from the persisted sync state (`lastFetchedRemoteShas` for write failures, and preserves the existing `localShas` entry for delete failures) so those specific files are re-detected as changed and retried on the next sync, while all other files in the batch are written and tracked normally in the same sync.
- **User feedback** – A notice is shown: “Sync incomplete — N file(s) couldn't be written locally… They will be retried automatically on the next sync.” The success message is suppressed when local failures exist.
- **Tests and documentation** – Added tests covering write and delete failure retry behavior; updated `docs/sync-logic.md` to explain the failure isolation and the first-sync scenario.

This change ensures that transient local file failures no longer block the entire sync, fixing the “first sync downloads nothing” issue while keeping the sync process resilient and self-healing on subsequent runs.
<!-- kody-pr-summary:end -->