### PR TITLE
fix(#361): stop treating a cached protected-path SHA as a sync baseline

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -122,6 +122,7 @@ Each file path has a **baseline** SHA in `localShas` (local) and `lastFetchedRem
 
 - Baselines are updated only on successful sync completion. A failed sync leaves them unchanged, so the next sync re-detects all accumulated changes.
 - A path **absent** from `localShas` has no confirmed local baseline — either it was never synced, or a clash removed the entry (see [Pending](#pending) below).
+- **A value only counts as a baseline if it was established by an actual confirmed sync under the *current* sync scope.** A value merely observed while a path was out of scope (excluded, ignored, not yet opted in) never counts, and doesn't become valid just because scope later changes to include it. Before any mechanism could move a path from out-of-scope to in-scope, this was true but vacuous — nothing could populate a baseline out-of-band. `obsidianSyncRules`' opt-in transition was the first such mechanism (see below) and is what made the out-of-band case reachable in practice. Any future mechanism with the same shape (a new selective-sync design, a settings change that widens what's tracked) needs the same guarantee: never auto-resolve using a baseline that predates the scope change.
 
 ### `_fit/` as scratchpad
 
@@ -276,10 +277,10 @@ A "conflict" requires two parties with competing claims to the same file. A prot
 `LocalStores.protectedPathShas` maps `path → last-seen remote SHA`. Enables the opt-in transition without a junk clash (see below). Entries are cleared when the path becomes opted in.
 
 **Opt-in transition:**
-When `obsidianSyncRules` gains a new entry, at the start of the next sync FIT reconciles `protectedPathShas` entries for newly-tracked paths:
-- If local file exists and matches cached remote SHA: set baseline in `localShas` and `lastFetchedRemoteShas` — sync is a no-op.
-- If local file exists but differs: set baseline in `localShas` (local will be pushed); `lastFetchedRemoteShas` not set so remote appears ADDED → remote applied (overwrite).
-- If local file absent: clear `lastFetchedRemoteShas[path]` so remote appears ADDED → downloaded and written to the live path.
+When `obsidianSyncRules` gains a new entry, at the start of the next sync FIT reconciles `protectedPathShas` entries for newly-tracked paths. `protectedPathShas[path]` is only ever a *passively observed* remote SHA, so per the [Baseline](#baseline) invariant it cannot be trusted the moment local turns out to disagree with it:
+- If local file exists and matches the cached remote SHA: this is genuinely safe — set baseline in `localShas` and `lastFetchedRemoteShas` — sync is a no-op.
+- If local file exists but differs: neither `localShas` nor `lastFetchedRemoteShas` is set for this path. Both sides then show as newly ADDED, which the normal pipeline resolves as an ordinary clash (written to `_fit/`) — never an automatic direction. This is what the [Baseline](#baseline) invariant above requires: a passively-observed SHA cannot short-circuit into an automatic overwrite.
+- If local file absent: clear `lastFetchedRemoteShas[path]` so remote appears ADDED → downloaded and written to the live path. (Local has nothing to lose here, so this direction is unambiguous — matches the "one side empty" case above.)
 
 In all cases the `protectedPathShas` entry is deleted (path is now tracked normally).
 
@@ -343,12 +344,14 @@ When a path is opted in via `obsidianSyncRules`, two additional rules apply:
 
 **Result for non-opted-in `.obsidian/` paths:**
 - Never synced in either direction
-- Remote copies saved to `_fit/.obsidian/` for transparency
+- Remote SHA passively recorded in `protectedPathShas` (see above) — no content download, no `_fit/` write
 - Excluded from `lastFetchedRemoteShas`; present in local scan but filtered before change detection
 
 **Result for opted-in `.obsidian/` paths:**
 - Tracked in `localShas` and synced bidirectionally like any regular file
-- `syncHiddenFiles = false` does not suppress them (explicit opt-in overrides the hidden-file default)
+- `syncHiddenFiles = false` does not suppress them (explicit opt-in overrides the hidden-file default) —
+  except that this "not suppressed" guarantee only holds for remote→local; for local→remote, an opted-in
+  path is only picked up if hidden-path discovery actually runs, which itself depends on `syncHiddenFiles`.
 
 ### Implementation Locations
 

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -527,6 +527,87 @@ describe('FitSync', () => {
 			expect(localStoreState.protectedPathShas?.['.obsidian/graph.json']).toBeUndefined();
 		});
 
+		it('should surface a clash (not silently apply remote) when opting in a path whose local content differs from the last-glimpsed remote SHA', async () => {
+			// protectedPathShas is only ever passively observed while a path is excluded —
+			// it was never established by an actual sync, so it must not be trusted as a
+			// baseline the moment local turns out to differ from it.
+			const fitSync = createFitSync();
+			const remoteContent = FileContent.fromPlainText('{"colorGroups":[]}');
+			const remoteSha = await LocalVault.fileSha1('.obsidian/graph.json', remoteContent);
+
+			await remoteVault.applyChanges([
+				{ path: '.obsidian/graph.json', content: remoteContent }
+			], []);
+
+			// First sync without opt-in: caches SHA in protectedPathShas, no download.
+			await syncAndHandleResult(fitSync, createMockNotice());
+			expect(localStoreState.protectedPathShas?.['.obsidian/graph.json']).toBe(remoteSha);
+
+			// Local independently has different content for this path (e.g. edited by Obsidian
+			// itself while sync was off for it).
+			localVault.setFile('.obsidian/graph.json', '{"colorGroups":["different"]}');
+
+			// User opts in the path (sync policy) and the vault can now read hidden
+			// paths (readability) — two independent axes, both need setting.
+			fitSync.fit.obsidianSyncRules = { '.obsidian/graph.json': {} };
+			localVault.setSyncHiddenFiles(true);
+
+			const result = await syncAndHandleResult(fitSync, createMockNotice());
+
+			// Must be a genuine clash, not a silent remote-wins overwrite. toEqual(objectContaining())
+			// rather than toMatchObject so a failure here (e.g. success:false) still surfaces the
+			// sibling `error` field instead of being hidden by a truncated diff.
+			expect(result).toEqual(expect.objectContaining({
+				success: true,
+				clash: expect.arrayContaining([expect.objectContaining({ path: '.obsidian/graph.json' })])
+			}));
+			expect(localVault.getAllFilesAsRaw()).toEqual({
+				'.obsidian/graph.json': '{"colorGroups":["different"]}',
+				'_fit/.obsidian/graph.json': '{"colorGroups":[]}'
+			});
+		});
+
+		it('should treat opt-in as a clean no-op when local content already matches the last-glimpsed remote SHA', async () => {
+			const fitSync = createFitSync();
+			const sharedContent = FileContent.fromPlainText('{"colorGroups":[]}');
+			const sharedSha = await LocalVault.fileSha1('.obsidian/graph.json', sharedContent);
+
+			await remoteVault.applyChanges([
+				{ path: '.obsidian/graph.json', content: sharedContent }
+			], []);
+
+			// First sync without opt-in: caches SHA in protectedPathShas.
+			await syncAndHandleResult(fitSync, createMockNotice());
+			expect(localStoreState.protectedPathShas?.['.obsidian/graph.json']).toBe(sharedSha);
+
+			// Local independently already has the exact same content (e.g. two devices
+			// converged, or the user copied it manually).
+			localVault.setFile('.obsidian/graph.json', '{"colorGroups":[]}');
+
+			// User opts in the path (sync policy) and the vault can now read hidden
+			// paths (readability) — two independent axes, both need setting.
+			fitSync.fit.obsidianSyncRules = { '.obsidian/graph.json': {} };
+			localVault.setSyncHiddenFiles(true);
+
+			const result = await syncAndHandleResult(fitSync, createMockNotice());
+
+			expect(result).toEqual(expect.objectContaining({ success: true, clash: [] }));
+			// No _fit/ write — this was a genuine no-op, not a resolved clash.
+			expect(localVault.getAllFilesAsRaw()).toEqual({
+				'.obsidian/graph.json': '{"colorGroups":[]}'
+			});
+
+			// "Clean no-op" means a real baseline was established, not just a lucky first
+			// pass — prove it behaviorally: a follow-up sync with nothing further changed
+			// also reports nothing to do, rather than asserting the internal
+			// localShas/protectedPathShas bookkeeping directly.
+			const followUp = await syncAndHandleResult(fitSync, createMockNotice());
+			expect(followUp).toEqual(expect.objectContaining({ success: true, clash: [] }));
+			expect(localVault.getAllFilesAsRaw()).toEqual({
+				'.obsidian/graph.json': '{"colorGroups":[]}'
+			});
+		});
+
 		it('should sync opted-in .obsidian/ file directly (not to _fit/)', async () => {
 			const fitSync = createFitSync();
 			fitSync.fit.obsidianSyncRules = { '.obsidian/appearance.json': {} };

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -802,6 +802,10 @@ export class FitSync implements IFitSync {
 
 			// Pre-sync: reconcile paths that became tracked since last sync (e.g. user opted in via obsidianSyncRules).
 			// Without this, a path with no localShas entry but an existing local file → untrackedPaths → junk clash.
+			// protectedPathShas is a SHA passively observed while the path was excluded — it was never
+			// established by an actual sync, so it can only be trusted as a real baseline when it turns
+			// out to exactly match local's current content. Any other case must surface as a normal
+			// clash rather than silently picking a direction (see below).
 			// Snapshot the three stores mutated here so we can restore them if the sync subsequently fails.
 			// saveLocalStoreCallback only runs on success, so in-memory mutations would otherwise leak
 			// into the next sync attempt and cause junk clashes or missed reconciliation.
@@ -819,12 +823,23 @@ export class FitSync implements IFitSync {
 					try {
 						const content = await this.fit.localVault.readFileContent(path);
 						const currentSha = await LocalVault.fileSha1(path, content);
-						// Establish baseline from current local content so detection sees no spurious change.
-						// If local == remote: also update lastFetchedRemoteShas → full no-op (no download).
-						// If local != remote: remote shows as ADDED → applied (remote wins on first opt-in sync).
-						this.fit.localShas[path] = currentSha;
 						if (currentSha === cachedRemoteSha) {
+							// Genuinely safe: local already matches what was last seen on remote.
+							// Establish both baselines so this shows as a full no-op (no download).
+							this.fit.localShas[path] = currentSha;
 							this.fit.lastFetchedRemoteShas[path] = cachedRemoteSha;
+						} else {
+							// Local differs from the cached remote SHA. That SHA was only ever
+							// passively observed while this path was excluded, never established by an
+							// actual sync — it doesn't count as a baseline. Leave localShas unset so
+							// local shows as ADDED, and explicitly clear lastFetchedRemoteShas (which
+							// may already hold this path from the general remote-tree cache — see
+							// catch branch below) so remote also shows as ADDED. Without clearing it,
+							// remote would show as unchanged and local's ADDED would go straight to
+							// safeLocal, silently pushing local's content over remote's — the same
+							// bug in the opposite direction. Both sides showing changed is what makes
+							// the normal pipeline resolve this as a genuine clash.
+							delete this.fit.lastFetchedRemoteShas[path];
 						}
 					} catch {
 						// File absent locally. lastFetchedRemoteShas may already have this path from prior

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -411,6 +411,16 @@ export class FakeLocalVault implements IVault<"local"> {
 	private statLog: string[] = []; // Track all stat operations for performance testing
 	private mockWriteFile: ((path: string) => Promise<void>) | null = null; // Mock for writeFile operations
 	private mockDeleteFile: ((path: string) => Promise<void>) | null = null; // Mock for deleteFile operations
+	private syncHiddenFiles = false;
+
+	/**
+	 * Mirrors LocalVault's syncHiddenFiles toggle exactly — a single global flag, not
+	 * a per-path allowlist. Defaults to false, matching this fake's pre-existing
+	 * behavior, so tests not calling this are unaffected.
+	 */
+	setSyncHiddenFiles(enabled: boolean): void {
+		this.syncHiddenFiles = enabled;
+	}
 
 	/**
 	 * Configure the vault to fail on a specific operation.
@@ -758,9 +768,13 @@ export class FakeLocalVault implements IVault<"local"> {
 	}
 
 	shouldTrackState(path: string): boolean {
-		// Exclude hidden files (same as LocalVault)
-		const parts = path.split('/');
-		return !parts.some(part => part.startsWith('.'));
+		// Same single criterion as real LocalVault: hidden paths are excluded only
+		// when syncHiddenFiles is off.
+		if (!this.syncHiddenFiles) {
+			const parts = path.split('/');
+			if (parts.some(part => part.startsWith('.'))) return false;
+		}
+		return true;
 	}
 }
 


### PR DESCRIPTION
Fixes #361

## Summary
- `protectedPathShas` is a passively-observed remote SHA (glimpsed while a path was excluded from sync via `obsidianSyncRules`), never confirmed via an actual sync. The opt-in-transition reconciliation logic treated it as a trustworthy baseline anyway, letting remote silently overwrite local with no clash surfaced when the two disagreed on first opt-in (found and fixed for both push- and pull-direction variants).
- Now surfaces an ordinary clash instead of guessing a direction, consistent with a general baseline invariant now documented in `docs/sync-logic.md` (§ Concepts and Invariants → Baseline): a value only counts as a sync baseline if it was established by an actual confirmed sync under the current sync scope.

## Test coverage
Two new tests in `src/fitSync.realFit.test.ts` cover the two lifecycle branches this fix distinguishes on opt-in transition:
- Local content diverges from the cached remote SHA → surfaces as an ordinary clash (local preserved, remote copy written to `_fit/`), never an automatic overwrite in either direction.
- Local content already matches the cached remote SHA → clean no-op, proven behaviorally via a follow-up sync (not by asserting internal state), matching pre-existing coverage style.
<!-- kody-pr-summary:start -->
## Summary

Fixes a bug in the opt-in transition for protected (`.obsidian/`) paths via `obsidianSyncRules`: a SHA cached in `protectedPathShas` was being treated as a valid sync baseline, which could cause silent data loss.

## Problem

When a path was excluded from sync, its remote SHA was passively observed and cached in `protectedPathShas`. On the sync where the user opted the path in:

- If local content **matched** the cached SHA, the system correctly established a baseline and did nothing.
- If local content **differed** from the cached SHA, the old code still set `localShas` from local content (so local appeared unchanged) and left `lastFetchedRemoteShas` unset, making remote appear as ADDED → remote content was silently applied, **overwriting the local file**.

This was wrong because a passively observed SHA was never established by an actual sync and cannot be trusted as a baseline when local disagrees with it. It could result in unexpected, automatic loss of local changes.

## Changes

- **`src/fitSync.ts`**: In the opt-in reconciliation logic, only establish a baseline when the local file's content exactly matches the cached remote SHA. If it differs, both `localShas` and `lastFetchedRemoteShas` are left unset (the latter explicitly cleared), so both sides appear as newly added and the normal pipeline resolves the situation as a genuine clash (written to `_fit/`) instead of silently choosing a direction.
- **`docs/sync-logic.md`**: Updated the baseline invariant and the opt-in transition documentation to reflect that a passively observed SHA never counts as a trustworthy baseline; only an exact local match is safe. Also clarified that the hidden-file override only guarantees remote→local, not local→remote.
- **`src/fitSync.realFit.test.ts`**: Added two tests:
  - Opting in a path with differing local content results in a clash (local file preserved, remote copy written to `_fit/`).
  - Opting in a path where local already matches remote is a clean no-op (no `_fit/` write, no conflict).
- **`src/testUtils.ts`**: Added a `syncHiddenFiles` toggle to the fake local vault so tests can accurately simulate how hidden-file filtering affects opt-in behavior.

## Impact

- Fixes potential silent loss of local edits when opting in an excluded path whose content has diverged from remote.
- Keeps the existing safe no-op behavior for the matching-content case.
- The fix relies on the existing clash machinery, so no new resolution paths are introduced.
<!-- kody-pr-summary:end -->

