### PR TITLE
fix: release anti-pattern check false-positives on dep-only package.json edits

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -66,19 +66,26 @@ jobs:
         BASE="origin/${{ github.base_ref }}"
 
         CHANGED=$(git diff --name-only "${BASE}" HEAD)
-        VERSION_FILES=$(echo "$CHANGED" | grep -E '^(manifest\.json|package\.json|versions\.json)$' || true)
         CODE_FILES=$(echo "$CHANGED" | grep -vE '^(manifest\.json|package\.json|versions\.json)$' | grep -E '\.(ts|js|css|mjs)$' || true)
+
+        NEW_VERSION=$(jq -r '.version' manifest.json)
+        BASE_VERSION=$(git show "${BASE}:manifest.json" | jq -r '.version')
+        PKG_VERSION=$(jq -r '.version' package.json)
+        BASE_PKG_VERSION=$(git show "${BASE}:package.json" | jq -r '.version')
+
+        VERSION_BUMPED=false
+        if [ "$NEW_VERSION" != "$BASE_VERSION" ] || [ "$PKG_VERSION" != "$BASE_PKG_VERSION" ] \
+          || echo "$CHANGED" | grep -qx 'versions.json'; then
+          VERSION_BUMPED=true
+        fi
 
         FAILED=false
 
-        if [ -n "$VERSION_FILES" ]; then
+        if $VERSION_BUMPED; then
           if [ -n "$CODE_FILES" ]; then
-            echo "::error::Version files changed alongside code files. Version bumps must be in dedicated commits/PRs — see docs/CONTRIBUTING.md for the release process."
+            echo "::error::Version bump alongside code files. Version bumps must be in dedicated commits/PRs — see docs/CONTRIBUTING.md for the release process."
             FAILED=true
           fi
-
-          NEW_VERSION=$(jq -r '.version' manifest.json)
-          PKG_VERSION=$(jq -r '.version' package.json)
 
           if [ "$NEW_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::manifest.json version (${NEW_VERSION}) does not match package.json version (${PKG_VERSION})."
@@ -90,7 +97,6 @@ jobs:
             FAILED=true
           fi
 
-          BASE_VERSION=$(git show "${BASE}:manifest.json" | jq -r '.version')
           if [ "${{ github.base_ref }}" = "main" ] && [ "$NEW_VERSION" != "$BASE_VERSION" ] && ! echo "$NEW_VERSION" | grep -q -- '-'; then
             echo "Checking GitHub Release exists for ${NEW_VERSION}..."
             if ! gh release view "$NEW_VERSION" > /dev/null 2>&1; then

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -79,14 +79,19 @@ jobs:
           VERSION_BUMPED=true
         fi
 
+        ANY_VERSION_TOUCHED=false
+        if echo "$CHANGED" | grep -qE '^(manifest\.json|package\.json|versions\.json)$'; then
+          ANY_VERSION_TOUCHED=true
+        fi
+
         FAILED=false
 
-        if $VERSION_BUMPED; then
-          if [ -n "$CODE_FILES" ]; then
-            echo "::error::Version bump alongside code files. Version bumps must be in dedicated commits/PRs — see docs/CONTRIBUTING.md for the release process."
-            FAILED=true
-          fi
+        if $VERSION_BUMPED && [ -n "$CODE_FILES" ]; then
+          echo "::error::Version bump alongside code files. Version bumps must be in dedicated commits/PRs — see docs/CONTRIBUTING.md for the release process."
+          FAILED=true
+        fi
 
+        if $ANY_VERSION_TOUCHED; then
           if [ "$NEW_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::manifest.json version (${NEW_VERSION}) does not match package.json version (${PKG_VERSION})."
             FAILED=true


### PR DESCRIPTION
## Summary
- The "Check for release anti-patterns" step in `pr-checks.yml` flagged any diff touching `manifest.json`/`package.json`/`versions.json` as a version bump, failing the PR if code files were also changed — even when no `version` field actually moved.
- This false-positived on #359, which only added a dependency (`node-diff3`) to `package.json` alongside `.ts` changes.
- Now computes whether a version bump actually happened (manifest.json's or package.json's `.version` field changed, or versions.json changed at all) and gates all the anti-pattern checks (bump+code, manifest/package mismatch, beta-on-main, missing GitHub Release) on that instead of mere file-touch.

## Test plan
- [x] Simulated old script against #359's real diff → fails (reproduces the bug)
- [x] Simulated new script against #359's real diff → passes
- [x] Simulated new script against a synthetic genuine version-bump+code-change case → still correctly fails on all three checks (mismatch, beta, missing release)
- [x] `npm run lint`, `npm run typecheck`, `npm test` (334 tests) pass via pre-push hook

---

<!-- kody-pr-summary:start -->
This pull request fixes a false-positive issue in the release anti-pattern check workflow. Previously, the workflow would fail if any version-related file (manifest.json, package.json, versions.json) was changed alongside code files, even if the version itself wasn't actually bumped. This caused legitimate PRs that only edit package.json (e.g., adding a dependency) to be incorrectly blocked.

The new logic:

- Only fails when a **version bump** is detected (i.e., the version in manifest.json or package.json differs from the base branch, or versions.json is changed) **and** code files are modified in the same PR.
- Retains the consistency checks (manifest/package version match, and release existence for main-branch bumps) whenever any version file is touched, ensuring those validations still run.

This eliminates false positives for dependency-only package.json edits while preserving the intended guard against mixing version bumps with code changes.
<!-- kody-pr-summary:end -->