### PR TITLE
feat(#337): .fitattributes.json schema, parsing, and config validation

### DIFF
--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -732,7 +732,7 @@ interface FitAttributeRule {
 }
 ```
 
-**Malformed `.fitattributes.json`:** a parse failure (invalid JSON, non-object root, invalid rule shape) surfaces a visible sync-notice warning (`Fit.fitAttributesWarning`, shown by `FitSync` via `FitNotice`) and a persistent entry in [Explain Sync Status](#explain-sync-status) — not just a debug-log line, even though nothing downstream acts on the parsed content yet.
+**Malformed or unreadable `.fitattributes.json`:** both a parse failure (invalid JSON, non-object root, invalid rule shape) and the file existing but failing to read (I/O error, permission issue) surface a visible sync-notice warning (`Fit.fitAttributesWarning`, shown by `FitSync` via `FitNotice`) and a persistent entry in [Explain Sync Status](#explain-sync-status) — not just a debug-log line, even though nothing downstream acts on the parsed content yet.
 
 **Forward-looking diagnostic:** whenever a `.obsidian/` path has remote content this version doesn't sync (i.e. `protectedPathShas` has an entry for it), FIT logs which such paths already have a `format:"text"` entry in `.fitattributes.json` (will start syncing once a later change wires this gate up) versus which are still unconfigured. Purely informational — no effect on sync, see the Debug Logging example below.
 

--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -732,7 +732,7 @@ interface FitAttributeRule {
 }
 ```
 
-**Malformed or unreadable `.fitattributes.json`:** both a parse failure (invalid JSON, non-object root, invalid rule shape) and the file existing but failing to read (I/O error, permission issue) surface a visible sync-notice warning (`Fit.fitAttributesWarning`, shown by `FitSync` via `FitNotice`) and a persistent entry in [Explain Sync Status](#explain-sync-status) — not just a debug-log line, even though nothing downstream acts on the parsed content yet.
+**Malformed `.fitattributes.json`:** a parse failure (invalid JSON, non-object root, invalid rule shape) surfaces a visible sync-notice warning (`Fit.fitAttributesWarning`, shown by `FitSync` via `FitNotice`) and a persistent entry in [Explain Sync Status](#explain-sync-status) — not just a debug-log line, even though nothing downstream acts on the parsed content yet. A separate failure mode — the file existing but failing to *read* (I/O error, permission issue) — is debug-logged only, not surfaced as a warning: `LocalVault.readFromSource()`'s own per-file scan reads this same file as part of its normal pass and aborts the whole sync on any unreadable tracked file before the warning-Notice code would run, so a dedicated warning here couldn't reliably appear anyway.
 
 **Forward-looking diagnostic:** whenever a `.obsidian/` path has remote content this version doesn't sync (i.e. `protectedPathShas` has an entry for it), FIT logs which such paths already have a `format:"text"` entry in `.fitattributes.json` (will start syncing once a later change wires this gate up) versus which are still unconfigured. Purely informational — no effect on sync, see the Debug Logging example below.
 

--- a/docs/sync-logic.md
+++ b/docs/sync-logic.md
@@ -722,15 +722,23 @@ interface JsonMergeSpec {
 
 `mergeJson(base, local, remote, spec)` returns `{ merged: true, value }` or `{ merged: false, reason }`. `base` is `null` when unavailable; the engine degrades to two-way merge in that case (same-id item difference → immediate conflict, no three-way resolution). Canvas uses a hardcoded spec (`CANVAS_MERGE_SPEC`); the interface is designed for future `.fitattributes` parameterization (#337).
 
-### Future extension: `.fitattributes` (#337)
+### `.fitattributes.json` (groundwork, #337)
 
-Canvas merge is the first use of the merge engine. #337 will add a `.fitattributes` file (analogous to `.gitattributes`) where users can declare:
-- Additional paths to merge with keyed-array semantics
-- Order-significance selectors (opt arrays into index-based merge)
-- Field exclusion selectors (ignore specific JSON paths during comparison) — required for #67
-- Text-mode policies (`always-local`, `always-remote`) for non-JSON files
+`.fitattributes.json` (schema: [`src/fitAttributes.ts`](../src/fitAttributes.ts)) is a vault-root JSON file that will eventually configure per-path sync behavior for `.obsidian/` files. **Not yet wired into any sync decision** — `shouldSyncPath` doesn't consult it; `obsidianSyncRules` (Settings-driven) is still the only thing controlling `.obsidian/` sync. This groundwork covers schema, parsing, and validation only:
 
-Until #337 is implemented, only `.canvas` files use semantic merge.
+```typescript
+interface FitAttributeRule {
+  format?: 'json' | 'text';
+}
+```
+
+**Malformed `.fitattributes.json`:** a parse failure (invalid JSON, non-object root, invalid rule shape) surfaces a visible sync-notice warning (`Fit.fitAttributesWarning`, shown by `FitSync` via `FitNotice`) and a persistent entry in [Explain Sync Status](#explain-sync-status) — not just a debug-log line, even though nothing downstream acts on the parsed content yet.
+
+**Forward-looking diagnostic:** whenever a `.obsidian/` path has remote content this version doesn't sync (i.e. `protectedPathShas` has an entry for it), FIT logs which such paths already have a `format:"text"` entry in `.fitattributes.json` (will start syncing once a later change wires this gate up) versus which are still unconfigured. Purely informational — no effect on sync, see the Debug Logging example below.
+
+**Also new in this groundwork:** `.fitattributes.json` itself always syncs regardless of `syncHiddenFiles`, since it has to propagate for the eventual feature to work at all.
+
+A later change adds the actual sync-decision wiring (git-driven tracking + format gate) this groundwork is preparing for — see #67/#337.
 
 ## Explain Sync Status
 
@@ -1336,6 +1344,28 @@ When enabled (Settings → Enable debug logging), FIT writes to `.obsidian/plugi
 - Parallel execution visible: both operations start at :543ms
 - Push operation: ~577ms (GitHub API to create commit)
 - Total sync: ~1 second
+
+**Example** — `.obsidian/app.json` syncs via the still-live legacy `obsidianSyncRules` (watermarked, since that mechanism is being retired); `.obsidian/graph.json` and `.obsidian/plugins/obsidian42-brat/data.json` already have remote content but aren't wired into any sync decision yet, so they only show up in a forward-looking, informational log:
+```
+[timestamp] [FitSync] .obsidian/ paths with remote content not synced in this version: {
+  "configuredForFutureSync": [".obsidian/graph.json"],
+  "unconfigured": [".obsidian/plugins/obsidian42-brat/data.json"]
+}
+[timestamp] 🔄 [Sync] Checking local and remote changes (parallel)...
+[timestamp] .. 💾 [LocalVault] Scanning files...
+[timestamp] .. ☁️ [RemoteVault] Fetching from GitHub...
+[timestamp] ... 💾 [LocalVault] Scanned 7 files
+[timestamp] ... ☁️ [RemoteVault] Fetched 9 files
+[timestamp] .. ✅ [Sync] Change detection complete
+[timestamp] [FitSync] .obsidian/ paths synced via legacy obsidianSyncRules (replaced by git-driven tracking in a later version): {
+  "paths": [".obsidian/app.json"]
+}
+[timestamp] 🔄 [FitSync] Syncing changes (1 local, 1 remote): {
+  "local": { "MODIFIED": [".obsidian/app.json"] },
+  "remote": { "MODIFIED": ["note.md"] }
+}
+```
+The forward-looking log runs pre-sync (reporting on `protectedPathShas` from a previous sync); the watermark log runs post-scan, only when `obsidianSyncRules` actually drove an outcome this sync. Neither `.obsidian/graph.json` nor `.obsidian/plugins/obsidian42-brat/data.json` appear in the change sets above — only `.obsidian/app.json` (via the legacy rule) does.
 
 **Example initial sync pulling 195 files (slower ~2-3s due to network + tree fetch):**
 ```

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -240,10 +240,15 @@ export class Fit {
 				this.setFitAttributes({});
 				this.fitAttributesWarning = message;
 			}
-		} catch {
-			// Exists but unreadable — treat as unconfigured rather than aborting the sync.
+		} catch (err) {
+			// Exists but unreadable (I/O error, permission issue, etc.) — distinct from a
+			// parse failure above, but equally worth surfacing rather than silently treating
+			// as unconfigured: a config file this load-bearing shouldn't fail silently.
+			const reason = err instanceof Error ? err.message : String(err);
+			const message = `.fitattributes.json exists but could not be read (${reason}) — will affect correctness of sync in future versions`;
+			fitLogger.log(`[Fit] ${message}`);
 			this.setFitAttributes({});
-			this.fitAttributesWarning = null;
+			this.fitAttributesWarning = message;
 		}
 	}
 
@@ -278,12 +283,12 @@ export class Fit {
 
 		// Re-parse .fitattributes.json content from this scan's own knowledge of whether the
 		// file exists — never a separate stat/read probe, so a sync where it simply doesn't
-		// exist touches it zero times. Note: this makes this.fitAttributes reflect the
-		// *previous* completed scan by the time the pre-sync reconcile block (FitSync) reads
-		// it at the start of the *next* sync — a local edit to .fitattributes.json needs one
-		// sync to be observed (like any other tracked file's content) before reconciliation
-		// can act on it; not a correctness gap, just the same one-sync convergence lag already
-		// inherent to this feature.
+		// exist touches it zero times. This runs before shouldSyncPath filtering below, so a
+		// local edit made just before running sync already gates this sync's own local
+		// push/pull decisions — no lag. The pre-sync reconcile block (FitSync) is a separate
+		// consumer of this.fitAttributes with its own eager refresh
+		// (refreshFitAttributesForReconcile), specifically so a tracking-transition decision
+		// doesn't have to wait on this lazy path either.
 		if (currentState[FITATTRIBUTES_PATH] !== undefined) {
 			await this.readAndApplyFitAttributes();
 		} else {

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -242,13 +242,21 @@ export class Fit {
 			}
 		} catch (err) {
 			// Exists but unreadable (I/O error, permission issue, etc.) — distinct from a
-			// parse failure above, but equally worth surfacing rather than silently treating
-			// as unconfigured: a config file this load-bearing shouldn't fail silently.
+			// parse failure above. Unlike that case, this one can't reliably surface as a
+			// visible Notice: the caller reached this catch either via getLocalChanges (whose
+			// own LocalVault.readFromSource() already reads this same file as part of its
+			// normal per-file scan, and throws/aborts the WHOLE sync on any unreadable tracked
+			// file before this code path would even run for a failing read) or via
+			// refreshFitAttributesForReconcile's eager path (which does reach here, but
+			// getLocalChanges's later readFromSource call re-attempts the same failing read
+			// and aborts the sync anyway, before the warning-Notice code downstream is
+			// reached). So: log for debugging, but don't claim a user-visible warning that
+			// can't actually appear — treat as unconfigured, matching the parse-failure case's
+			// "nothing configured" fallback without pretending it's equally visible.
 			const reason = err instanceof Error ? err.message : String(err);
-			const message = `.fitattributes.json exists but could not be read (${reason}) — will affect correctness of sync in future versions`;
-			fitLogger.log(`[Fit] ${message}`);
+			fitLogger.log(`[Fit] .fitattributes.json exists but could not be read (${reason})`);
 			this.setFitAttributes({});
-			this.fitAttributesWarning = message;
+			this.fitAttributesWarning = null;
 		}
 	}
 

--- a/src/fit.ts
+++ b/src/fit.ts
@@ -7,6 +7,7 @@
 
 import { LocalStores } from "@/localStores";
 import { FitSettings, ObsidianSyncRules } from "@/fitSettings";
+import { FitAttributesFile, FITATTRIBUTES_PATH, parseFitAttributes } from "@/fitAttributes";
 import { FileChange, FileStates, compareFileStates } from "./util/changeTracking";
 import { Vault } from "obsidian";
 import { LocalVault } from "./localVault";
@@ -53,6 +54,11 @@ export class Fit {
 	pendingClashes: string[];               // Paths with unresolved _fit/ copies
 	protectedPathShas: FileStates;          // Remote SHAs for paths excluded by shouldSyncPath (dedup cache)
 	obsidianSyncRules: ObsidianSyncRules;
+	fitAttributes: FitAttributesFile = {};  // Parsed from local .fitattributes.json; refreshed each sync
+	// Set when the last .fitattributes.json parse attempt failed; null when it parsed fine or
+	// the file doesn't exist. FitSync surfaces this as a visible Notice — a malformed file
+	// would otherwise fail silently, which is worse than noisy for a config file this load-bearing.
+	fitAttributesWarning: string | null = null;
 	localVault: LocalVault;                 // Local vault (tracks local file state)
 	remoteVault: RemoteGitHubVault;
 	private ownDataPath: string | null = null; // e.g. ".obsidian/plugins/fit/data.json"
@@ -182,6 +188,24 @@ export class Fit {
 	}
 
 	/**
+	 * `.obsidian/` paths seen this sync (local and/or remote) that are actively syncing
+	 * because of a legacy obsidianSyncRules opt-in — for a once-per-sync watermark log, not
+	 * a per-call one, since shouldSyncPath itself is called many times per path per sync.
+	 * obsidianSyncRules is retired entirely in the git-driven tracking replacement, so this
+	 * (and its only caller) disappears with it — no future cleanup needed here.
+	 */
+	activeObsidianSyncRulePaths(currentLocalState: FileStates, remoteTreeSha: FileStates): string[] {
+		const candidates = new Set<string>();
+		for (const path of Object.keys(currentLocalState)) {
+			if (path.startsWith(".obsidian/")) candidates.add(path);
+		}
+		for (const path of Object.keys(remoteTreeSha)) {
+			if (path.startsWith(".obsidian/")) candidates.add(path);
+		}
+		return [...candidates].filter(path => this.shouldSyncPath(path)).sort();
+	}
+
+	/**
 	 * Filter a FileState to include only paths that should be synced.
 	 * Used when updating LocalStores to ensure excluded paths (like _fit/) aren't tracked.
 	 *
@@ -198,10 +222,74 @@ export class Fit {
 		return filtered;
 	}
 
+	/**
+	 * Reads and parses local .fitattributes.json content (already known to exist), updating
+	 * this.fitAttributes and this.fitAttributesWarning. Shared by the eager (reconcile) and
+	 * lazy (getLocalChanges) refresh paths below.
+	 */
+	private async readAndApplyFitAttributes(): Promise<void> {
+		try {
+			const fitAttributesContent = await this.localVault.readFileContent(FITATTRIBUTES_PATH);
+			const parsed = parseFitAttributes(fitAttributesContent.toPlainText());
+			if (parsed.ok) {
+				this.setFitAttributes(parsed.value);
+				this.fitAttributesWarning = null;
+			} else {
+				const message = `.fitattributes.json is malformed (${parsed.error}) — will affect correctness of sync in future versions`;
+				fitLogger.log(`[Fit] ${message}`);
+				this.setFitAttributes({});
+				this.fitAttributesWarning = message;
+			}
+		} catch {
+			// Exists but unreadable — treat as unconfigured rather than aborting the sync.
+			this.setFitAttributes({});
+			this.fitAttributesWarning = null;
+		}
+	}
+
+	/** Replaces the parsed .fitattributes.json content. */
+	setFitAttributes(attributes: FitAttributesFile): void {
+		this.fitAttributes = attributes;
+	}
+
+	/**
+	 * Eagerly re-parses local .fitattributes.json content into this.fitAttributes, ahead of
+	 * the normal per-sync local scan. Only worth calling when there's something that could
+	 * actually be reconciled this sync (see FitSync's pre-sync reconcile block) — a local
+	 * edit to .fitattributes.json needs to be visible the SAME sync it was made, not delayed
+	 * a sync like the general lazy update in getLocalChanges (which only updates fitAttributes
+	 * from data the scan already touched). Checks existence via statPaths first so a call
+	 * where the file doesn't exist touches nothing further.
+	 */
+	async refreshFitAttributesForReconcile(): Promise<void> {
+		const stats = await this.localVault.statPaths([FITATTRIBUTES_PATH]);
+		if (stats.get(FITATTRIBUTES_PATH) !== 'file') {
+			this.setFitAttributes({});
+			this.fitAttributesWarning = null;
+			return;
+		}
+		await this.readAndApplyFitAttributes();
+	}
+
 	async getLocalChanges(): Promise<{changes: FileChange[], state: FileStates}> {
 		fitLogger.log('.. 💾 [LocalVault] Scanning files...');
 		const readResult = await this.localVault.readFromSource();
 		const currentState = readResult.state;
+
+		// Re-parse .fitattributes.json content from this scan's own knowledge of whether the
+		// file exists — never a separate stat/read probe, so a sync where it simply doesn't
+		// exist touches it zero times. Note: this makes this.fitAttributes reflect the
+		// *previous* completed scan by the time the pre-sync reconcile block (FitSync) reads
+		// it at the start of the *next* sync — a local edit to .fitattributes.json needs one
+		// sync to be observed (like any other tracked file's content) before reconciliation
+		// can act on it; not a correctness gap, just the same one-sync convergence lag already
+		// inherent to this feature.
+		if (currentState[FITATTRIBUTES_PATH] !== undefined) {
+			await this.readAndApplyFitAttributes();
+		} else {
+			this.setFitAttributes({});
+			this.fitAttributesWarning = null;
+		}
 
 		// Clean up orphaned legacy entries for files no longer present locally.
 		for (const path of Object.keys(this.localSha)) {

--- a/src/fitAttributes.test.ts
+++ b/src/fitAttributes.test.ts
@@ -21,7 +21,7 @@ describe('parseFitAttributes', () => {
 		});
 	});
 
-	it('treats an empty rule as simply "opted in" with default handling', () => {
+	it('accepts an empty rule object, with all fields left to their defaults', () => {
 		const text = JSON.stringify({ '.obsidian/appearance.json': {} });
 		expect(parseFitAttributes(text)).toEqual({
 			ok: true,

--- a/src/fitAttributes.test.ts
+++ b/src/fitAttributes.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Covers .fitattributes.json parsing/validation only (parseFitAttributes).
+ * Not covered here: applying rules during sync, field-level JSON masking —
+ * see docs/sync-logic.md § `.fitattributes.json` (#337).
+ */
+import { describe, it, expect } from 'vitest';
+import { parseFitAttributes } from '@/fitAttributes';
+
+describe('parseFitAttributes', () => {
+	it('parses a valid multi-path config', () => {
+		const text = JSON.stringify({
+			'.obsidian/core-plugins.json': {},
+			'.obsidian/community-plugins.json': { format: 'json' },
+		});
+		expect(parseFitAttributes(text)).toEqual({
+			ok: true,
+			value: {
+				'.obsidian/core-plugins.json': {},
+				'.obsidian/community-plugins.json': { format: 'json' },
+			},
+		});
+	});
+
+	it('treats an empty rule as simply "opted in" with default handling', () => {
+		const text = JSON.stringify({ '.obsidian/appearance.json': {} });
+		expect(parseFitAttributes(text)).toEqual({
+			ok: true,
+			value: { '.obsidian/appearance.json': {} },
+		});
+	});
+
+	it('rejects malformed JSON', () => {
+		const result = parseFitAttributes('{not json');
+		expect(result.ok).toBe(false);
+	});
+
+	it.each([
+		['array', '[]'],
+		['string', '"foo"'],
+		['number', '1'],
+		['null', 'null'],
+	])('rejects a %s root', (_label, text) => {
+		expect(parseFitAttributes(text)).toEqual(
+			expect.objectContaining({ ok: false }),
+		);
+	});
+
+	it('rejects a rule that is not an object', () => {
+		const text = JSON.stringify({ '.obsidian/graph.json': ['not', 'an', 'object'] });
+		expect(parseFitAttributes(text)).toEqual(
+			expect.objectContaining({ ok: false }),
+		);
+	});
+
+	it('accepts format: "json"', () => {
+		const text = JSON.stringify({ '.obsidian/graph.json': { format: 'json' } });
+		expect(parseFitAttributes(text)).toEqual({
+			ok: true,
+			value: { '.obsidian/graph.json': { format: 'json' } },
+		});
+	});
+
+	it('accepts format: "text"', () => {
+		const text = JSON.stringify({ '.obsidian/snippets/custom.css': { format: 'text' } });
+		expect(parseFitAttributes(text)).toEqual({
+			ok: true,
+			value: { '.obsidian/snippets/custom.css': { format: 'text' } },
+		});
+	});
+
+	it('rejects an unrecognized format value', () => {
+		const text = JSON.stringify({ '.obsidian/graph.json': { format: 'yaml' } });
+		expect(parseFitAttributes(text)).toEqual(
+			expect.objectContaining({ ok: false }),
+		);
+	});
+});

--- a/src/fitAttributes.ts
+++ b/src/fitAttributes.ts
@@ -63,8 +63,8 @@ function validateRule(path: string, rawRule: unknown): { ok: true; rule: FitAttr
 /**
  * Parses and validates .fitattributes.json content. Never throws — malformed
  * input (bad JSON, non-object root, invalid rule shape) is reported via the
- * `ok: false` branch so callers (settings UI, Explain) can surface it loudly
- * instead of silently treating it as "nothing configured".
+ * `ok: false` branch so the caller (Fit) can surface it loudly instead of
+ * silently treating it as "nothing configured".
  */
 export function parseFitAttributes(text: string): ParseFitAttributesResult {
 	let parsed: unknown;

--- a/src/fitAttributes.ts
+++ b/src/fitAttributes.ts
@@ -1,0 +1,89 @@
+/**
+ * .fitattributes.json recipe schema: parsing and validation only.
+ * Design notes + rationale: docs/sync-logic.md § `.fitattributes.json` (#337)
+ *
+ * A path's presence here does NOT opt it into sync — the trigger is git, not
+ * FIT. A path becomes tracked purely because content for it exists in the
+ * remote git tree; this file only modulates how an already-tracked path is
+ * handled (merge hints, whole-file text-mode designation). A rule for a path
+ * with no remote content is inert.
+ *
+ * TODO(#337): field-level JSON masking (which fields within a tracked JSON
+ * path actually move) is a later change, not this module.
+ */
+
+export interface FitAttributeRule {
+	/**
+	 * "text": opts this tracked path into whole-file sync — full content
+	 * replace, ordinary `_fit/` clash on both-sides-changed, no merge attempt
+	 * yet. Required for any non-JSON tracked path (e.g. .obsidian/snippets/
+	 * *.css) to actually sync; without it, a tracked non-JSON path is
+	 * detected/logged but never read or written.
+	 * "json": reserved, not yet implemented — will opt a path into
+	 * field-level JSON masking once that lands.
+	 */
+	format?: 'json' | 'text';
+}
+
+/**
+ * Path → rule. Presence as a key here configures how a path is handled *if*
+ * it is independently tracked (has remote git content) — it never causes
+ * tracking by itself.
+ */
+export type FitAttributesFile = Record<string, FitAttributeRule>;
+
+export const FITATTRIBUTES_PATH = '.fitattributes.json';
+
+export type ParseFitAttributesResult =
+	| { ok: true; value: FitAttributesFile }
+	| { ok: false; error: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateRule(path: string, rawRule: unknown): { ok: true; rule: FitAttributeRule } | { ok: false; error: string } {
+	if (!isPlainObject(rawRule)) {
+		return { ok: false, error: `rule for "${path}" must be an object` };
+	}
+
+	let format: 'json' | 'text' | undefined;
+	if ('format' in rawRule && rawRule.format !== undefined) {
+		if (rawRule.format !== 'json' && rawRule.format !== 'text') {
+			return { ok: false, error: `rule for "${path}": "format" must be "json" or "text" if present` };
+		}
+		format = rawRule.format;
+	}
+
+	const rule: FitAttributeRule = {};
+	if (format) rule.format = format;
+	return { ok: true, rule };
+}
+
+/**
+ * Parses and validates .fitattributes.json content. Never throws — malformed
+ * input (bad JSON, non-object root, invalid rule shape) is reported via the
+ * `ok: false` branch so callers (settings UI, Explain) can surface it loudly
+ * instead of silently treating it as "nothing configured".
+ */
+export function parseFitAttributes(text: string): ParseFitAttributesResult {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (e) {
+		return { ok: false, error: e instanceof Error ? e.message : String(e) };
+	}
+
+	if (!isPlainObject(parsed)) {
+		return { ok: false, error: 'root value must be a JSON object mapping paths to rules' };
+	}
+
+	const value: FitAttributesFile = {};
+	for (const [path, rawRule] of Object.entries(parsed)) {
+		const result = validateRule(path, rawRule);
+		if (!result.ok) return result;
+		value[path] = result.rule;
+	}
+
+	return { ok: true, value };
+}

--- a/src/fitStatusExplainer.test.ts
+++ b/src/fitStatusExplainer.test.ts
@@ -10,6 +10,7 @@ function snapshot(overrides: Partial<SyncStatusSnapshot> = {}): SyncStatusSnapsh
 		trackedFileCount: 3,
 		pendingClashes: [],
 		oversizedFilePaths: [],
+		fitAttributesWarning: null,
 		...overrides,
 	};
 }
@@ -41,6 +42,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [],
 				  "statusNote": "Never synced — run Fit Sync to connect to your remote.",
@@ -56,6 +58,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [],
 				  "statusNote": "All 5 files synced (commit abcdef1)",
@@ -73,6 +76,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": "https://github.com/dbarnett/myvault/tree/2e39870bfd4e1715222800d62947222c76def787",
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [],
 				  "statusNote": "All 5 files synced (commit 2e39870)",
@@ -86,6 +90,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [],
 				  "statusNote": "All 1 file synced (commit abcdef1)",
@@ -105,6 +110,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": "https://github.com/dbarnett/myvault/tree/2e39870bfd4e1715222800d62947222c76def787",
+				  "fitAttributesNote": null,
 				  "scanNote": "Couldn't read: ItsASecret.md, locked/private.md — local changes may be incomplete",
 				  "sections": [],
 				  "statusNote": null,
@@ -118,6 +124,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": "Couldn't read: secret.md — local changes may be incomplete",
 				  "sections": [],
 				  "statusNote": null,
@@ -131,6 +138,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": "Couldn't scan all files — local changes may be incomplete",
 				  "sections": [],
 				  "statusNote": null,
@@ -150,6 +158,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": "https://github.com/dbarnett/myvault/tree/2e39870bfd4e1715222800d62947222c76def787",
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -175,6 +184,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -207,6 +217,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -231,6 +242,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -264,6 +276,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -296,6 +309,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -324,6 +338,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -364,6 +379,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -391,6 +407,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -422,6 +439,23 @@ describe('renderExplanation', () => {
 		});
 	});
 
+	describe('malformed .fitattributes.json', () => {
+		it('reports issues, not ok, when only fitAttributesWarning is set', () => {
+			const explanation = buildStatusExplanation(snapshot({ fitAttributesWarning: 'boom' }), []);
+			expect(explanation).toEqual(expect.objectContaining({ kind: 'issues' }));
+		});
+
+		it('surfaces the warning text as fitAttributesNote', () => {
+			const result = explain(snapshot({ fitAttributesWarning: 'boom' }), []);
+			expect(result).toEqual(expect.objectContaining({ fitAttributesNote: 'boom' }));
+		});
+
+		it('does not surface a note when .fitattributes.json is valid or absent', () => {
+			const result = explain(snapshot({ fitAttributesWarning: null }), []);
+			expect(result).toEqual(expect.objectContaining({ fitAttributesNote: null }));
+		});
+	});
+
 	describe('multiple issue types', () => {
 		it('all three sections — order: clashes, oversized, local changes', () => {
 			expect(explain(
@@ -432,6 +466,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": null,
 				  "commitUrl": "https://github.com/dbarnett/myvault/tree/2e39870bfd4e1715222800d62947222c76def787",
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -484,6 +519,7 @@ describe('renderExplanation', () => {
 					{
 					  "autoSyncNote": "Auto-sync: off",
 					  "commitUrl": null,
+					  "fitAttributesNote": null,
 					  "scanNote": null,
 					  "sections": [],
 					  "statusNote": "All 3 files synced (commit abcdef1)",
@@ -499,6 +535,7 @@ describe('renderExplanation', () => {
 					{
 					  "autoSyncNote": "Auto-sync: every 30 min (never synced in this session)",
 					  "commitUrl": null,
+					  "fitAttributesNote": null,
 					  "scanNote": null,
 					  "sections": [],
 					  "statusNote": "All 3 files synced (commit abcdef1)",
@@ -515,6 +552,7 @@ describe('renderExplanation', () => {
 					{
 					  "autoSyncNote": "Auto-sync: every 30 min · last synced 3 min ago · next in ~27 min",
 					  "commitUrl": null,
+					  "fitAttributesNote": null,
 					  "scanNote": null,
 					  "sections": [],
 					  "statusNote": "All 3 files synced (commit abcdef1)",
@@ -531,6 +569,7 @@ describe('renderExplanation', () => {
 					{
 					  "autoSyncNote": "Auto-sync: every 30 min · last synced just now · next in ~30 min",
 					  "commitUrl": null,
+					  "fitAttributesNote": null,
 					  "scanNote": null,
 					  "sections": [],
 					  "statusNote": "All 3 files synced (commit abcdef1)",
@@ -549,6 +588,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": "Auto-sync: every 15 min · last synced 10 min ago · next in ~5 min",
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -577,6 +617,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": "Auto-sync: off",
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": null,
 				  "sections": [
 				    {
@@ -605,6 +646,7 @@ describe('renderExplanation', () => {
 				{
 				  "autoSyncNote": "Auto-sync: every 30 min · last synced 5 min ago · next in ~25 min",
 				  "commitUrl": null,
+				  "fitAttributesNote": null,
 				  "scanNote": "Couldn't read: ItsASecret.md — local changes may be incomplete",
 				  "sections": [],
 				  "statusNote": null,

--- a/src/fitStatusExplainer.ts
+++ b/src/fitStatusExplainer.ts
@@ -12,6 +12,8 @@ export interface SyncStatusSnapshot {
 	trackedFileCount: number;
 	pendingClashes: string[];
 	oversizedFilePaths: string[];
+	/** Fit.fitAttributesWarning — set when .fitattributes.json failed to parse. */
+	fitAttributesWarning: string | null;
 }
 
 export interface FileStatusItem {
@@ -42,7 +44,7 @@ export interface AutoSyncInfo {
 export type StatusExplanation =
 	| { kind: 'never-synced' }
 	| { kind: 'ok'; fileCount: number; shortSha: string }
-	| { kind: 'issues'; sections: StatusSection[]; scanNote: string | null };
+	| { kind: 'issues'; sections: StatusSection[]; scanNote: string | null; fitAttributesNote: string | null };
 
 export interface RenderableExplanation {
 	title: string;
@@ -51,6 +53,7 @@ export interface RenderableExplanation {
 	autoSyncNote: string | null;
 	sections: StatusSection[];
 	scanNote: string | null;
+	fitAttributesNote: string | null;
 }
 
 const MODAL_TITLE = 'Fit Sync Status';
@@ -132,7 +135,7 @@ export function buildStatusExplanation(
 		});
 	}
 
-	if (sections.length === 0 && !scanNote) {
+	if (sections.length === 0 && !scanNote && !snapshot.fitAttributesWarning) {
 		return {
 			kind: 'ok',
 			fileCount: snapshot.trackedFileCount,
@@ -140,7 +143,7 @@ export function buildStatusExplanation(
 		};
 	}
 
-	return { kind: 'issues', sections, scanNote };
+	return { kind: 'issues', sections, scanNote, fitAttributesNote: snapshot.fitAttributesWarning };
 }
 
 function formatAutoSyncNote(info: AutoSyncInfo): string {
@@ -181,6 +184,7 @@ export function renderExplanation(
 				autoSyncNote,
 				sections: [],
 				scanNote: null,
+				fitAttributesNote: null,
 			};
 
 		case 'ok':
@@ -191,6 +195,7 @@ export function renderExplanation(
 				autoSyncNote,
 				sections: [],
 				scanNote: null,
+				fitAttributesNote: null,
 			};
 
 		case 'issues':
@@ -201,6 +206,7 @@ export function renderExplanation(
 				autoSyncNote,
 				sections: explanation.sections,
 				scanNote: explanation.scanNote,
+				fitAttributesNote: explanation.fitAttributesNote,
 			};
 	}
 }

--- a/src/fitStatusExplainer.ts
+++ b/src/fitStatusExplainer.ts
@@ -12,7 +12,7 @@ export interface SyncStatusSnapshot {
 	trackedFileCount: number;
 	pendingClashes: string[];
 	oversizedFilePaths: string[];
-	/** Fit.fitAttributesWarning — set when .fitattributes.json is malformed or unreadable. */
+	/** Fit.fitAttributesWarning — set when .fitattributes.json is malformed (invalid JSON/shape). */
 	fitAttributesWarning: string | null;
 }
 

--- a/src/fitStatusExplainer.ts
+++ b/src/fitStatusExplainer.ts
@@ -12,7 +12,7 @@ export interface SyncStatusSnapshot {
 	trackedFileCount: number;
 	pendingClashes: string[];
 	oversizedFilePaths: string[];
-	/** Fit.fitAttributesWarning — set when .fitattributes.json failed to parse. */
+	/** Fit.fitAttributesWarning — set when .fitattributes.json is malformed or unreadable. */
 	fitAttributesWarning: string | null;
 }
 

--- a/src/fitStatusModal.ts
+++ b/src/fitStatusModal.ts
@@ -33,7 +33,7 @@ export class FitStatusModal extends Modal {
 
 	onOpen() {
 		const { contentEl } = this;
-		const { title, commitUrl, statusNote, autoSyncNote, sections, scanNote } = this.renderable;
+		const { title, commitUrl, statusNote, autoSyncNote, sections, scanNote, fitAttributesNote } = this.renderable;
 
 		contentEl.createEl('h2', { text: title });
 
@@ -50,6 +50,10 @@ export class FitStatusModal extends Modal {
 
 		if (autoSyncNote) {
 			contentEl.createEl('p', { text: autoSyncNote, cls: 'fit-autosync-note' });
+		}
+
+		if (fitAttributesNote) {
+			contentEl.createEl('p', { text: fitAttributesNote, cls: 'fit-fitattributes-note' });
 		}
 
 		if (sections.length > 0) {

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -14,6 +14,7 @@ import { Vault } from 'obsidian';
 import { FakeLocalVault, FakeRemoteVault } from './testUtils';
 import { LocalVault } from './localVault';
 import { FitSettings } from '@/fitSettings';
+import { FITATTRIBUTES_PATH } from '@/fitAttributes';
 import { LocalStores } from '@/localStores';
 import { VaultError } from './vault';
 import { fitLogger } from './logger';
@@ -2874,6 +2875,71 @@ describe('FitSync', () => {
 			expect(result).toEqual(expect.objectContaining({ success: true }));
 			expect(localVault.getAllFilesAsRaw()).toHaveProperty('_fit/note.md');
 			expect(localStoreState.pendingClashes).toContain('note.md');
+		});
+	});
+
+	describe('.fitattributes.json validation', () => {
+		it('surfaces a visible warning Notice when .fitattributes.json is malformed', async () => {
+			// .fitattributes.json is a load-bearing config file — a malformed file must not
+			// fail silently (log-only).
+			const fitNoticeSpy = vi.spyOn(FitNotice.prototype, 'show').mockImplementation(() => {});
+			const fitSync = createFitSync();
+			localVault.setFile(FITATTRIBUTES_PATH, '{not valid json');
+
+			await syncAndHandleResult(fitSync, createMockNotice());
+
+			expect(fitNoticeSpy).toHaveBeenCalled();
+			fitNoticeSpy.mockRestore();
+		});
+
+		it('does not show the .fitattributes.json warning Notice once the file is fixed', async () => {
+			const fitNoticeSpy = vi.spyOn(FitNotice.prototype, 'show').mockImplementation(() => {});
+			const fitSync = createFitSync();
+			localVault.setFile(FITATTRIBUTES_PATH, JSON.stringify({ '.obsidian/graph.json': { format: 'text' } }));
+
+			await syncAndHandleResult(fitSync, createMockNotice());
+
+			expect(fitNoticeSpy).not.toHaveBeenCalled();
+			fitNoticeSpy.mockRestore();
+		});
+
+		it('logs configured-vs-unconfigured buckets for remote .obsidian/ content this version does not sync', async () => {
+			// Neither path actually syncs in this version (shouldSyncPath doesn't consult
+			// fitAttributes yet) — this is a forward-looking, informational-only log.
+			const fitSync = createFitSync();
+			localVault.setFile(FITATTRIBUTES_PATH, JSON.stringify({ '.obsidian/graph.json': { format: 'text' } }));
+
+			await remoteVault.applyChanges([
+				{ path: '.obsidian/graph.json', content: FileContent.fromPlainText('{"colorGroups":[]}') },
+				{ path: '.obsidian/appearance.json', content: FileContent.fromPlainText('{"theme":"dark"}') },
+			], []);
+
+			// First sync: observes remote content into protectedPathShas (silent, pre-existing).
+			await syncAndHandleResult(fitSync, createMockNotice());
+			// Second sync: protectedPathShas is now non-empty, triggering the forward-looking log.
+			await syncAndHandleResult(fitSync, createMockNotice());
+
+			expectLoggerCalledWith('[FitSync] .obsidian/ paths with remote content not synced in this version', {
+				configuredForFutureSync: ['.obsidian/graph.json'],
+				unconfigured: ['.obsidian/appearance.json'],
+			});
+		});
+
+		it('explainStatus surfaces fitAttributesNote for a malformed .fitattributes.json, even with nothing else pending', async () => {
+			const fitSync = createFitSync();
+			localVault.setFile('note.md', 'content');
+			localVault.setFile(FITATTRIBUTES_PATH, '{not valid json');
+
+			// Establish a baseline sync (with the malformed file already in place) so
+			// explainStatus() reaches its normal issues/ok branches, not never-synced.
+			await syncAndHandleResult(fitSync, createMockNotice());
+
+			const explanation = await fitSync.explainStatus();
+
+			expect(explanation).toEqual(expect.objectContaining({
+				kind: 'issues',
+				fitAttributesNote: expect.stringContaining('.fitattributes.json is malformed'),
+			}));
 		});
 	});
 });

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -2892,21 +2892,6 @@ describe('FitSync', () => {
 			fitNoticeSpy.mockRestore();
 		});
 
-		it('surfaces a visible warning Notice when .fitattributes.json exists but cannot be read', async () => {
-			// Distinct failure mode from malformed JSON above: the file stats as present but
-			// readFileContent itself throws (I/O error, permission issue). Must not be treated
-			// as silently unconfigured.
-			const fitNoticeSpy = vi.spyOn(FitNotice.prototype, 'show').mockImplementation(() => {});
-			const fitSync = createFitSync();
-			localVault.setFile(FITATTRIBUTES_PATH, JSON.stringify({ '.obsidian/graph.json': { format: 'text' } }));
-			localVault.seedReadFileContentFailure(FITATTRIBUTES_PATH, new Error('EACCES: permission denied'));
-
-			await syncAndHandleResult(fitSync, createMockNotice());
-
-			expect(fitNoticeSpy).toHaveBeenCalled();
-			fitNoticeSpy.mockRestore();
-		});
-
 		it('does not show the .fitattributes.json warning Notice once the file is fixed', async () => {
 			const fitNoticeSpy = vi.spyOn(FitNotice.prototype, 'show').mockImplementation(() => {});
 			const fitSync = createFitSync();

--- a/src/fitSync.realFit.test.ts
+++ b/src/fitSync.realFit.test.ts
@@ -2892,6 +2892,21 @@ describe('FitSync', () => {
 			fitNoticeSpy.mockRestore();
 		});
 
+		it('surfaces a visible warning Notice when .fitattributes.json exists but cannot be read', async () => {
+			// Distinct failure mode from malformed JSON above: the file stats as present but
+			// readFileContent itself throws (I/O error, permission issue). Must not be treated
+			// as silently unconfigured.
+			const fitNoticeSpy = vi.spyOn(FitNotice.prototype, 'show').mockImplementation(() => {});
+			const fitSync = createFitSync();
+			localVault.setFile(FITATTRIBUTES_PATH, JSON.stringify({ '.obsidian/graph.json': { format: 'text' } }));
+			localVault.seedReadFileContentFailure(FITATTRIBUTES_PATH, new Error('EACCES: permission denied'));
+
+			await syncAndHandleResult(fitSync, createMockNotice());
+
+			expect(fitNoticeSpy).toHaveBeenCalled();
+			fitNoticeSpy.mockRestore();
+		});
+
 		it('does not show the .fitattributes.json warning Notice once the file is fixed', async () => {
 			const fitNoticeSpy = vi.spyOn(FitNotice.prototype, 'show').mockImplementation(() => {});
 			const fitSync = createFitSync();

--- a/src/fitSync.ts
+++ b/src/fitSync.ts
@@ -813,7 +813,29 @@ export class FitSync implements IFitSync {
 			preReconcileLocalShas = {...this.fit.localShas};
 			preReconcileLastFetchedRemoteShas = {...this.fit.lastFetchedRemoteShas};
 
-			const reconcilePaths = Object.keys(this.fit.protectedPathShas)
+			// shouldSyncPath below may need current fitAttributes — only worth an eager refresh
+			// (extra stat/read outside the normal scan) when there's actually a candidate path
+			// that could be reconciled this sync.
+			const reconcileCandidates = Object.keys(this.fit.protectedPathShas);
+			if (reconcileCandidates.length > 0) {
+				await this.fit.refreshFitAttributesForReconcile();
+				// Forward-looking, informational only: this version's shouldSyncPath doesn't
+				// consult fitAttributes yet, so none of these actually reconcile below — but
+				// .fitattributes.json IS already parsed, so we can report which of these
+				// remote-only .obsidian/ paths are already configured for format:"text" (will
+				// start syncing once that gate lands) versus still unconfigured.
+				const configuredForFutureSync = reconcileCandidates.filter(
+					p => this.fit.fitAttributes[p]?.format === 'text'
+				);
+				const unconfigured = reconcileCandidates.filter(
+					p => this.fit.fitAttributes[p]?.format !== 'text'
+				);
+				fitLogger.log(
+					'[FitSync] .obsidian/ paths with remote content not synced in this version',
+					{ configuredForFutureSync, unconfigured }
+				);
+			}
+			const reconcilePaths = reconcileCandidates
 				.filter(p => this.fit.shouldSyncPath(p));
 			if (reconcilePaths.length > 0) {
 				fitLogger.log('[FitSync] Reconciling newly-tracked paths from protectedPathShas', { paths: reconcilePaths });
@@ -872,6 +894,24 @@ export class FitSync implements IFitSync {
 			const {changes: localChanges, state: currentLocalState} = localResult.value;
 			const {changes: remoteChanges, state: remoteTreeSha, commitSha: remoteCommitSha} = remoteResult.value;
 			fitLogger.log('.. ✅ [Sync] Change detection complete');
+
+			// .fitattributes.json is a load-bearing config file — a malformed file silently
+			// meaning "nothing configured" deserves a visible warning rather than only a
+			// debug-log line (getLocalChanges/refreshFitAttributesForReconcile already logged
+			// the parse error itself).
+			if (this.fit.fitAttributesWarning) {
+				const warningNotice = new FitNotice(this.fit, [], this.fit.fitAttributesWarning, 0);
+				warningNotice.show();
+			}
+
+			// Watermark: legacy obsidianSyncRules is being replaced by git-driven tracking
+			// (#337/#67) — logging when it actually drives an outcome makes future debug.log
+			// archaeology easier to place against a plugin version, and keeps this version's
+			// sync path self-explanatory once the replacement lands and this log disappears.
+			const legacyRulePaths = this.fit.activeObsidianSyncRulePaths(currentLocalState, remoteTreeSha);
+			if (legacyRulePaths.length > 0) {
+				fitLogger.log('[FitSync] .obsidian/ paths synced via legacy obsidianSyncRules (replaced by git-driven tracking in a later version)', { paths: legacyRulePaths });
+			}
 
 			// Phase 0: Resolve pending clashes
 			// For each path with an unresolved _fit/ copy, check if the user has resolved it.
@@ -1330,6 +1370,7 @@ export class FitSync implements IFitSync {
 			trackedFileCount: Object.keys(this.fit.localShas).length,
 			pendingClashes: [...this.fit.pendingClashes],
 			oversizedFilePaths: Object.keys(this.fit.unpushedFiles ?? {}),
+			fitAttributesWarning: this.fit.fitAttributesWarning,
 		};
 
 		if (!snapshot.lastFetchedCommitSha) {
@@ -1342,6 +1383,9 @@ export class FitSync implements IFitSync {
 		try {
 			const result = await this.fit.getLocalChanges();
 			localChanges = result.changes;
+			// getLocalChanges() may have just refreshed fitAttributesWarning (lazy hook) —
+			// use the post-scan value so Explain reflects the current file, not last sync's.
+			snapshot.fitAttributesWarning = this.fit.fitAttributesWarning;
 		} catch (err) {
 			scanFailedPaths = err instanceof VaultError && err.details?.failedPaths
 				? err.details.failedPaths

--- a/src/localVault.test.ts
+++ b/src/localVault.test.ts
@@ -123,6 +123,16 @@ describe('LocalVault', () => {
 			expect(localVault.shouldTrackState('notes/.gitignore')).toBe(true);
 			expect(localVault.shouldTrackState('normal/file.md')).toBe(true);
 		});
+
+		it('should track .fitattributes.json even when syncHiddenFiles is off (#337)', () => {
+			const localVault = new LocalVault(mockVault as any as Vault);
+			localVault.configure({ syncHiddenFiles: false });
+
+			expect(localVault.shouldTrackState('.fitattributes.json')).toBe(true);
+			// Unlike .fitattributes.json, .gitignore itself still follows normal hidden-file
+			// gating — only its content (read separately via GitignoreFilter) is unconditional.
+			expect(localVault.shouldTrackState('.gitignore')).toBe(false);
+		});
 	});
 
 	describe('readFromSource', () => {
@@ -1028,6 +1038,33 @@ describe('LocalVault', () => {
 			const { state } = await localVault.readFromSource();
 
 			expect(Object.keys(state).sort()).toEqual(['file.log', 'file.md']);
+		});
+	});
+
+	describe('.fitattributes.json discovery in readFromSource (#337)', () => {
+		it('should include .fitattributes.json even when syncHiddenFiles is off', async () => {
+			const fakeVault = new FakeObsidianVault();
+
+			await fakeVault.adapter.write('.fitattributes.json', '{}');
+			await fakeVault.create('note.md', 'content');
+
+			const localVault = new LocalVault(fakeVault as any);
+			localVault.configure({ syncHiddenFiles: false });
+			const { state } = await localVault.readFromSource();
+
+			expect(Object.keys(state).sort()).toEqual(['.fitattributes.json', 'note.md']);
+		});
+
+		it('should not fabricate a .fitattributes.json entry when it does not exist locally', async () => {
+			const fakeVault = new FakeObsidianVault();
+
+			await fakeVault.create('note.md', 'content');
+
+			const localVault = new LocalVault(fakeVault as any);
+			localVault.configure({ syncHiddenFiles: false });
+			const { state } = await localVault.readFromSource();
+
+			expect(Object.keys(state).sort()).toEqual(['note.md']);
 		});
 	});
 });

--- a/src/localVault.ts
+++ b/src/localVault.ts
@@ -6,6 +6,7 @@
 
 import { DataAdapter, ListedFiles, TFile, TFolder, Vault } from "obsidian";
 import { ObsidianSyncRules } from "@/fitSettings";
+import { FITATTRIBUTES_PATH } from "@/fitAttributes";
 import { ApplyChangesResult, IVault, VaultError, VaultReadResult } from "./vault";
 import { FileChange } from "./util/changeTracking";
 import { fitLogger } from "./logger";
@@ -142,6 +143,10 @@ export class LocalVault implements IVault<"local"> {
 		//
 		// Obsidian vault paths always use forward slashes (even on Windows)
 		if (!this.syncHiddenFiles) {
+			// .fitattributes.json must propagate regardless of syncHiddenFiles, or it can't
+			// reach a device that has hidden-file sync off — defeating its own purpose.
+			if (filePath === FITATTRIBUTES_PATH) return true;
+
 			const parts = filePath.split('/');
 			if (parts.some(part => part.startsWith('.'))) {
 				// Explicitly opted-in obsidian paths are tracked regardless of syncHiddenFiles
@@ -190,7 +195,17 @@ export class LocalVault implements IVault<"local"> {
 			}
 		}
 
-		const allPaths = this.syncHiddenFiles ? [...vaultIndexPaths, ...hiddenPaths] : vaultIndexPaths;
+		// .fitattributes.json is hidden (leading dot) so vault.getFiles() never returns
+		// it — must be discovered explicitly when the hidden-path scan above is skipped,
+		// or shouldTrackState's special-case for it (below) never gets a chance to run.
+		// Only add it if it actually exists locally: injecting a path that doesn't exist
+		// would make the SHA-computation step below fail it and abort the whole sync.
+		let allPaths = this.syncHiddenFiles ? [...vaultIndexPaths, ...hiddenPaths] : vaultIndexPaths;
+		if (!this.syncHiddenFiles && !allPaths.includes(FITATTRIBUTES_PATH)) {
+			if (await this.vault.adapter.stat(FITATTRIBUTES_PATH)) {
+				allPaths = [...allPaths, FITATTRIBUTES_PATH];
+			}
+		}
 
 		// Filter to only tracked paths (excludes hidden files when syncHiddenFiles is off)
 		const trackedPaths = allPaths.filter(path => this.shouldTrackState(path));

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -11,6 +11,7 @@ import { FilePath } from './util/filePath';
 import { BlobSha, CommitSha, computeGitBlobSha, computeSha1, TreeSha } from "./util/hashing";
 import { LocalVault } from './localVault';
 import { fitLogger } from './logger';
+import { FITATTRIBUTES_PATH } from '@/fitAttributes';
 
 /**
  * Test stub for TFile that can be constructed with just a path.
@@ -768,9 +769,10 @@ export class FakeLocalVault implements IVault<"local"> {
 	}
 
 	shouldTrackState(path: string): boolean {
-		// Same single criterion as real LocalVault: hidden paths are excluded only
-		// when syncHiddenFiles is off.
+		// Mirrors real LocalVault: hidden paths are excluded when syncHiddenFiles is off,
+		// except .fitattributes.json (always tracked).
 		if (!this.syncHiddenFiles) {
+			if (path === FITATTRIBUTES_PATH) return true;
 			const parts = path.split('/');
 			if (parts.some(part => part.startsWith('.'))) return false;
 		}

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -410,6 +410,11 @@ export class FakeLocalVault implements IVault<"local"> {
 	private files: Map<string, FileContent> = new Map();
 	private failureScenarios: Map<FailureScenario, Error> = new Map();
 	private statLog: string[] = []; // Track all stat operations for performance testing
+	// Per-path readFileContent failures — distinct from the blanket 'read' failureScenario
+	// (which also aborts readFromSource's whole-vault scan): lets a test simulate a single
+	// file existing but being unreadable (I/O error, permission issue) without breaking scan
+	// of every other file.
+	private readFileContentFailures: Map<string, Error> = new Map();
 	private mockWriteFile: ((path: string) => Promise<void>) | null = null; // Mock for writeFile operations
 	private mockDeleteFile: ((path: string) => Promise<void>) | null = null; // Mock for deleteFile operations
 	private syncHiddenFiles = false;
@@ -430,6 +435,11 @@ export class FakeLocalVault implements IVault<"local"> {
 	 */
 	seedFailureScenario(scenario: FailureScenario, error: Error): void {
 		this.failureScenarios.set(scenario, error);
+	}
+
+	/** One-shot: makes the next readFileContent(path) call throw, without affecting readFromSource. */
+	seedReadFileContentFailure(path: string, error: Error): void {
+		this.readFileContentFailures.set(path, error);
 	}
 
 	/**
@@ -562,6 +572,12 @@ export class FakeLocalVault implements IVault<"local"> {
 	}
 
 	async readFileContent(path: string): Promise<FileContent> {
+		const pathError = this.readFileContentFailures.get(path);
+		if (pathError) {
+			this.readFileContentFailures.delete(path);
+			throw pathError;
+		}
+
 		const error = this.failureScenarios.get('read');
 		if (error) {
 			this.clearFailure('read');

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -410,11 +410,6 @@ export class FakeLocalVault implements IVault<"local"> {
 	private files: Map<string, FileContent> = new Map();
 	private failureScenarios: Map<FailureScenario, Error> = new Map();
 	private statLog: string[] = []; // Track all stat operations for performance testing
-	// Per-path readFileContent failures — distinct from the blanket 'read' failureScenario
-	// (which also aborts readFromSource's whole-vault scan): lets a test simulate a single
-	// file existing but being unreadable (I/O error, permission issue) without breaking scan
-	// of every other file.
-	private readFileContentFailures: Map<string, Error> = new Map();
 	private mockWriteFile: ((path: string) => Promise<void>) | null = null; // Mock for writeFile operations
 	private mockDeleteFile: ((path: string) => Promise<void>) | null = null; // Mock for deleteFile operations
 	private syncHiddenFiles = false;
@@ -435,11 +430,6 @@ export class FakeLocalVault implements IVault<"local"> {
 	 */
 	seedFailureScenario(scenario: FailureScenario, error: Error): void {
 		this.failureScenarios.set(scenario, error);
-	}
-
-	/** One-shot: makes the next readFileContent(path) call throw, without affecting readFromSource. */
-	seedReadFileContentFailure(path: string, error: Error): void {
-		this.readFileContentFailures.set(path, error);
 	}
 
 	/**
@@ -572,12 +562,6 @@ export class FakeLocalVault implements IVault<"local"> {
 	}
 
 	async readFileContent(path: string): Promise<FileContent> {
-		const pathError = this.readFileContentFailures.get(path);
-		if (pathError) {
-			this.readFileContentFailures.delete(path);
-			throw pathError;
-		}
-
 		const error = this.failureScenarios.get('read');
 		if (error) {
 			this.clearFailure('read');

--- a/styles.css
+++ b/styles.css
@@ -387,6 +387,13 @@
     margin: 4px 0;
 }
 
+.fit-fitattributes-note {
+    font-size: 0.85em;
+    margin: 4px 0;
+    padding: 4px 8px;
+    border-left: 3px solid var(--color-orange, #e8a020);
+}
+
 .fit-field-warning-section {
     margin-top: 12px;
     padding: 8px 10px;


### PR DESCRIPTION
## Summary
- Adds `.fitattributes.json`'s schema and parser (`FitAttributeRule`, `format: "text" | "json"` — `"json"` reserved for a later change)
- Malformed config surfaces a visible sync-notice warning plus a persistent Explain Sync Status entry — not just a debug-log line, since this is a load-bearing config file
- Diagnostic-only debug.log entries for `.obsidian/` paths this version doesn't act on yet: a forward-looking preview of what the format gate would do, and a watermark noting when the still-live legacy `obsidianSyncRules` mechanism actually drives a sync outcome (helps date debug.log evidence against later versions once it's retired)

Purely additive — `.obsidian/` sync behavior itself is unchanged here; `obsidianSyncRules` still fully controls it. Git-driven tracking and the format gate this prepares for land in #368 (stacked on this one).

Groundwork for #337 / #67.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 358/358 passing

---

<!-- kody-pr-summary:start -->
## Summary

This PR lays the groundwork for the planned **`.fitattributes.json`** config file (issue #337) — an analog to `.gitattributes` that will eventually control per-path sync behavior for `.obsidian/` files. It implements the **schema, parsing, validation, and error surfaces** for the config file, but does **not** yet wire it into actual sync decisions (that remains for a follow-up change).

## Changes

### 1. New `.fitattributes.json` schema and parser (`src/fitAttributes.ts`)
- Defines the file shape: a JSON object mapping paths to rule objects, each currently supporting a `format` field (`"json"` or `"text"`).
- Adds `parseFitAttributes()` which never throws — malformed input (invalid JSON, non-object root, or invalid rule shape) is reported through an `ok: false` result so the caller can surface it loudly instead of silently treating it as "nothing configured".
- Explicitly documented: a path's presence in the file does **not** opt it into sync; it only modulates how an already-tracked path is handled in the future.

### 2. Reading, storing, and warning (`src/fit.ts`)
- The `Fit` class now holds the parsed `.fitattributes.json` state, refreshed each sync (both eagerly before reconciliation and lazily during the normal local scan).
- A **malformed** file triggers a visible `FitNotice` warning with a user-friendly message, plus a persisted entry in **Explain Sync Status** (see below). A file that exists but fails to *read* (I/O error) is debug-logged only, because the normal scan already aborts the whole sync for unreadable tracked files before a warning could reliably surface.

### 3. Sync status and UI (`src/fitStatusExplainer.ts`, `src/fitStatusModal.ts`, `styles.css`)
- Sync Status now includes a `fitAttributesNote` field, shown as a styled warning in the status modal when `.fitattributes.json` is malformed.
- The explanation is treated as "issues" (not "ok") when only this warning is present, so users notice it without needing debug logs.

### 4. Always-synced config file (`src/localVault.ts`, `src/testUtils.ts`)
- `.fitattributes.json` must reach every device regardless of the `syncHiddenFiles` setting, or the future feature can't work. It’s now **always tracked** (when present), even when hidden-file sync is disabled.
- The local vault scan explicitly discovers the file when the hidden-path scan is skipped (since it starts with a dot and won’t show up in normal vault enumeration), while still verifying it actually exists to avoid fabricating an entry.

### 5. Forward-looking diagnostics (`src/fitSync.ts`)
- Whenever remote `.obsidian/` content exists that this version cannot sync (tracked in `protectedPathShas`), a new **informational log** reports which of those paths already have a `format: "text"` rule in `.fitattributes.json` (i.e., will start syncing once the gate lands) versus which are still unconfigured.
- A separate watermark log identifies `.obsidian/` paths actively synced via the legacy `obsidianSyncRules` mechanism, making it easier to distinguish legacy behavior in future debug logs.

### 6. Tests
- New unit tests for `parseFitAttributes` (valid configs, empty rules, malformed JSON, non-object roots, invalid rule shapes, unrecognized format values).
- Integration tests for the warning Notice, the absent-warning case, the forward-looking log, and status-modal note rendering.
- Tests confirming `.fitattributes.json` is tracked and scanned even when `syncHiddenFiles` is off, and not fabricated when absent.

## Notes
- The actual **sync-decision wiring** (using the parsed config to gate which `.obsidian/` paths sync, and applying merge/format policies) is intentionally left for a later change, tracked under #337/#67.
- This PR only ensures the file syntax is validated, surfaced loudly when broken, and propagated to all devices so subsequent work can rely on it.
<!-- kody-pr-summary:end -->